### PR TITLE
Add a script to list git branches and their age

### DIFF
--- a/git/git_branch_age.nu
+++ b/git/git_branch_age.nu
@@ -1,0 +1,6 @@
+# Creates a table listing the branches of a git repository and the day of the last commit
+git branch | lines | str substring 2, | wrap name | insert "last commit" {
+    get name | each {
+        git show $it --no-patch --format=%as
+    }
+} | sort-by "last commit"


### PR DESCRIPTION
As suggested on nushell Discord, here is a PR for a "cool-oneliner" I made to list the branches of a git repository and their age.

Since this has its own file I reformatted the script to use line-breaks, so it's not technically a oneliner anymore :)