### PR TITLE
sockets command

### DIFF
--- a/network/sockets/README.md
+++ b/network/sockets/README.md
@@ -1,0 +1,4 @@
+The `sockets` command returns a table containing information on network sockets and the processes they belong to.
+It currently supports MacOS only: it is basically a join of the tables produced by the native `lsof` command on MacOS, and the nushell `ps` command.
+
+<img width="1486" alt="image" src="https://user-images.githubusercontent.com/52205/196287615-00e46f8e-06ed-45ce-8fe7-a5c5f38afaaa.png">

--- a/network/sockets/README.md
+++ b/network/sockets/README.md
@@ -1,4 +1,4 @@
 The `sockets` command returns a table containing information on network sockets and the processes they belong to.
-It currently supports MacOS only: it is basically a join of the tables produced by the native `lsof` command on MacOS, and the nushell `ps` command.
+It is basically a join of the tables produced by the `lsof` command, and the nushell `ps` command.
 
 <img width="1486" alt="image" src="https://user-images.githubusercontent.com/52205/196287615-00e46f8e-06ed-45ce-8fe7-a5c5f38afaaa.png">

--- a/network/sockets/sockets.nu
+++ b/network/sockets/sockets.nu
@@ -1,0 +1,32 @@
+export def sockets [--abbreviate-java-class-paths (-j)] {
+  let input = (^lsof +c 0xFFFF -i -n -P)
+  let header = ($input | lines
+                       | take 1
+                       | each { str downcase | str replace ' name$' ' name state' })
+  let body = ($input | lines
+                     | skip 1
+                     | each { str replace '([^)])$' '$1 (NONE)' | str replace ' \((.+)\)$' ' $1' })
+  [$header] | append $body
+            | to text
+            | detect columns
+            | upsert 'pid' { |r| $r.pid | into int }
+            | rename -c ['name' 'connection']
+            | reject 'command'
+            | join-table (ps -l) 'pid' 'pid'
+            | if $abbreviate_java_class_paths {
+                upsert 'classpath' { |r| $r.command | java-cmd classpath }
+                | upsert 'command' { |r| $r.command | java-cmd abbreviate-classpath }
+              } else { $in }
+}
+
+export def 'java-cmd classpath' [] {
+  str replace '.* -classpath +(.+\.jar) +.*' '$1' | split row ':'
+}
+
+export def 'java-cmd abbreviate-classpath' [] {
+  str replace '[^ ]*\.jar' '*.jar'
+}
+
+export def join-table [table: table, left_on: string, right_on: string] {
+  into df | join ($table | into df) $left_on $right_on | into nu
+}


### PR DESCRIPTION
README contents:


The `sockets` command returns a table containing information on network sockets and the processes they belong to.
It is basically a join of the tables produced by the `lsof` command, and the nushell `ps` command.

<img width="1486" alt="image" src="https://user-images.githubusercontent.com/52205/196287615-00e46f8e-06ed-45ce-8fe7-a5c5f38afaaa.png">
