### PR TITLE
Script to gather test coverage for nushell

### DIFF
--- a/make_release/get_coverage.nu
+++ b/make_release/get_coverage.nu
@@ -1,0 +1,31 @@
+# Test coverage gathering for nushell 
+# Uses cargo-llvm-cov
+# Uses separate execution to track the integration tests
+# Hacked together by @sholderbach
+
+# Get test coverage for nushell
+def main [
+       --extra # Get coverage for extra features
+   ] {
+   cargo llvm-cov show-env --export-prefix | 
+       lines | 
+       str substring '7,' | 
+       split column '=' | 
+       str trim -c '"'  | 
+       transpose | 
+       headers | 
+       reject 'column1' | 
+       get 0 | 
+       load-env
+   
+   cargo llvm-cov clean --workspace 
+   if $extra {
+       cargo build --workspace --features extra
+       cargo test --workspace --features extra
+   } else {
+       cargo build --workspace
+       cargo test --workspace
+   }
+   cargo llvm-cov --no-run --lcov --output-path lcov.info 
+   cargo llvm-cov --no-run --html
+}

--- a/make_release/get_coverage.nu
+++ b/make_release/get_coverage.nu
@@ -16,6 +16,7 @@ def main [
        headers | 
        reject 'column1' | 
        get 0 | 
+       str trim |
        load-env
    
    cargo llvm-cov clean --workspace 


### PR DESCRIPTION
Uses https://github.com/taiki-e/cargo-llvm-cov

Adapted to gather integration test from https://github.com/taiki-e/cargo-llvm-cov#get-coverage-of-external-tests
