### PR TITLE
Fix git checkout/switch completions

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -6,7 +6,7 @@ def "nu-complete git switchable branches" [] {
    let remotes_regex = (["(", ((nu-complete git remotes | each {|r| ['remotes/', $r, '/'] | str join}) | str join "|"), ")"] | str join)
    ^git branch -a
    | lines
-   | parse -r (['^[\* ]+', $remotes_regex, '?(?P<branch>\w+)'] | flatten | str join)
+   | parse -r (['^[\* ]+', $remotes_regex, '?(?P<branch>\S+)'] | flatten | str join)
    | get branch
    | uniq
    | where {|branch| $branch != "HEAD"}


### PR DESCRIPTION
The git completions for switch/checkout contained a bug where characters would be removed due to invalid regex. This commit fixes that and the completions contain all characters of a branch name.