### PR TITLE
add timed_weather that checks the weather at timed intervals

### DIFF
--- a/weather/timed_weather_run_env.nu
+++ b/weather/timed_weather_run_env.nu
@@ -1,0 +1,44 @@
+# This script will run a command, in this case get_weather, at a prescribed interval
+# This is meant to be run from your prompt so that it runs every time you cd or
+# run a command. Each time it will check if it's been longer than the interval and
+# if so, run the command, otherwise it uses the cached weather information.
+# I wrote this so I could have weather in my prompt but not pay the price of hitting
+# the web for every prompt.
+
+# this script is depenedent on get-weather
+use get-weather.nu get_weather
+
+# Create a mutable weather table to hold the weather data
+let-env WEATHER = (get_weather | upsert last_run_time { (date now | date format '%Y-%m-%d %H:%M:%S %z')})
+
+#command to run at interval
+def-env timed_weather_run [
+    --interval(-i): duration # The interval duration
+    ] {
+
+    # get the last runtime and add my timezone difference
+    let last_runtime = ($env.WEATHER | get last_run_time | into datetime)
+    if $last_runtime + $interval > (date now) {
+        # $"interval not met. last_runtime: [($last_runtime)](char nl)"
+        let temp = ($env.WEATHER.Temperature)
+        let emoji = ($env.WEATHER.Emoji)
+        {
+            Temperature: ($temp)
+            Source: "cache"
+            Emoji: ($emoji)
+        }
+    } else {
+        # $"interval met, running command: [($command)](char nl)"
+
+        let-env WEATHER = (get_weather | upsert last_run_time { (date now | date format '%Y-%m-%d %H:%M:%S %z')})
+        let temp = ($env.WEATHER.Temperature)
+        let emoji = ($env.WEATHER.Emoji)
+        {
+            Temperature: ($temp)
+            Source: "expired-cache"
+            Emoji: ($emoji)
+        }
+    }
+}
+
+timed_weather_run --interval 1min


### PR DESCRIPTION
This script will check the weather and forecast at timed intervals and store the results in an environment variable. The main use of this env var cache is to put the temperature in your prompt without paying the price to have to go out to the web with every prompt.

You put this in your pormpt command `timed_weather_run --interval 1min` and when you create a new prompt, it runs and checks the env var to see if it's time to run again, or just pull it from the cache.

The env var data looks something like this. We might want to decrease it in the future or make the forecast optional.
```
╭──────────────────┬─────────────────────────────────────╮
│ Weather Location │ Rockwell, US                        │
│ Longitude        │ -93.2899                            │
│ Latitude         │ 34.4287                             │
│ Temperature      │ 62.4 °F                             │
│ Feels Like       │ 63.0 °F                             │
│ Humidity         │ 100                                 │
│ Pressure         │ 1007                                │
│ Emoji            │ ░                                   │
│ Forecast Day 1   │ Wed, Jan 18 ☔ high: 62.6 low: 47.5 │
│ Forecast Day 2   │ Thu, Jan 19 ☀️ high: 54.8 low: 40.3 │
│ Forecast Day 3   │ Fri, Jan 20 ☁️ high: 56.6 low: 38.2 │
│ Forecast Day 4   │ Sat, Jan 21 ☔ high: 46.9 low: 35.4 │
│ Forecast Day 5   │ Sun, Jan 22 ☔ high: 44.9 low: 33.6 │
│ Forecast Day 6   │ Mon, Jan 23 ☁️ high: 47.7 low: 31.1 │
│ Forecast Day 7   │ Tue, Jan 24 ❄️ high: 48.5 low: 33.9 │
│ last_run_time    │ 2023-01-18 08:46:23 -0600           │
╰──────────────────┴─────────────────────────────────────╯
```
This script depends on the get-weather.nu script. However, this timed functionality could be used in a variety of things.