### PR TITLE
Export command to make it use-able

### DIFF
--- a/data_extraction/ultimate_extractor.nu
+++ b/data_extraction/ultimate_extractor.nu
@@ -1,5 +1,5 @@
 #Function to extract archives with different extensions
-def extract [name:string #name of the archive to extract
+export def extract [name:string #name of the archive to extract
 ] {
   let exten = [ [ex com];
                     ['.tar.bz2' 'tar xjf']


### PR DESCRIPTION
export the command definition so it can also be registered with `use` instead of only with `source`