### PR TITLE
oh-my-nu-v2 script - a new prompt for 8bit/24bit terminals

### DIFF
--- a/prompt/oh-my-v2-docs.md
+++ b/prompt/oh-my-v2-docs.md
@@ -1,0 +1,192 @@
+# oh-my.nu v2
+
+This is less a version 2 and more of a different way of thinking. The intent of this script is to start to make oh-my.nu more configurable. We start with that by defining a lot of variables. Then we create a runtime_colors list of records. Those records will have 8bit colors, 24bit colors, or a value. 8bit for terminals like MacOS's Terminal.app and 24bit color for the rest of the world.
+
+The thought would be that at some point this file source read another file for configured settings. That part is not done yet.
+
+In order to use this script you need to source it and then set these.
+```
+let-env PROMPT_COMMAND = { (get_prompt 8bit).left_prompt }
+let-env PROMPT_COMMAND_RIGHT = { (get_prompt 8bit).right_prompt }
+let-env PROMPT_INDICATOR = { "" }
+```
+
+I'd love for someone to take up the torch and work on this script in order to make it better, configurable, awesome.
+
+Below is some rough documentation on what the configuration points are and could be. Not all of these configuration points are implemented. BTW, this is a total rip-off of the fish [tide](https://github.com/IlanCosman/tide) prompt, but not as nice.
+
+
+### color mode
+
+* 24bit
+* 8bit
+
+### prompt
+
+| Variable                   | Description                                                                                   | Type    |
+| -------------------------- | --------------------------------------------------------------------------------------------- | ------- |
+| add_newline_before         | print an empty line before the prompt                                                         | boolean |
+| color_frame_and_connection | color of frame and prompt connection                                                          | color   |
+| color_separator_same_color | color of the separator between items with the same background color                           | color   |
+| icon_connection            | repeated symbol that spans gap between left and right sides of prompt                         | string  |
+| min_cols                   | if using one-line prompt, Tide attempts to have at least this many columns for you to type in | integer |
+| pad_items                  | if true, add a space before and after each item                                               | boolean |
+
+| variable_name | 24bit_color | 8bit_color |
+| - | - | - |
+|tide_prompt_color_frame_and_connection|#6C6C6C|242|
+|tide_prompt_color_separator_same_color|#949494|246|
+
+### left_prompt
+
+| Variable             | Description                                               | Type    |
+| -------------------- | --------------------------------------------------------- | ------- |
+| frame_enabled        | display the left prompt frame                             | boolean |
+| items                | order of items to print in the left prompt                | list    |
+| prefix               | string to put at the beginning the left prompt            | string  |
+| separator_diff_color | string to separate items with different background colors | string  |
+| separator_same_color | string to separate items with the same background color   | string  |
+| suffix               | string to put at the end of the left prompt               | string  |
+
+| variable_name | char |
+| - | - |
+|tide_left_prompt_separator_diff_color|e0b0|
+|tide_left_prompt_separator_same_color|e0b1|
+
+### right_prompt
+
+| Variable             | Description                                               | Type    |
+| -------------------- | --------------------------------------------------------- | ------- |
+| frame_enabled        | display the right prompt frame                            | boolean |
+| items                | order of items to print in the right prompt               | list    |
+| prefix               | string to put at the beginning the right prompt           | string  |
+| separator_diff_color | string to separate items with different background colors | string  |
+| separator_same_color | string to separate items with the same background color   | string  |
+| suffix               | string to put at the end of the right prompt              | string  |
+
+| variable_name | char |
+| - | - |
+|tide_right_prompt_separator_diff_color|e0b2|
+|tide_right_prompt_separator_same_color|e0b3|
+
+### cmd_duration
+
+| Variable  | Description                                                        | Type    |
+| --------- | ------------------------------------------------------------------ | ------- |
+| bg_color  | background color of the cmd_duration item                          | color   |
+| color     | color of the cmd_duration item                                     | color   |
+| decimals  | number of decimals to display after the seconds place              | integer |
+| icon      | icon for the cmd_duration item                                     | string  |
+| threshold | number of milliseconds that duration must exceed to produce output | integer |
+
+| variable_name | 24bit_color | 8bit_color |
+| - | - | - |
+|tide_cmd_duration_bg_color|#C4A000|178|
+|tide_cmd_duration_color|#000000|16|
+
+### git
+
+| Variable          | Description                                                            | Type   |
+| ----------------- | ---------------------------------------------------------------------- | ------ |
+| bg_color          | default background color of the git_item                               | color  |
+| bg_color_unstable | background color when repository has dirty, staged, or untracked files | color  |
+| bg_color_urgent   | background color when repository has conflicts or ongoing operations   | color  |
+| color_branch      | color of branch/SHA                                                    | color  |
+| color_conflicted  | color of conflicted files number                                       | color  |
+| color_dirty       | color of dirty files number                                            | color  |
+| color_operation   | color of the current operation                                         | color  |
+| color_staged      | color of staged files number                                           | color  |
+| color_stash       | color of stashes number                                                | color  |
+| color_untracked   | color of untracked files number                                        | color  |
+| color_upstream    | color of upstream behind/ahead numbers                                 | color  |
+| icon              | icon of the git item, colored same as branch                           | string |
+
+| variable_name | 24bit_color | 8bit_color |
+| - | - | - |
+|tide_git_bg_color|#4E9A06|70|
+|tide_git_bg_color_unstable|#C4A000|178|
+|tide_git_bg_color_urgent|#CC0000|160|
+|tide_git_color_branch|#000000|16|
+|tide_git_color_conflicted|#000000|16|
+|tide_git_color_dirty|#000000|16|
+|tide_git_color_operation|#000000|16|
+|tide_git_color_staged|#000000|16|
+|tide_git_color_stash|#000000|16|
+|tide_git_color_untracked|#000000|16|
+|tide_git_color_upstream|#000000|16|
+
+### os
+
+| Variable | Description                 | Type  |
+| -------- | --------------------------- | ----- |
+| bg_color | background color of os item | color |
+| color    | color of os item            | color |
+
+| variable_name | 24bit_color | 8bit_color |
+| - | - | - |
+|tide_os_bg_color|#CED7CF|188|
+|tide_os_color|#080808|232|
+
+### pwd
+
+| Variable             | Description                                                                                    | Type   |
+| -------------------- | ---------------------------------------------------------------------------------------------- | ------ |
+| bg_color             | background color of pwd item                                                                   | color  |
+| color_anchors        | color of anchor directories. These directories are displayed in bold and immune to truncation. | color  |
+| color_dirs           | color of normal directories                                                                    | color  |
+| color_truncated_dirs | color of truncated directories                                                                 | color  |
+| icon                 | default icon for pwd item                                                                      | string |
+| icon_home            | icon when the the current directory is the user's HOME                                         | string |
+| icon_unwritable      | icon when the directory is not writable by the user                                            | string |
+| markers              | if a directory contains any of these files/directories, it will be anchored                    | list   |
+
+| variable_name | 24bit_color | 8bit_color |
+| - | - | - |
+|tide_pwd_bg_color|#3465A4|61|
+|tide_pwd_color_anchors|#E4E4E4|254|
+|tide_pwd_color_dirs|#E4E4E4|254|
+|tide_pwd_color_truncated_dirs|#BCBCBC|250|
+
+### rustc
+
+| Variable | Description                              | Type   |
+| -------- | ---------------------------------------- | ------ |
+| bg_color | background color of rust item            | color  |
+| color    | color of rust item                       | color  |
+| icon     | icon to display next to the rust version | string |
+
+| variable_name | 24bit_color | 8bit_color |
+| - | - | - |
+|tide_rustc_bg_color|#F74C00|202|
+|tide_rustc_color|#000000|16|
+
+### status
+
+| Variable         | Description                         | Type   |
+| ---------------- | ----------------------------------- | ------ |
+| bg_color         | background color when `$status` = 0 | color  |
+| bg_color_failure | background color when `$status` > 0 | color  |
+| color            | color when `$status` = 0            | string |
+| color_failure    | color when `$status` > 0            | color  |
+| icon             | icon when `$status` = 0             | string |
+| icon_failure     | icon when `$status` > 0             | string |
+
+| variable_name | 24bit_color | 8bit_color |
+| - | - | - |
+|tide_status_bg_color|#2E3436|236|
+|tide_status_bg_color_failure|#CC0000|160|
+|tide_status_color|#4E9A06|70|
+|tide_status_color_failure|#FFFF00|226|
+
+### time
+
+| Variable | Description                                 | Type   |
+| -------- | ------------------------------------------- | ------ |
+| bg_color | background color of time item               | color  |
+| color    | color of time item                          | color  |
+| format   | format of time item. Uses `date` formatting | string |
+
+| variable_name | 24bit_color | 8bit_color |
+| - | - | - |
+|tide_time_bg_color|#D3D7CF|188|
+|tide_time_color|#000000|16|

--- a/prompt/oh-my-v2.nu
+++ b/prompt/oh-my-v2.nu
@@ -1,0 +1,435 @@
+# See the readme for how to use this script
+# modes
+# * 8bit
+# * 24bit
+let color_mode = "8bit"
+
+# setup separate characters
+let left_prompt_separator_diff_color = (char -u 'e0b0')
+let left_prompt_separator_same_color = (char -u 'e0b1')
+let right_prompt_separator_diff_color = (char -u 'e0b2')
+let right_prompt_separator_same_color = (char -u 'e0b3')
+
+# setup color variables for 24bit and 8bit
+# prompt
+let prompt_color_frame_and_connection_24 = (ansi -e { fg: "#6C6C6C" })
+let prompt_color_separator_same_color_24 = (ansi -e { fg: "#949494" })
+let prompt_color_frame_and_connection_8 = $"(ansi idx_fg)242m"
+let prompt_color_separator_same_color_8 = $"(ansi idx_fg)246m"
+let prompt_add_new_line_before = false
+let prompt_color_frame_and_connection = ""
+let prompt_color_separator_same_color = ""
+
+let left_separator_diff_color = ""
+let left_separator_same_color = ""
+let left_items = []
+let left_prefix = ""
+let left_suffix = ""
+
+let right_separator_diff_color = ""
+let right_separator_same_color = ""
+let right_items = []
+let right_prefix = ""
+let right_suffix = ""
+
+# cmd
+let cmd_duration_bg_color_24 = (ansi -e { bg: "#C4A000" })
+let cmd_duration_color_24 = (ansi -e { fg: "#000000" })
+let cmd_duration_bg_color_8 = $"(ansi idx_bg)178m"
+let cmd_duration_color_8 = $"(ansi idx_fg)16m"
+let cmd_bg_color = ""
+let cmd_color = ""
+let cmd_decimals = 2
+let cmd_icon = ""
+
+# git
+let git_bg_color_24 = (ansi -e { bg: "#4E9A06" })
+let git_bg_color_unstable_24 = (ansi -e { bg: "#C4A000" })
+let git_bg_color_urgent_24 = (ansi -e { bg: "#CC0000" })
+let git_color_branch_24 = (ansi -e { fg: "#000000" })
+let git_color_conflicted_24 = (ansi -e { fg: "#000000" })
+let git_color_dirty_24 = (ansi -e { fg: "#000000" })
+let git_color_operation_24 = (ansi -e { fg: "#000000" })
+let git_color_staged_24 = (ansi -e { fg: "#000000" })
+let git_color_stash_24 = (ansi -e { fg: "#000000" })
+let git_color_untracked_24 = (ansi -e { fg: "#000000" })
+let git_color_upstream_24 = (ansi -e { fg: "#000000" })
+
+let git_bg_color_8 = $"(ansi idx_bg)70m"
+let git_bg_color_unstable_8 = $"(ansi idx_bg)178m"
+let git_bg_color_urgent_8 = $"(ansi idx_bg)160m"
+let git_color_branch_8 = $"(ansi idx_fg)16m"
+let git_color_conflicted_8 = $"(ansi idx_fg)16m"
+let git_color_dirty_8 = $"(ansi idx_fg)16m"
+let git_color_operation_8 = $"(ansi idx_fg)16m"
+let git_color_staged_8 = $"(ansi idx_fg)16m"
+let git_color_stash_8 = $"(ansi idx_fg)16m"
+let git_color_untracked_8 = $"(ansi idx_fg)16m"
+let git_color_upstream_8 = $"(ansi idx_fg)16m"
+
+let git_bg_color = ""
+let git_bg_color_unstable = ""
+let git_bg_color_urgent = ""
+let git_color_branch = ""
+let git_color_conflicted = ""
+let git_color_dirty = ""
+let git_color_operation = ""
+let git_color_staged = ""
+let git_color_stash = ""
+let git_color_untracked = ""
+let git_color_upstream = ""
+
+# os
+let os_bg_color_24 = (ansi -e { bg: "#CED7CF" })
+let os_color_24 = (ansi -e { fg: "#080808" })
+let os_bg_color_8 = $"(ansi idx_bg)188m"
+let os_color_8 = $"(ansi idx_fg)232m"
+let os_bg_color = ""
+let os_color = ""
+
+# pwd
+let pwd_bg_color_24 = (ansi -e { bg: "#3465A4" })
+let pwd_color_anchors_24 = (ansi -e { fg: "#E4E4E4" })
+let pwd_color_dirs_24 = (ansi -e { fg: "#E4E4E4" })
+let pwd_color_truncated_dirs_24 = (ansi -e { fg: "#BCBCBC" })
+
+let pwd_bg_color_8 = $"(ansi idx_bg)61m"
+let pwd_color_anchors_8 = $"(ansi idx_fg)254m"
+let pwd_color_dirs_8 = $"(ansi idx_fg)254m"
+let pwd_color_truncated_dirs_8 = $"(ansi idx_fg)250m"
+
+let pwd_bg_color = ""
+let pwd_color_anchors = ""
+let pwd_color_dirs = ""
+let pwd_color_truncated_dirs = ""
+let pwd_icon = ""
+let pwd_icon_home = ""
+let pwd_icon_unwritable = ""
+let pwd_markers = []
+
+# rustc
+let rustc_bg_color_24 = (ansi -e { bg: "#F74C00" })
+let rustc_color_24 = (ansi -e { fg: "#000000" })
+let rustc_bg_color_8 = $"(ansi idx_bg)202m"
+let rustc_color_8 = $"(ansi idx_fg)16m"
+
+let rustc_bg_color = ""
+let rustc_color = ""
+let rustc_icon = ""
+
+# status
+let status_bg_color_24 = (ansi -e { bg: "#2E3436" })
+let status_bg_color_failure_24 = (ansi -e { bg: "#CC0000" })
+let status_color_24 = (ansi -e { fg: "#4E9A06" })
+let status_color_failure_24 = (ansi -e { fg: "#FFFF00" })
+
+let status_bg_color_8 = $"(ansi idx_bg)236m"
+let status_bg_color_failure_8 = $"(ansi idx_bg)160m"
+let status_color_8 = $"(ansi idx_fg)70m"
+let status_color_failure_8 = $"(ansi idx_fg)226m"
+
+let status_bg_color = ""
+let status_bg_color_faiure = ""
+let status_color = ""
+let status_color_failure = ""
+let status_icon = ""
+let status_icon_failure = ""
+
+# time
+let time_bg_color_24 = (ansi -e { bg: "#D3D7CF" })
+let time_color_24 = (ansi -e { fg: "#000000" })
+let time_bg_color_8 = $"(ansi idx_bg)188m"
+let time_color_8 = $"(ansi idx_fg)16m"
+
+let time_bg_color = ""
+let time_color = ""
+let time_format = ""
+
+# indicator
+let indicator_color_24 = (ansi -e { fg: "#3465a4" })
+let indicator_bg_color_24 = (ansi -e { bg: "#000000" })
+let indicator_color_8 = $"(ansi idx_fg)61m"
+let indicator_bg_color_8 = $"(ansi idx_bg)16m"
+
+# terminal background color
+let terminal_color_24 = (ansi -e { fg: "#c7c7c7" })
+let terminal_color_8 = (ansi white)
+let terminal_bg_color_24 = (ansi -e { bg: "#000000" })
+let terminal_bg_color_8 = (ansi black)
+
+# cmd_duration_ms
+let cmd_duration_ms_color_24 = (ansi -e { fg: "#606060" })
+let cmd_duration_ms_color_8 = $"(ansi idx_fg)244m"
+let cmd_duration_ms_bg_color_24 = (ansi -e { fg: "#000000" })
+let cmd_duration_ms_bg_color_8 = (ansi black)
+
+let runtime_colors = [
+    { name: prompt_color_frame_and_connection, 8bit: $prompt_color_frame_and_connection_8, 24bit: $prompt_color_frame_and_connection_24 },
+    { name: prompt_color_separator_same_color, 8bit: $prompt_color_separator_same_color_8, 24bit: $prompt_color_separator_same_color_24 },
+    { name: left_separator_diff_color, 8bit: $left_prompt_separator_diff_color, 24bit: $left_prompt_separator_diff_color },
+    { name: left_separator_same_color, 8bit: $left_prompt_separator_same_color, 24bit: $left_prompt_separator_same_color },
+    { name: left_prefix, value: $nothing },
+    { name: left_suffix, value: $nothing },
+    { name: right_separator_diff_color, 8bit: $right_prompt_separator_diff_color, 24bit: $right_prompt_separator_diff_color },
+    { name: right_separator_same_color, 8bit: $right_prompt_separator_same_color, 24bit: $right_prompt_separator_same_color },
+    { name: right_prefix, value: $nothing },
+    { name: right_suffix, value: $nothing },
+
+    { name: cmd_bg_color, 8bit: $cmd_duration_bg_color_8, 24bit: $cmd_duration_bg_color_24 },
+    { name: cmd_color, 8bit: $cmd_duration_color_8, 24bit: $cmd_duration_color_24 },
+    { name: cmd_decimals, value: 2 },
+    { name: cmd_icon, value:  },
+
+    { name: git_bg_color, 8bit: $git_bg_color_8, 24bit: $git_bg_color_24 },
+    { name: git_bg_color_unstable, 8bit: $git_bg_color_unstable_8, 24bit: $git_bg_color_unstable_24 },
+    { name: git_bg_color_urgent, 8bit: $git_bg_color_urgent_8 , 24bit: $git_bg_color_urgent_24 },
+    { name: git_color_branch, 8bit: $git_color_branch_8, 24bit: $git_color_branch_24 },
+    { name: git_color_conflicted, 8bit: $git_color_conflicted_8, 24bit: $git_color_conflicted_24 },
+    { name: git_color_dirty, 8bit: $git_color_dirty_8, 24bit: $git_color_dirty_24 },
+    { name: git_color_operation, 8bit: $git_color_operation_8, 24bit: $git_color_operation_24 },
+    { name: git_color_staged, 8bit: $git_color_staged_8, 24bit: $git_color_staged_24 },
+    { name: git_color_stash, 8bit: $git_color_stash_8, 24bit: $git_color_stash_24 },
+    { name: git_color_untracked, 8bit: $git_color_untracked_8, 24bit: $git_color_untracked_24 },
+    { name: git_color_upstream, 8bit: $git_color_upstream_8, 24bit: $git_color_upstream_24 },
+
+    { name: os_bg_color, 8bit: $os_bg_color_8, 24bit: $os_bg_color_24 },
+    { name: os_color, 8bit: $os_color_8, 24bit: $os_color_24 },
+
+    { name: pwd_bg_color, 8bit: $pwd_bg_color_8, 24bit: $pwd_bg_color_24 },
+    { name: pwd_color_anchors, 8bit: $pwd_color_anchors_8, 24bit: $pwd_color_anchors_24 },
+    { name: pwd_color_dirs, 8bit: $pwd_color_dirs_8, 24bit: $pwd_color_dirs_24 },
+    { name: pwd_color_truncated_dirs, 8bit: $pwd_color_truncated_dirs_8, 24bit: $pwd_color_truncated_dirs_24 },
+    { name: pwd_icon, value: $nothing },
+    { name: pwd_icon_home, value: $nothing },
+    { name: pwd_icon_unwritable, value: $nothing },
+
+    { name: rustc_bg_color, 8bit: $rustc_bg_color_8, 24bit: $rustc_bg_color_24 },
+    { name: rustc_color, 8bit: $rustc_color_8, 24bit: $rustc_color_24 },
+    { name: rustc_icon, value:  },
+
+    { name: status_bg_color, 8bit: $status_bg_color_8, 24bit: $status_bg_color_24 },
+    { name: status_bg_color_failure, 8bit: $status_bg_color_failure_8, 24bit: $status_bg_color_failure_24 },
+    { name: status_color, 8bit: $status_color_8, 24bit: $status_color_24 },
+    { name: status_color_failure, 8bit: $status_color_failure_8 , 24bit: $status_color_failure_24 },
+    { name: status_icon, value: $nothing },
+    { name: status_icon_failure, value: $nothing },
+
+    { name: time_bg_color, 8bit: $time_bg_color_8, 24bit: $time_bg_color_24 },
+    { name: time_color, 8bit: $time_color_8, 24bit: $time_color_24 },
+    { name: time_format, value: $nothing },
+
+    { name: indicator_bg_color, 8bit: $indicator_bg_color_8, 24bit: $indicator_bg_color_24 },
+    { name: indicator_color, 8bit: $indicator_color_8, 24bit: $indicator_color_24 },
+
+    { name: terminal_color, 8bit: $terminal_color_8, 24bit: $terminal_color_24 },
+    { name: terminal_bg_color, 8bit: $terminal_bg_color_8, 24bit: $terminal_bg_color_24 },
+
+    {name: cmd_duration_ms_color, 8bit: $cmd_duration_ms_color_8, 24bit: $cmd_duration_ms_color_24 },
+    {name: cmd_duration_ms_bg_color, 8bit: $cmd_duration_ms_bg_color_8, 24bit: $cmd_duration_ms_bg_color_24 },
+]
+
+# get the color from the $runtime_colors array
+def get_color [name, mode] {
+    $runtime_colors | where name == $name | get $mode | get 0
+}
+
+######################################################
+
+# Abbreviate home path for the prompt
+def home_abbrev [os_name] {
+    let is_home_in_path = ($env.PWD | str starts-with $nu.home-path)
+    if $is_home_in_path {
+        if ($os_name == "Windows") {
+            let home = ($nu.home-path | str replace -a '\\' '/')
+            let pwd = ($env.PWD | str replace -a '\\' '/')
+            $pwd | str replace $home '~'
+        } else {
+            $env.PWD | str replace $nu.home-path '~'
+        }
+    } else {
+        $env.PWD | str replace -a '\\' '/'
+    }
+}
+
+# get the operating system icon for the prompt
+def get_os_icon [os] {
+    # f17c = tux, f179 = apple, f17a = windows
+    if ($os.name =~ macos) {
+        (char -u f179)
+    } else if ($os.name =~ windows) {
+        (char -u f17a)
+    } else if ($os.kernel_version =~ WSL) {
+        $'(char -u f17a)(char -u f17c)'
+    } else if ($os.family =~ unix) {
+        (char -u f17c)
+    } else {
+        ''
+    }
+}
+
+# get the os segment for the prompt
+def get_os_segment [os color_mode] {
+    let os_bg_color = (get_color os_bg_color $color_mode)
+    let os_color = (get_color os_color $color_mode)
+    let os_icon = (get_os_icon $os)
+    let transition_icon = $left_prompt_separator_diff_color
+    let transition_bg_color = (get_color pwd_bg_color $color_mode)
+    let transition_color = (get_color pwd_color_anchors $color_mode)
+
+    let os_segment = (
+    [
+        ($os_color)
+        ($os_bg_color)
+        (char space)
+        ($os_icon)
+        (char space)
+        ($transition_color)
+        ($transition_bg_color)
+        ($transition_icon)
+        (char space)
+    ] | str collect
+    )
+
+    $os_segment
+}
+
+# get the path segment for the prompt
+def get_path_segment [os color_mode] {
+    let display_path = (home_abbrev $os.name)
+    let is_home_in_path = ($env.PWD | str starts-with $nu.home-path)
+    let pwd_bg_color = (get_color pwd_bg_color $color_mode)
+    let pwd_color = (get_color pwd_color_dirs $color_mode)
+    let home_or_folder = (if $is_home_in_path { (char nf_house1) } else { (char nf_folder1) })
+    let path_segment = (
+        [
+            $home_or_folder
+            (char space)                           # space
+            $display_path                          # ~/src/forks/nushell
+            ($pwd_color)
+            ($pwd_bg_color)
+            (char space)                           # space
+        ] | str collect
+    )
+
+    $path_segment
+}
+
+# get the indicator segment for the prompt
+def get_indicator_segment [os color_mode] {
+    let R = (ansi reset)
+    let indicator_color = (get_color indicator_color $color_mode)
+    let indicator_bg_color = (get_color indicator_bg_color $color_mode)
+    let indicator_segment = (
+        [
+        ($indicator_color)
+        ($indicator_bg_color)
+        (char nf_segment)                         # 
+        ($R)                                   # reset color
+        ] | str collect
+    )
+
+    $indicator_segment
+}
+
+# construct the left prompt
+def get_left_prompt [os color_mode] {
+    let os_segment = (get_os_segment $os $color_mode)
+    let path_segment = (get_path_segment $os $color_mode)
+    let indicator_segment = (get_indicator_segment $os $color_mode)
+    $os_segment + $path_segment + $indicator_segment
+}
+
+# get the time segment for the prompt
+def get_time_segment [os color_mode] {
+    let R = (ansi reset)
+    let time_bg_color = (get_color time_bg_color $color_mode)
+    let time_color = (get_color time_color $color_mode)
+    
+    let time_segment = ([
+        (ansi { fg: $time_bg_color bg: $time_color})
+        (char nf_right_segment) #(char -u e0b2)     # 
+        ($time_color)
+        ($time_bg_color)
+        (char space)
+        (date now | date format '%I:%M:%S %p')
+        (char space)
+        ($R)
+    ] | str collect)
+
+    $time_segment
+}
+
+# get the status segment for the prompt
+def get_status_segment [os color_mode] {
+    let R = (ansi reset)
+
+    # set status bg color to foreground since bg is dark
+    let fg_failure = (get_color status_bg_color_failure $color_mode)
+    let term_bg_color = (get_color terminal_bg_color $color_mode)
+    let cmd_dur_fg = (get_color cmd_duration_ms_color $color_mode)
+    let cmd_dur_bg = (get_color cmd_duration_ms_bg_color $color_mode)
+
+    let status_segment = (
+        [
+            (if $env.LAST_EXIT_CODE != 0 {
+                (ansi { fg: $fg_failure bg: $term_bg_color })
+            } else {
+                (ansi { fg: $cmd_dur_fg bg: $cmd_dur_bg })
+            })
+            (char nf_right_segment_thin)
+            (char space)
+            $env.LAST_EXIT_CODE
+            (char space)
+            ($R)
+        ] | str collect
+    )
+
+    $status_segment
+}
+
+# get the execution segment for the prompt
+def get_execution_time_segment [os color_mode] {
+    let R = (ansi reset)
+    let cmd_dur_fg = (get_color cmd_duration_ms_color $color_mode)
+    let cmd_dur_bg = (get_color cmd_duration_ms_bg_color $color_mode)
+
+    let execution_time_segment = (
+        [
+            ($cmd_dur_fg)
+            ($cmd_dur_bg)
+            # (ansi { fg: $cmd_dur_fg bg: $cmd_dur_bg })
+            (char nf_right_segment_thin)
+            (char space)
+            $env.CMD_DURATION_MS
+            (char space)
+            ($R)
+        ] | str collect
+    )
+
+    $execution_time_segment
+}
+
+# construct the right prompt
+def get_right_prompt [os color_mode] {
+    let status_segment = (get_status_segment $os $color_mode)
+    let execution_time_segment = (get_execution_time_segment $os $color_mode)
+    let time_segment = (get_time_segment $os $color_mode)
+    let exit_if = (if $env.LAST_EXIT_CODE != 0 { $status_segment })
+    [$exit_if $execution_time_segment $time_segment] | str collect
+}
+
+# constructe the left and right prompt by color_mode (8bit or 24bit)
+def get_prompt [color_mode] {
+    # modes = 8bit or 24bit
+    # let os = ((sys).host)
+    let os = $nu.os-info
+    let left_prompt = (get_left_prompt $os $color_mode)
+    let right_prompt = (get_right_prompt $os $color_mode)
+
+    # return in record literal syntax to be used kind of like a tuple
+    # so we don't have to run this script more than once per prompt
+    {
+        left_prompt: $left_prompt
+        right_prompt: $right_prompt
+    }
+}


### PR DESCRIPTION
I've had this script laying undone on my computer for more than a year now. I submit it as a MVP and a slightly different way of thinking for prompt scripting because it has a lot of points that theoretically could be configuration points for someone to make a super fancy prompt. This is totally ripped off of the [fish tide prompt](https://github.com/IlanCosman/tide), thanks to them for the awesome work in fish.

Read the included markdown file for some of my thoughts and how to use it. The real reason I started this script was because the dumb macOS Terminal.app didn't/doesn't support 24bit color. So, this script will allow you to use 8bit or 24bit modes.

This is what the 8bit mode looks like in terminal.app on my Mac.
<img width="931" alt="Screenshot 2022-11-05 at 3 54 21 PM" src="https://user-images.githubusercontent.com/343840/200141003-9900cc27-226d-4a53-aa96-08057201cafa.png">
