### PR TITLE
Make "nu-complete cargo packages" offline for speed

### DIFF
--- a/custom-completions/cargo/cargo-completions.nu
+++ b/custom-completions/cargo/cargo-completions.nu
@@ -15,7 +15,7 @@ def "nu-complete cargo examples" [] {
 }
 
 def "nu-complete cargo packages" [] {
-  let metadata = (cargo metadata --format-version=1)
+  let metadata = (cargo metadata --format-version=1 --offline --no-deps)
   if $metadata == '' {
     []
   } else {


### PR DESCRIPTION
It uses `cargo metadata` command with `--offline` flag to forbid it fetching anything from the net, which caused some input lag before