### PR TITLE
Respond to upstream changes: empty? -> is-empty, TODO list

### DIFF
--- a/prompt/async_git_prompt/README.md
+++ b/prompt/async_git_prompt/README.md
@@ -26,3 +26,8 @@ To use this module:
    ```
 
 5. To go back to synchronous mode, run `async-git-prompt-delete-cache`.
+
+### TODO
+
+- Automatic cache invalidation
+- Show untracked files (this can be very expensive in large repos)

--- a/prompt/async_git_prompt/async-git-prompt.nu
+++ b/prompt/async_git_prompt/async-git-prompt.nu
@@ -16,7 +16,7 @@ def do-async [commands: string] {
 
 export def async-git-prompt-string [] {
     let cache_path = (cache-path)
-    if ($cache_path | empty?) {
+    if ($cache_path | is-empty) {
         ""
     } else if ($cache_path | path exists) {
         $"(cached-result-symbol)(open $cache_path | str trim)"
@@ -69,7 +69,7 @@ def cache-path [] {
     } else {
         do -i { git rev-parse --show-toplevel | str trim -r }
     }
-    if ($dir | empty?) {
+    if ($dir | is-empty) {
         null
     } else {
         $dir | path join (cache-file)

--- a/prompt/async_git_prompt/prompt.nu
+++ b/prompt/async_git_prompt/prompt.nu
@@ -3,7 +3,7 @@ use async-git-prompt.nu *
 
 def prompt-concat [parts: table] {
     $parts
-    | where (not ($it.text | empty?))
+    | where (not ($it.text | is-empty))
     | each { |it| $"($it.color)($it.text)" }
     | str collect ' '
 }


### PR DESCRIPTION
Quick PR:

1. `empty? -> is-empty` (This script narrowly misssed out on the  search-and-replace in 203727b2917b1c15cfaf5c032b1ec8baa71458b6)
2. Add some TODOs to the README.