### PR TITLE
FIX: the math functions can not be `use`d

### DIFF
--- a/maths/math_functions.nu
+++ b/maths/math_functions.nu
@@ -152,7 +152,8 @@ def scale-minmax-table [a, b,input?] {
 	let n_cols = ($x | transpose | length)
 	let name_cols = ($x | transpose | column2 0)
 
-	for $i in 0..($n_cols - 1) {
+	0..($n_cols - 1)
+	| each {|i|
 		($x | column2 $i) | scale-minmax $a $b | wrap ($name_cols | get $i)
 	} | reduce {|it, acc| $acc | merge {$it}}
 }

--- a/maths/math_functions.nu
+++ b/maths/math_functions.nu
@@ -34,11 +34,6 @@ def fact [num: int] {
 	}
 }
 
-### Added by kira
-## constants
-let pi = 3.1415926535897932
-let e  = 2.7182818284590452
-
 #Calculate roots of the quadratic function: ax^2+bx+x
 def q_roots [
 	a 	# x^2


### PR DESCRIPTION
before that commit, one could get two errors when `use`ing the script
```bash
> use maths/math_functions.nu
Error: nu::parser::expected_keyword (link)

  × Expected keyword.
    ╭─[maths/math_functions.nu:38:1]
 38 │ ## constants
 39 │ let pi = 3.1415926535897932
    · ─┬─
    ·  ╰── expected def or export keyword
 40 │ let e  = 2.7182818284590452
    ╰────
```
and
```bash
> use maths/math_functions.nu
Error: nu::parser::unexpected_keyword (link)

  × Statement used in pipeline.
     ╭─[maths/math_functions.nu:154:1]
 154 │
 155 │     for $i in 0..($n_cols - 1) {
     ·     ─┬─
     ·      ╰── not allowed in pipeline
 156 │         ($x | column2 $i) | scale-minmax $a $b | wrap ($name_cols | get $i)
     ╰────
  help: 'for' keyword is not allowed in
        pipeline. Use 'for' by itself,
        outside of a pipeline.
```



this PR fixes them by
- removing the `pi` and `e` definitions with `let`
- changing the problematic `for` to an `each`