### PR TITLE
add stargazer script to monitor nushell stars

### DIFF
--- a/webscraping/shell_stars.nu
+++ b/webscraping/shell_stars.nu
@@ -1,0 +1,42 @@
+let shell_list = [
+    [name repo];
+    [bash bminor/bash]
+    [fish fish-shell/fish-shell]
+    [nushell nushell/nushell]
+    # [powershell no-github-url]
+    [pwsh PowerShell/PowerShell]
+    [ksh2020 ksh2020/ksh]
+    [ksh93u att/ast]
+    # [csh no-github-url]
+    # [dash no-github-url]
+    # [sh no-github-url]
+    # [cmd no-github-url]
+    [aws-shell awslabs/aws-shell]
+    [azure-cloud-shell Azure/CloudShell]
+    [elvish elves/elvish]
+    [es wryun/es-shell]
+    [ion redox-os/ion]
+    [MirBSDksh MirBSD/mksh]
+    [ngs ngs-lang/ngs]
+    [openbsd_ksh ibara/oksh]
+    [oil oilshell/oil]
+    [shell++ alexst07/shell-plus-plus]
+    [tcsh tcsh-org/tcsh]
+    [xonsh xonsh/xonsh]
+    [yash magicant/yash]
+    [zsh zsh-users/zsh]
+]
+
+$shell_list | each { |r|
+    print -n $"Working on ($r.name)"
+    sleep 250ms
+    if ($r.repo | str starts-with no) {
+        [[shell repo stars]; [($r.name) "no github url" 0]]
+        print ""
+    } else {
+        let url = $"https://api.github.com/repos/($r.repo)"
+        let count = (fetch -u $env.GITHUB_USERNAME -p $env.GITHUB_PASSWORD ($url) | get stargazers_count)
+        print $" ($count)"
+        [[shell repo stars]; [($r.name) ($r.repo) ($count)]]
+    }
+} | flatten | sort-by -r stars | table -n 1


### PR DESCRIPTION
This script produces a report that looks like this.
```
╭────┬───────────────────┬──────────────────────────┬───────╮
│ #  │       shell       │           repo           │ stars │
├────┼───────────────────┼──────────────────────────┼───────┤
│  1 │ pwsh              │ PowerShell/PowerShell    │ 34166 │
│  2 │ nushell           │ nushell/nushell          │ 19745 │
│  3 │ fish              │ fish-shell/fish-shell    │ 19123 │
│  4 │ aws-shell         │ awslabs/aws-shell        │  6591 │
│  5 │ xonsh             │ xonsh/xonsh              │  6100 │
│  6 │ elvish            │ elves/elvish             │  4768 │
│  7 │ zsh               │ zsh-users/zsh            │  2810 │
│  8 │ oil               │ oilshell/oil             │  2197 │
│  9 │ ion               │ redox-os/ion             │  1269 │
│ 10 │ ngs               │ ngs-lang/ngs             │  1151 │
│ 11 │ ksh93u            │ att/ast                  │   439 │
│ 12 │ bash              │ bminor/bash              │   372 │
│ 13 │ openbsd_ksh       │ ibara/oksh               │   239 │
│ 14 │ es                │ wryun/es-shell           │   234 │
│ 15 │ azure-cloud-shell │ Azure/CloudShell         │   191 │
│ 16 │ yash              │ magicant/yash            │   165 │
│ 17 │ MirBSDksh         │ MirBSD/mksh              │   165 │
│ 18 │ tcsh              │ tcsh-org/tcsh            │   153 │
│ 19 │ shell++           │ alexst07/shell-plus-plus │   104 │
│ 20 │ ksh2020           │ ksh2020/ksh              │    22 │
├────┼───────────────────┼──────────────────────────┼───────┤
│ #  │       shell       │           repo           │ stars │
╰────┴───────────────────┴──────────────────────────┴───────╯
```
other shell urls are welcome contributions