### PR TITLE
custom completions: scoop: fix list sub command

### DIFF
--- a/custom-completions/scoop/scoop-completions.nu
+++ b/custom-completions/scoop/scoop-completions.nu
@@ -114,7 +114,7 @@ export extern "scoop" [
 
 # Lists all installed apps, or the apps matching the supplied query.
 export extern "scoop list" [
-  query: string@scoopInstalledApps # string that will be matched
+  query?: string@scoopInstalledApps # string that will be matched
   --help(-h) # Show help for this command.
 ]
 


### PR DESCRIPTION
hi

I forgotten to include `?` to `query` argument to make it optional.
`scoop list` can be called without any parameters.

thanks
