### PR TITLE
FIX: export the `git cherry-pick` completion

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -141,7 +141,7 @@ export extern "git switch" [
 ]
 
 # Apply the change introduced by an existing commit
-extern "git cherry-pick" [
+export extern "git cherry-pick" [
   commit?: string@"nu-complete git commits"     # The commit ID to be cherry-picked
   --edit(-e)                                    # Edit the commit message prior to committing
   --no-commit(-n)                               # Apply changes without making any commit


### PR DESCRIPTION
Related to #355.

it appears the `git cherry-pick` completions does not work when the `export` keyword is not used with `extern`.

this PR simply adds `export` to `extern "git cherry-pick"` in `custom-completions/git/git-completions.nu` :yum: 

hope you like it :relieved: 