### PR TITLE
fix env.PATH after conda activate

### DIFF
--- a/virtual_environments/conda.nu
+++ b/virtual_environments/conda.nu
@@ -102,8 +102,7 @@ def conda-create-path-windows [env-dir: path] {
     ]
 
     let new-path = ([$env-path (system-path)]
-        | flatten
-        | str collect (char esep))
+        | flatten)
 
     { PATH: $new-path }
 }
@@ -114,8 +113,7 @@ def conda-create-path-unix [env-dir: path] {
     ]
 
     let new-path = ([$env-path $env.PATH]
-        | flatten
-        | str collect (char esep))
+        | flatten)
 
     { PATH: $new-path }
 }


### PR DESCRIPTION
When activate conda env, the `$env.PATH` is a bash like path, it's not working well inside `nushell`(I don't if it's nushell issue)
![img](https://user-images.githubusercontent.com/22256154/178671375-f6173aca-57ed-462f-9ed6-034af62cd6e3.png)

The fix is making `$env.PATH` to be a `list` rather than `str` after `conda activate`, so everything works fine
![img](https://user-images.githubusercontent.com/22256154/178671160-792d57bd-6805-486e-adf3-51d9222986bc.png)
