### PR TITLE
parse fish command history for git usage

### DIFF
--- a/cool-oneliners/parse_fish_command_history.nu
+++ b/cool-oneliners/parse_fish_command_history.nu
@@ -1,0 +1,1 @@
+open ~/.config/fish/fish_history | from yaml | get cmd | find --regex '^git .*' | split column ' ' command subcommand


### PR DESCRIPTION
This is a privacy friendly way to extract command and subcommand usage for Fish shell users
