### PR TITLE
fix conda deactivate error when activate with no-prompt

### DIFF
--- a/virtual_environments/conda.nu
+++ b/virtual_environments/conda.nu
@@ -57,6 +57,7 @@ export def-env activate [
         | insert PROMPT_COMMAND $new_prompt
     } else {
         $new_env
+        | insert CONDA_OLD_PROMPT_COMMAND $nothing
     }
 
     load-env $new_env
@@ -66,21 +67,20 @@ export def-env activate [
 export def-env deactivate [] {
     let path_name = if "PATH" in (env).name { "PATH" } else { "Path" }
     let-env $path_name = $env.CONDA_OLD_PATH
-    let-env PROMPT_COMMAND = $env.CONDA_OLD_PROMPT_COMMAND
 
-    hide CONDA_PROMPT_MODIFIER
-    hide CONDA_PREFIX
-    hide CONDA_SHLVL
-    hide CONDA_DEFAULT_ENV
-    hide CONDA_OLD_PATH
+    hide-env CONDA_PROMPT_MODIFIER
+    hide-env CONDA_PREFIX
+    hide-env CONDA_SHLVL
+    hide-env CONDA_DEFAULT_ENV
+    hide-env CONDA_OLD_PATH
 
-    let-env PROMPT_COMMAND = if 'CONDA_OLD_PROMPT_COMMAND' in (env).name {
-        $env.CONDA_OLD_PROMPT_COMMAND
-    } else {
+    let-env PROMPT_COMMAND = if $env.CONDA_OLD_PROMPT_COMMAND == $nothing {
         $env.PROMPT_COMMAND
+    } else {
+        $env.CONDA_OLD_PROMPT_COMMAND
     }
 
-    hide CONDA_OLD_PROMPT_COMMAND
+    hide-env CONDA_OLD_PROMPT_COMMAND
 }
 
 def 'nu-complete conda envs' [] {


### PR DESCRIPTION
Currently when activte conda env with `--no-prompt` flag, deactivate env will show error:
```
Error: nu::shell::name_not_found (link)

  × Name not found
    ╭─[/Users/zzz/projects/rust_online_code/nu_scripts/virtual_environments/conda.nu:68:1]
 68 │     let-env $path_name = $env.CONDA_OLD_PATH
 69 │     let-env PROMPT_COMMAND = $env.CONDA_OLD_PROMPT_COMMAND
    ·                                   ────────────┬───────────
    ·                                               ╰── did you mean 'PROMPT_COMMAND'?
 70 │
    ╰────
```

This pr is going to fix it