### PR TITLE
Make the default for the `up` command (in the filesystem directory) 1

### DIFF
--- a/filesystem/up.nu
+++ b/filesystem/up.nu
@@ -5,7 +5,7 @@ def up_inner [limit: int] {
 
 # Go up a number of directories
 def-env up [
-    limit = 1: int # The number of directories to go up
+    limit = 1: int # The number of directories to go up (default is 1)
   ] {
     cd (
     (up_inner $limit)

--- a/filesystem/up.nu
+++ b/filesystem/up.nu
@@ -5,7 +5,7 @@ def up_inner [limit: int] {
 
 # Go up a number of directories
 def-env up [
-    limit: int # The number of directories to go up
+    limit = 1: int # The number of directories to go up
   ] {
     cd (
     (up_inner $limit)


### PR DESCRIPTION
So that you don't have to specify "1" if you just want to go `up` once