### PR TITLE
cdpath fixed for windows

### DIFF
--- a/filesystem/cdpath.nu
+++ b/filesystem/cdpath.nu
@@ -1,5 +1,9 @@
 def-env c [dir = ""] {
-    let default = $env.HOME
+    let default = if $env.OS == "Windows_NT" {
+        $env.USERPROFILE
+    } else {
+        $env.HOME
+    }
 
     let complete_dir = if $dir == "" {
         $default


### PR DESCRIPTION
windows uses userprofile instead of home so it used to raise an error in previous version