### PR TITLE
kubouch's benchmark script

### DIFF
--- a/engine-q/coloring/gradient_benchmark.nu
+++ b/engine-q/coloring/gradient_benchmark.nu
@@ -1,0 +1,152 @@
+# Kubouch wrote this on/around 01/26/2022
+
+def iter_inc [incr mult iter] {
+    $incr + $mult * $iter
+}
+
+let is_release = input "Did you compile in a release mode? y/n "
+
+if ($is_release | str downcase | str trim) == "y" {
+
+    $"running test 0 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
+    # 0. this has wrong output
+    let 0 = (seq 10 | benchmark {
+        let height = 40
+        let width = 160
+        let stamp = 'Nu'
+        seq 0 $height | each {
+            let row_data = (seq 0 $width | each { |col|
+                let fgcolor = (iter_inc 2 2 $col)
+                if $fgcolor > 200 && $fgcolor < 210 {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m($stamp)(ansi -e '0m')"
+                } else {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m(char sp)(ansi -e '0m')"
+                }
+            } | str collect)
+            $"($row_data)(char newline)"
+        } | str collect
+    } | math avg)
+
+
+    $"running test 1 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
+    # 1. Fixed newline to fix the output (char cr)
+    let 1 = (seq 10 | benchmark {
+        let height = 40
+        let width = 160
+        let stamp = 'Nu'
+        seq 0 $height | each {
+            let row_data = (seq 0 $width | each { |col|
+                let fgcolor = (iter_inc 2 2 $col)
+                if $fgcolor > 200 && $fgcolor < 210 {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m($stamp)(ansi -e '0m')"
+                } else {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m(char sp)(ansi -e '0m')"
+                }
+            } | str collect)
+            $"($row_data)(char cr)"
+        } | str collect
+    } | math avg)
+
+    $"running test 2 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
+    # 2. Replace (char sp) with just space
+    let 2 = (seq 10 | benchmark {
+        let height = 40
+        let width = 160
+        let stamp = 'Nu'
+        seq 0 $height | each {
+            let row_data = (seq 0 $width | each { |col|
+                let fgcolor = (iter_inc 2 2 $col)
+                if $fgcolor > 200 && $fgcolor < 210 {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m($stamp)(ansi -e '0m')"
+                } else {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m (ansi -e '0m')"
+                }
+            } | str collect)
+            $"($row_data)(char cr)"
+        } | str collect
+    } | math avg)
+
+    $"running test 3 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
+    # 3. Precompute (ansi -e '48;2;0;0;') and (ansi -e '0m') -- seems to be slower
+    let 3 = (seq 10 | benchmark {
+        let height = 40
+        let width = 160
+        let stamp = 'Nu'
+        let ansi1 = ansi -e '48;2;0;0;'
+        let ansi2 = ansi -e '0m'
+        seq 0 $height | each {
+            let row_data = (seq 0 $width | each { |col|
+                let fgcolor = (iter_inc 2 2 $col)
+                if $fgcolor > 200 && $fgcolor < 210 {
+                    $"($ansi1)($fgcolor)m($stamp)($ansi2)"
+                } else {
+                    $"($ansi1)($fgcolor)m(char sp)($ansi2)"
+                }
+            } | str collect)
+            $"($row_data)(char cr)"
+        } | str collect
+    } | math avg)
+
+    $"running test 4 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
+    # 4. Inline iter_inc call
+    let 4 = (seq 10 | benchmark {
+        let height = 40
+        let width = 160
+        let stamp = 'Nu'
+        seq 0 $height | each {
+            let row_data = (seq 0 $width | each { |col|
+                let fgcolor = 2 + 2 * $col
+                if $fgcolor > 200 && $fgcolor < 210 {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m($stamp)(ansi -e '0m')"
+                } else {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m(char sp)(ansi -e '0m')"
+                }
+            } | str collect)
+            $"($row_data)(char cr)"
+        } | str collect
+    } | math avg)
+
+    $"running test 5 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
+    # 5. Combine (char sp) substitution and iter_inc inlining
+    let 5 = (seq 10 | benchmark {
+        let height = 40
+        let width = 160
+        let stamp = 'Nu'
+        seq 0 $height | each {
+            let row_data = (seq 0 $width | each { |col|
+                let fgcolor = 2 + 2 * $col
+                if $fgcolor > 200 && $fgcolor < 210 {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m($stamp)(ansi -e '0m')"
+                } else {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m (ansi -e '0m')"
+                }
+            } | str collect)
+            $"($row_data)(char cr)"
+        } | str collect
+    } | math avg)
+
+    $"running test 6 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
+    # 6. The above with par-each outer loop (using par-each anywhere else breaks the output)
+    let 6 = (seq 10 | benchmark {
+        let height = 40
+        let width = 160
+        let stamp = 'Nu'
+        seq 0 $height | par-each {
+            let row_data = (seq 0 $width | each { |col|
+                let fgcolor = 2 + 2 * $col
+                if $fgcolor > 200 && $fgcolor < 210 {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m($stamp)(ansi -e '0m')"
+                } else {
+                    $"(ansi -e '48;2;0;0;')($fgcolor)m (ansi -e '0m')"
+                }
+            } | str collect)
+            $"($row_data)(char cr)"
+        } | str collect
+    } | math avg)
+
+    echo 'collating tests'
+    [ $0 $1 $2 $3 $4 $5 $6 ]
+
+} else {
+    echo "Compile in a release mode!"
+}


### PR DESCRIPTION
Output should look similar to this
```
> source .\gradient_benchmark.nu              
Did you compile in a release mode? y/n y
running test 0 at 2022-01-27 15:57:24.100
running test 1 at 2022-01-27 15:57:25.162
running test 2 at 2022-01-27 15:57:26.231
running test 3 at 2022-01-27 15:57:27.304
running test 4 at 2022-01-27 15:57:28.361
running test 5 at 2022-01-27 15:57:29.167
running test 6 at 2022-01-27 15:57:29.992
collating tests
╭───┬───────────────────────╮
│ 0 │ 1sec 60ms 609us       │
│ 1 │ 1sec 68ms 925us 200ns │
│ 2 │ 1sec 72ms 58us 900ns  │
│ 3 │ 1sec 56ms 866us       │
│ 4 │ 804ms 703us 400ns     │
│ 5 │ 824ms 498us 100ns     │
│ 6 │ 150ms 873us 200ns     │
╰───┴───────────────────────╯
```