### PR TITLE
add cargo update completions

### DIFF
--- a/custom-completions/cargo/cargo-completions.nu
+++ b/custom-completions/cargo/cargo-completions.nu
@@ -495,3 +495,18 @@ export extern "cargo clippy" [
 	--version(-V)  # Prints version information
 	--help(-h)     # Prints help information
 ]
+
+# Parameters from cargo update
+export extern "cargo install-update" [
+  --cargo-dir(-c)    # The cargo home directory. Default: $CARGO_HOME or $HOME/.cargo
+  --temp-dir(-t)     # The temporary directory. Default: $TEMP/cargo-update
+  --all(-a)          # Update all packages
+  --list(-l)         # Don't update packages, only list and check if they need an update (all packages by default)
+  --force(-f)        # Update all packages regardless if they need updating
+  --downdate(-d)     # Downdate packages to match latest unyanked registry version
+  --allow-no-update(-i) # Allow for fresh-installing packages
+  --git(-g)             # Also update git packages
+  --quiet(-q)           # No output printed to stdout
+  --filter(-s)          # Specify a filter a package must match to be considered
+  --install-cargo(-r)   # Specify an alternative cargo to run for installations
+]


### PR DESCRIPTION
I'm so sick of `cargo install-update -l` puking on Windows (but not other operating systems) that it pushed me to add these stinking completions.