### PR TITLE
prompt/full-line.nu -- full width prompt

### DIFF
--- a/prompt/full-line.nu
+++ b/prompt/full-line.nu
@@ -1,0 +1,48 @@
+# Nushell "Full Line" Prompt
+# Fills the entire line above the prompt with "useful" info, creates an easy-to-read separation between commands outputs.
+# Just the thing for portrait format terminal windows.
+# This one includes working directory in the middle and has option for timestamp info on right. 
+# (many) other permutations are possible.
+# You can play with this by `source full-line.nu` in an active shell.
+# To enable permanently, modify your `env.nu` file; add `create_center_prompt` and modify `let-env PROMPT_COMMAND` line as shown here.
+# Life made complicated by `str lpad` counting all the ansi sequences as visible, so it doesn't pad enough.
+
+def create_center_prompt [] {
+    let path_segment = if (is-admin) {
+        $" (ansi red_bold)($env.PWD)(ansi reset) "
+    } else {
+        $" (ansi green_bold)($env.PWD)(ansi reset) "
+    }
+    let path_segment_visible_length = ($path_segment | ansi strip | str length)
+    let path_segment_excess_length = ($path_segment | str length) - $path_segment_visible_length
+
+    # to disable the right hand segment, change line below to be simply `let time_segment = ''`.
+    let time_segment = $"(date now | date format ' %F %r')(ansi reset)"
+    let time_segment_excess_length = ($time_segment | str length) - ($time_segment | ansi strip | str length)
+
+    let path_segment_pad = ((((term size).columns + $path_segment_visible_length) / 2) | into int)
+    let time_segment_pad = (term size).columns - $path_segment_pad
+    
+    let pad_char = '-'
+
+    let segment = ([
+        ( $path_segment | str lpad -l ($path_segment_pad + $path_segment_excess_length) -c $pad_char), 
+        ( $time_segment | str lpad -l ($time_segment_pad + $time_segment_excess_length) -c $pad_char)
+        ] | str join)
+
+    $segment
+}
+
+# For full width prompt we simply print the prompt line but throw away the value; 
+# Nushell displays PROMPT_INDICATOR in left hand column, leaving lots of room for long command lines.
+let-env PROMPT_COMMAND = { print (create_center_prompt); }
+# let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
+let-env PROMPT_COMMAND_RIGHT = ''
+
+# The prompt indicators are environmental variables that represent
+# the state of the prompt
+let-env PROMPT_INDICATOR = { "〉" }
+let-env PROMPT_INDICATOR_VI_INSERT = { ": " }
+let-env PROMPT_INDICATOR_VI_NORMAL = { "〉" }
+let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
+


### PR DESCRIPTION
Sample snippet to add to your `env.nu` to create a "full width" prompt on line above your usual input prompt.  The width tracks changes in terminal width.  
This layout looks good (sez me) on portrait layout terminals, provides a visual separation between commands and doesn't crowd you if your working path is deeply nested.  The sample adds the date/time on right hand edge as an example

Sample screen:
```bash
-------------------------------------- /home/anome/src/nushell/nu_scripts/prompt ---------------- 2023-01-15 12:10:27 AM
〉git status
On branch full-prompt
Your branch is up to date with 'origin/full-prompt'.

nothing to commit, working tree clean
-------------------------------------- /home/anome/src/nushell/nu_scripts/prompt ---------------- 2023-01-15 12:11:03 AM
〉ls
╭────┬──────────────────┬──────┬─────────┬───────────────╮
│  # │       name       │ type │  size   │   modified    │
├────┼──────────────────┼──────┼─────────┼───────────────┤
│  0 │ README.md        │ file │   727 B │ 4 hours ago   │
│  1 │ async_git_prompt │ dir  │     5 B │ 4 hours ago   │
│  2 │ full-line.nu     │ file │  2.4 KB │ 8 minutes ago │
│  3 │ images           │ dir  │     4 B │ 4 hours ago   │
│  4 │ oh-my-minimal.nu │ file │  9.9 KB │ 4 hours ago   │
│  5 │ oh-my-v2-docs.md │ file │ 10.6 KB │ 4 hours ago   │
│  6 │ oh-my-v2.nu      │ file │ 16.1 KB │ 4 hours ago   │
│  7 │ oh-my.nu         │ file │ 19.3 KB │ 4 hours ago   │
│  8 │ panache-git.nu   │ file │ 10.6 KB │ 4 hours ago   │
│  9 │ shell_space.nu   │ file │   447 B │ 4 hours ago   │
│ 10 │ simple.nu        │ file │   685 B │ 4 hours ago   │
│ 11 │ starship.nu      │ file │   376 B │ 4 hours ago   │
╰────┴──────────────────┴──────┴─────────┴───────────────╯
-------------------------------------- /home/anome/src/nushell/nu_scripts/prompt ---------------- 2023-01-15 12:11:10 AM
〉
```