### PR TITLE
Change "list of values" to "list of records" with value and description

### DIFF
--- a/custom-completions/bitwarden-cli/bitwarden-cli-completions.nu
+++ b/custom-completions/bitwarden-cli/bitwarden-cli-completions.nu
@@ -46,8 +46,7 @@ def "nu-complete bw organization-user-statuses" [] {
 #
 # Supported settings
 def "nu-complete bw config-settings" [] {
-  [server # On-premises hosted installation URL.
-  ]
+  [{ value: "server", description: "On-premises hosted installation URL." }]
 }
 
 # bw list supported object values


### PR DESCRIPTION
It is just one entry for now, but I just found out from the docs that in this case comments are not used as description and a list of records with `[{ value: ..., description: }]` is required if descriptions should be shown in the UI.