### PR TITLE
dict.nu — bugfix

### DIFF
--- a/cool_oneliners/dict.nu
+++ b/cool_oneliners/dict.nu
@@ -8,8 +8,9 @@ def dict [word: string] {
   let link = (build-string 'https://api.dictionaryapi.dev/api/v2/entries/en/' ($word|str find-replace ' ' '%20'))
   let output = (fetch $link |
   rename word)
-  
-  if $output.word == "No Definitions Found" {echo $output.word} {echo $output | 
+  let w = ($output.word | first)  
+
+  if $w == "No Definitions Found" {echo $output.word} {echo $output | 
   get meanings.definitions |
   select definition example
   }


### PR DESCRIPTION
fixed coercion error that used to be thrown, when the column word contained more than one item. should be working fully correctly right now, feedback appreciated tho