### PR TITLE
Fix undetected windows enviroment

### DIFF
--- a/prompt/oh-my-v2.nu
+++ b/prompt/oh-my-v2.nu
@@ -239,7 +239,7 @@ def get_color [name, mode] {
 def home_abbrev [os_name] {
     let is_home_in_path = ($env.PWD | str starts-with $nu.home-path)
     if $is_home_in_path {
-        if ($os_name == "Windows") {
+        if ($os_name == "windows") {
             let home = ($nu.home-path | str replace -a '\\' '/')
             let pwd = ($env.PWD | str replace -a '\\' '/')
             $pwd | str replace $home '~'


### PR DESCRIPTION
$nu.os-info.name returns lowercase "windows" instead of capitalized "Windows", which causes the following error.
![image](https://user-images.githubusercontent.com/45326534/201401187-40986cc7-35ff-442b-8dba-3897aaa53599.png)
