### PR TITLE
Add example engine-q config script with a module

### DIFF
--- a/engine-g/example-config/config.nu
+++ b/engine-g/example-config/config.nu
@@ -1,0 +1,11 @@
+# ~/.config/nushell/config.nu
+#
+# Nushell-s config file used in engine-q.
+#
+# It fethes all definitions and environment variables from the `init` module.
+
+use ~/.config/nushell/init.nu *
+
+let config = build-config
+
+alias gd = git diff

--- a/engine-g/example-config/init.nu
+++ b/engine-g/example-config/init.nu
@@ -1,0 +1,53 @@
+# ~/.config/nushell/init.nu
+#
+# Init module that exports commands and environment variables wanted at startup
+
+# commands
+export def build-config [] { { footer_mode: "50" } }
+
+export def egd [...rest] {
+    with-env [GIT_EXTERNAL_DIFF 'difftastic'] { git diff $rest }
+}
+
+# env
+export env LS_COLORS {
+    [
+       "di=01;34;2;102;217;239"
+       "or=00;40;31"
+       "mi=00;40;31"
+       "ln=00;36"
+       "ex=00;32"
+    ] | str collect ':'
+}
+export env BROWSER { "firefox" }
+export env CARGO_TARGET_DIR { "~/.cargo/target" }
+export env EDITOR { "nvim" }
+export env VISUAL { "nvim" }
+export env PAGER { "less" }
+export env SHELL { "~/.cargo/bin/nu" }
+export env JULIA_NUM_THREADS { (nproc) }
+export env HOSTNAME { (hostname | split row '.' | first | str trim) }
+export env SHOW_USR { "true" }
+
+# prompt
+export env PROMPT_COMMAND { "build-prompt" }
+export def build-prompt [] {
+    let usr-str = (if $nu.env.SHOW_USR == "true" {
+        [
+            $nu.env.USER
+            '@'
+            $nu.env.HOSTNAME
+            ':'
+        ] | str collect
+    } else {
+        ''
+    })
+
+    let pwd-str = (if (pwd | str starts-with $nu.env.HOME).0 {
+        (pwd | str find-replace $nu.env.HOME '~' | str trim).0
+    } else {
+        pwd
+    })
+
+    [ $usr-str $pwd-str ' ' ] | str collect
+}


### PR DESCRIPTION
This adds an example engine-q config that loads a module to fetch the commands and environment variables.