### PR TITLE
Update conda to 0.66 variable naming convention

### DIFF
--- a/virtual_environments/conda.nu
+++ b/virtual_environments/conda.nu
@@ -1,36 +1,36 @@
 # Activate conda environment
 export def-env activate [
-    env-name: string@'nu-complete conda envs' # name of the environment
+    env_name: string@'nu-complete conda envs' # name of the environment
     --no-prompt                               # do not update the prompt
 ] {
-    let conda-info = (conda info --envs --json | from json)
+    let conda_info = (conda info --envs --json | from json)
 
-    let suffix = if $env-name == "base" {
+    let suffix = if $env_name == "base" {
         ""
     } else {
-        ["envs" $env-name] | path join
+        ["envs" $env_name] | path join
     }
 
-    let env-dir = ([$conda-info.root_prefix $suffix] | path join)
-    let old-path = (system-path | str collect (char esep))
+    let env_dir = ([$conda_info.root_prefix $suffix] | path join)
+    let old_path = (system-path | str collect (char esep))
 
-    let new-path = if windows? {
-        conda-create-path-windows $env-dir
+    let new_path = if windows? {
+        conda-create-path-windows $env_dir
     } else {
-        conda-create-path-unix $env-dir
+        conda-create-path-unix $env_dir
     }
 
-    let virtual-prompt = $'[($env-name)] '
+    let virtual_prompt = $'[($env_name)] '
 
-    let new-env = ({
-        CONDA_DEFAULT_ENV: $env-name
-        CONDA_PREFIX: $env-dir
-        CONDA_PROMPT_MODIFIER: $virtual-prompt
+    let new_env = ({
+        CONDA_DEFAULT_ENV: $env_name
+        CONDA_PREFIX: $env_dir
+        CONDA_PROMPT_MODIFIER: $virtual_prompt
         CONDA_SHLVL: "1"
-        CONDA_OLD_PATH: $old-path
-    } | merge { $new-path })
+        CONDA_OLD_PATH: $old_path
+    } | merge { $new_path })
 
-    let new-env = if not $no-prompt {
+    let new_env = if not $no_prompt {
         let old_prompt_command = if (has-env CONDA_OLD_PROMPT_COMMAND) {
             $env.CONDA_OLD_PROMPT_COMMAND
         } else {
@@ -42,30 +42,30 @@ export def-env activate [
         }
 
 
-        let new-prompt = if (has-env 'PROMPT_COMMAND') {
+        let new_prompt = if (has-env 'PROMPT_COMMAND') {
             if ($old_prompt_command | describe) == 'block' {
-                { $'($virtual-prompt)(do $old_prompt_command)' }
+                { $'($virtual_prompt)(do $old_prompt_command)' }
             } else {
-                { $'($virtual-prompt)($old_prompt_command)' }
+                { $'($virtual_prompt)($old_prompt_command)' }
             }
         } else {
-            { $'($virtual-prompt)' }
+            { $'($virtual_prompt)' }
         }
 
-        $new-env
+        $new_env
         | insert CONDA_OLD_PROMPT_COMMAND $old_prompt_command
-        | insert PROMPT_COMMAND $new-prompt
+        | insert PROMPT_COMMAND $new_prompt
     } else {
-        $new-env
+        $new_env
     }
 
-    load-env $new-env
+    load-env $new_env
 }
 
 # Deactivate currently active conda environment
 export def-env deactivate [] {
-    let path-name = if "PATH" in (env).name { "PATH" } else { "Path" }
-    let-env $path-name = $env.CONDA_OLD_PATH
+    let path_name = if "PATH" in (env).name { "PATH" } else { "Path" }
+    let-env $path_name = $env.CONDA_OLD_PATH
     let-env PROMPT_COMMAND = $env.CONDA_OLD_PROMPT_COMMAND
 
     hide CONDA_PROMPT_MODIFIER
@@ -91,31 +91,33 @@ def 'nu-complete conda envs' [] {
     | each {|entry| $entry | split row ' ' | get 0 }
 }
 
-def conda-create-path-windows [env-dir: path] {
+def conda-create-path-windows [env_dir: path] {
     # Conda on Windows needs a few additional Path elements
-    let env-path = [
-        $env-dir
-        ([$env-dir "Scripts"] | path join)
-        ([$env-dir "Library" "mingw-w64"] | path join)
-        ([$env-dir "Library" "bin"] | path join)
-        ([$env-dir "Library" "usr" "bin"] | path join)
+    let env_path = [
+        $env_dir
+        ([$env_dir "Scripts"] | path join)
+        ([$env_dir "Library" "mingw-w64"] | path join)
+        ([$env_dir "Library" "bin"] | path join)
+        ([$env_dir "Library" "usr" "bin"] | path join)
     ]
 
-    let new-path = ([$env-path (system-path)]
-        | flatten)
+    let new_path = ([$env_path (system-path)]
+        | flatten
+        | str collect (char esep))
 
-    { PATH: $new-path }
+    { PATH: $new_path }
 }
 
-def conda-create-path-unix [env-dir: path] {
-    let env-path = [
-        ([$env-dir "bin"] | path join)
+def conda-create-path-unix [env_dir: path] {
+    let env_path = [
+        ([$env_dir "bin"] | path join)
     ]
 
-    let new-path = ([$env-path $env.PATH]
-        | flatten)
+    let new_path = ([$env_path $env.PATH]
+        | flatten
+        | str collect (char esep))
 
-    { PATH: $new-path }
+    { PATH: $new_path }
 }
 
 def windows? [] {


### PR DESCRIPTION
Renames all variables from `aa-xx` to `aa_xx` style. No other changes.