### PR TITLE
Add `helpers` folder and add script for running C/C++ quickly

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,0 +1,13 @@
+# Helpers
+
+Commands to make your life easier.
+
+## How to use
+
+Execute following snippet at any time to be able to run the commands in the scripts:
+
+```zsh
+source './path/to/script.nu'
+```
+
+With `./path/to/...` being the path to the script you want to utilize.

--- a/helpers/run-c-cpp.nu
+++ b/helpers/run-c-cpp.nu
@@ -1,0 +1,27 @@
+# Runs C code via GCC without leaving a file behind
+def rcc [ 
+  file: path # The file to run
+] {
+  # Remove exe if still exists
+  rm $"($file).exe" --permanent --force
+  # Compile code to exe
+  ^gcc ("." | path join $file | path expand) -o ("." | path join $"($file).exe" | path expand)
+  # Execute exe
+  ^$"($file).exe"
+  # Remove exe
+  rm $"($file).exe" --permanent --force
+}
+
+# Runs C++ code via g++ without leaving a file behind
+def r++ [
+  file: path # The file to run 
+] {
+  # Remove exe if still exists
+  rm $"($file).exe" --permanent --force
+  # Compile code to exe
+  ^g++ ("." | path join $file | path expand) -o ("." | path join $"($file).exe" | path expand)
+  # Execute exe
+  ^$"($file).exe"
+  # Remove exe
+  rm $"($file).exe" --permanent --force
+}


### PR DESCRIPTION
One of the things I hate about running C/C++ code is I have to compile it to an `.exe`, then run it, then remove the `.exe`. I added scripts which add functions which do all of that instantly.

I decided to put this in a new folder called `helpers`. This folder will contain, well... helpers. Scripts that help you with your daily life.