### PR TITLE
feat: added coloring/hl.nu, a highlighting module

### DIFF
--- a/coloring/hl.nu
+++ b/coloring/hl.nu
@@ -1,0 +1,56 @@
+export def combine [txt: string, fg: record, bg: record] {
+  {
+    txt: $txt,
+    fg:  $fg.fg,
+    bg:  $bg.fg,
+    bli: ($fg.bli || $bg.bli),
+    bol: ($fg.bol || $bg.bol),
+    dim: ($fg.dim || $bg.dim),
+    hid: ($fg.hid || $bg.hid),
+    ita: ($fg.ita || $bg.ita),
+    rev: ($fg.rev || $bg.rev),
+    stk: ($fg.stk || $bg.stk),
+    und: ($fg.und || $bg.und)
+  }
+}
+
+export def create [txt: string,
+    fg = "n", bg = "n",
+    bli = false, bol = false, dim = false, hid = false,
+    ita = false, rev = false, stk = false, und = false] {
+  {
+    txt: $txt,
+    fg:  $fg,
+    bg:  $bg,
+    bli: $bli,
+    bol: $bol,
+    dim: $dim,
+    hid: $hid,
+    ita: $ita,
+    rev: $rev,
+    stk: $stk,
+    und: $und
+  }
+}
+
+export def render [obj: record] {
+  let attr = ""
+  let attr = $"($attr)(if $obj.bli {'l'})"
+  let attr = $"($attr)(if $obj.bol {'b'})"
+  let attr = $"($attr)(if $obj.dim {'d'})"
+  let attr = $"($attr)(if $obj.hid {'h'})"
+  let attr = $"($attr)(if $obj.ita {'i'})"
+  let attr = $"($attr)(if $obj.rev {'r'})"
+  let attr = $"($attr)(if $obj.stk {'s'})"
+  let attr = $"($attr)(if $obj.und {'u'})"
+
+  let color = {fg: $obj.fg, bg: $obj.bg, attr: $attr}
+
+  $"(ansi $color)($obj.txt)(ansi reset)"
+}
+
+export def reverse [obj: record] {
+  let r = ($obj | update fg $obj.bg)
+  let r = ($r | update bg $obj.fg)
+  $r
+}


### PR DESCRIPTION
This module is extracted from my [dotfiles](https://github.com/Neur1n/dotfiles/blob/master/nu/module/n_hl.nu). It provides 4 functionalities:

- `create`: creates a [record](https://www.nushell.sh/book/types_of_data.html#records) representing something like a "highlighting group" in (neo)vim. Let's call it "hl obj" in the following statement.
- `combine`: combines two hl objs
- `reverse`: reverses a hl obj
- `render`: renders a hl obj

Wish the code have explained itself without over complicated documentations.

For usage example, take a look at [this](https://github.com/Neur1n/dotfiles/blob/c060c046caf04331c806ad163f7e9a3e38fa6a9d/nu/script/n_prompt.nu#L19).