### PR TITLE
Replace deprecated operators in panache-git

### DIFF
--- a/prompt/panache-git.nu
+++ b/prompt/panache-git.nu
@@ -131,7 +131,7 @@ export def repo-structured [] {
 
   let has_staging_or_worktree_changes = (if $in_git_repo {
     $status
-    | where ($it | str starts-with '1') || ($it | str starts-with '2')
+    | where ($it | str starts-with '1') or ($it | str starts-with '2')
     | str join
     | is-empty
     | nope
@@ -161,7 +161,7 @@ export def repo-structured [] {
 
   let staging_worktree_table = (if $has_staging_or_worktree_changes {
     $status
-    | where ($it | str starts-with '1') || ($it | str starts-with '2')
+    | where ($it | str starts-with '1') or ($it | str starts-with '2')
     | split column ' '
     | get column2
     | split column '' staging worktree --collapse-empty
@@ -251,31 +251,31 @@ export def repo-styled [] {
   let is_local_only = ($status.tracking_upstream_branch != true)
 
   let upstream_deleted = (
-    $status.tracking_upstream_branch &&
+    $status.tracking_upstream_branch and
     $status.upstream_exists_on_remote != true
   )
 
   let is_up_to_date = (
-    $status.upstream_exists_on_remote &&
-    $status.commits_ahead == 0 &&
+    $status.upstream_exists_on_remote and
+    $status.commits_ahead == 0 and
     $status.commits_behind == 0
   )
 
   let is_ahead = (
-    $status.upstream_exists_on_remote &&
-    $status.commits_ahead > 0 &&
+    $status.upstream_exists_on_remote and
+    $status.commits_ahead > 0 and
     $status.commits_behind == 0
   )
 
   let is_behind = (
-    $status.upstream_exists_on_remote &&
-    $status.commits_ahead == 0 &&
+    $status.upstream_exists_on_remote and
+    $status.commits_ahead == 0 and
     $status.commits_behind > 0
   )
 
   let is_ahead_and_behind = (
-    $status.upstream_exists_on_remote &&
-    $status.commits_ahead > 0 &&
+    $status.upstream_exists_on_remote and
+    $status.commits_ahead > 0 and
     $status.commits_behind > 0
   )
 
@@ -310,15 +310,15 @@ export def repo-styled [] {
   })
 
   let has_staging_changes = (
-    $status.staging_added_count > 0 ||
-    $status.staging_modified_count > 0 ||
+    $status.staging_added_count > 0 or
+    $status.staging_modified_count > 0 or
     $status.staging_deleted_count > 0
   )
 
   let has_worktree_changes = (
-    $status.untracked_count > 0 ||
-    $status.worktree_modified_count > 0 ||
-    $status.worktree_deleted_count > 0 ||
+    $status.untracked_count > 0 or
+    $status.worktree_modified_count > 0 or
+    $status.worktree_deleted_count > 0 or
     $status.merge_conflict_count > 0
   )
 
@@ -342,7 +342,7 @@ export def repo-styled [] {
     ''
   })
 
-  let delimiter = (if ($has_staging_changes && $has_worktree_changes) {
+  let delimiter = (if ($has_staging_changes and $has_worktree_changes) {
     ('|' | bright-yellow)
   } else {
     ''


### PR DESCRIPTION
Use `and` in favor of `&&`
Use `or` in favor of `||`

https://www.nushell.sh/blog/2022-11-29-nushell-0.72.html#new-boolean-operator-xor-planned-operator-simplification