### PR TITLE
Misc tools

### DIFF
--- a/miscelaneous/nu_defs.nu
+++ b/miscelaneous/nu_defs.nu
@@ -419,3 +419,43 @@ def-env md [dir] {
   mkdir $dir
   cd $dir
 }
+
+# Fuzzy finds a value in a newline-separated-string or a list, using an
+# optional preview. If the string or the list contains only one item,
+# it is returned immediately.
+# Requires the external binary 'skim'.
+#
+# Examples:
+# > "a\nb\n" | skim
+# > ls | get name | skim --preview 'ls --color {}'
+def skim [
+  --preview (-p) = '' # command to use for the sk preview
+] {
+  let lst = $in
+  let type = ($lst | describe)
+  let s = (if ($type | str starts-with 'list<') {
+             $lst | str collect (char nl)
+           } else if ($type == 'string') {
+             $lst
+           })
+  if ($s | empty?) {
+    null
+  } else {
+    if ($preview | empty? ) {
+      ($s
+      | sk
+        --layout reverse
+        --preview-window down:65%
+        --select-1
+      | str trim)
+      } else {
+        ($s
+        | sk
+          --layout reverse
+          --preview-window down:65%
+          --select-1
+          --preview $preview
+        | str trim)
+      }
+  }
+}

--- a/miscelaneous/nu_defs.nu
+++ b/miscelaneous/nu_defs.nu
@@ -413,3 +413,9 @@ def ymd [] {
 def dmy [] {
   (date now | date format %d-%m-%Y)
 }
+
+# create directory and cd into it.
+def-env md [dir] {
+  mkdir $dir
+  cd $dir
+}

--- a/miscelaneous/nu_defs.nu
+++ b/miscelaneous/nu_defs.nu
@@ -403,3 +403,13 @@ def gnu-plot [
 
   rm data*.txt | ignore
 }
+
+# date string YYYY-MM-DD
+def ymd [] {
+  (date now | date format %Y-%m-%d)
+}
+
+# date string DD-MM-YYYY
+def dmy [] {
+  (date now | date format %d-%m-%Y)
+}


### PR DESCRIPTION
Some of my favorite functions.


`skim` is a wrapper around the `sk` command-line tool. I would love, if the basic list-select functionality would become a part of Nushell, as it is so handy.
```
> ls | get name | skim --preview 'ls --color {}'
# move the cursor (emacs key-bindings) or fuzzy find,
# then press enter to select the value
Downloads
```

`group-list` helps to quick-and-dirty parse lists of data with a repeating header+body schema. I need the capability of `group-list` quite often and wonder, why there is no other tool (as far as I know) with this functionality.
```
> [id_a 1 2 id_b 3] | group-list id_
╭───┬──────┬────────────────╮
│ # │ key  │     values     │
├───┼──────┼────────────────┤
│ 0 │ id_a │ [list 2 items] │
│ 1 │ id_b │ [list 1 item]  │
╰───┴──────┴────────────────╯
```

Shortcut that is very handy when creating file names.
```
> ymd
2022-05-21
```

```
> dmy
21-05-2022
```
