### PR TITLE
Add nu-serde to nu_release.nu

### DIFF
--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -1,6 +1,6 @@
 cd crates
 
-let first-wave = [nu-ansi-term, nu-pretty-hex, nu-source, nu-errors, nu-protocol, nu-value-ext, nu-test-support, nu-table, nu-parser, nu-plugin, nu-data, nu-stream, nu-engine, nu-json]
+let first-wave = [nu-ansi-term, nu-pretty-hex, nu-source, nu-errors, nu-protocol, nu-value-ext, nu-test-support, nu-table, nu-parser, nu-plugin, nu-data, nu-stream, nu-engine, nu-json, nu-serde]
 
 echo $first-wave | each { enter $it; cargo publish; exit; sleep 1min }
 


### PR DESCRIPTION
This is necessary for nu-serde to be published when we publish new versions of the nushell crates.