### PR TITLE
Fix extra print

### DIFF
--- a/prompt/oh-my-minimal.nu
+++ b/prompt/oh-my-minimal.nu
@@ -34,6 +34,7 @@ def home_abbrev [os] {
 export def path_abbrev_if_needed [apath term_width] {
     # probably shouldn't do coloring here but since we're coloring
     # only certain parts, it's kind of tricky to do it in another place
+    # if needed, use `ansi strip` to remove coloring
     let T = (ansi { fg: "#BCBCBC" bg: "#3465A4"}) # truncated
     let P = (ansi { fg: "#E4E4E4" bg: "#3465A4"}) # path
     let PB = (ansi { fg: "#E4E4E4" bg: "#3465A4" attr: b}) # path bold

--- a/prompt/oh-my-minimal.nu
+++ b/prompt/oh-my-minimal.nu
@@ -31,7 +31,7 @@ def home_abbrev [os] {
     }
 }
 
-def path_abbrev_if_needed [apath term_width] {
+export def path_abbrev_if_needed [apath term_width] {
     # probably shouldn't do coloring here but since we're coloring
     # only certain parts, it's kind of tricky to do it in another place
     let T = (ansi { fg: "#BCBCBC" bg: "#3465A4"}) # truncated
@@ -48,7 +48,7 @@ def path_abbrev_if_needed [apath term_width] {
         let splits_len = ($splits | length)
         let subtractor = (if ($splits_len <= 2) { 1 } else { 2 })
         # get all the tokens except the last
-        let tokens = (for x in 1..($splits_len - $subtractor) {
+        let tokens = (1..($splits_len - $subtractor) | each {|x|
             $"($T)(($splits | get $x | split chars) | get 0)($R)"
         })
 
@@ -66,7 +66,7 @@ def path_abbrev_if_needed [apath term_width] {
         # FIXME: This is close but it fails with folder with space. I'm not sure why.
         # let splits = ($apath | split row '/')
         # let splits_len = ($splits | length)
-        # let tokens = (for x in 0..($splits_len - 1) {
+        # let tokens = (0..($splits_len - 1) | each {|x|
         #     if ($x < ($splits_len - 1)) {
         #         $"/($T)(($splits | get $x | split chars).0)($R)"
         #     }
@@ -91,7 +91,7 @@ def path_abbrev_if_needed [apath term_width] {
         } else {
             let top_part = ($splits | first ($splits_len - 1))
             let end_part = ($splits | last)
-            let tokens = (for x in $top_part {
+            let tokens = ($top_part | each {|x|
                 $"/($T)(($x | split chars).0)($R)"
             })
             let tokens = ($tokens | append $"/($PB)($end_part)($R)")


### PR DESCRIPTION
- using closures and `each` to fix the issue where using `for` caused printing first characters of each folder in the path, instead of collecting them as part of the abbrev string
- exporting the useful path abbreviation function as I found it quite useful as a standalone function