### PR TITLE
FEATURE: export all the math functions to use them in `nushell`

### DIFF
--- a/maths/math_functions.nu
+++ b/maths/math_functions.nu
@@ -162,21 +162,6 @@ export def scale-minmax-table [a, b,input?] {
 	} | reduce {|it, acc| $acc | merge {$it}}
 }
 
-#sin function
-export def "math sin" [ ] {
-    each {|x| "s(" + $"($x)" + ")\n" | bc -l | into decimal }
-}
-
-#cos function
-export def "math cos" [ ] {
-    each {|x| "c(" + $"($x)" + ")\n" | bc -l | into decimal }
-}
-
-#natural log function
-export def "math ln" [ ] {
-    each {|x| "l(" + $"($x)" + ")\n" | bc -l | into decimal }
-}
-
 #exp function
 export def "math exp" [ ] {
     each {|x| "e(" + $"($x)" + ")\n" | bc -l | into decimal }

--- a/maths/math_functions.nu
+++ b/maths/math_functions.nu
@@ -1,20 +1,20 @@
 #Root with a custom denominator
-def root [ denominator, num ] {
+export def root [ denominator, num ] {
 	$num ** ( 1 / $denominator ) | math round  -p 10
 }
 
 #Cube root
-def croot [num] {
+export def croot [num] {
 	$num ** ( 1 / 3 ) | math round -p 10
 }
 
 #Root with a custom scaler and denominator
-def aroot [ scaler, denominator, num] {
+export def aroot [ scaler, denominator, num] {
 	$num ** ($scaler / $denominator) | math round -p 10
 }
 
 #calculate delta of the quadratic function
-def delta [ a,#x^2 factor
+export def delta [ a,#x^2 factor
 b, #x factor
 c #the rest
 ] {
@@ -22,7 +22,7 @@ c #the rest
 }
 
 #Factorial of the given number
-def fact [num: int] {
+export def fact [num: int] {
 	if $num >= 0 {
 		if $num < 2 {
 			$num
@@ -40,7 +40,7 @@ let pi = 3.1415926535897932
 let e  = 2.7182818284590452
 
 #Calculate roots of the quadratic function: ax^2+bx+x
-def q_roots [
+export def q_roots [
 	a 	# x^2
 	b	# x
 	c 	# independent term
@@ -69,7 +69,7 @@ def q_roots [
 }
 
 #Check if integer is prime
-def isprime [n: int] {
+export def isprime [n: int] {
 	let max = ($n | math sqrt | math ceil)
 
 	let flag = ([[isPrime];[true]] | update isPrime {if ($n mod 2) == 0 { false } else { seq 3 1 $max | each { |it| if ($n mod $it) == 0 { false }}}})
@@ -78,7 +78,7 @@ def isprime [n: int] {
 }
 
 #Prime list <= n
-def primelist [n: int] {
+export def primelist [n: int] {
 	let primes = [2 3]
 
 	let primes2 = (seq 5 2 $n | each {|it| if (isprime $it) == 'prime' {$it}})
@@ -87,17 +87,17 @@ def primelist [n: int] {
 }
 
 #Multiplication table of n till max
-def mtable [n: int, max: int] {
+export def mtable [n: int, max: int] {
 	seq 1 $max | each {|it| echo $"($it)*($n) = ($n * $it)"}
 }
 
 #Check if year is leap
-def isleap [year: int] {
+export def isleap [year: int] {
 	if ( (($year mod 4) == 0 and ($year mod 100) != 0) or ($year mod 400) == 0 ) { echo "It is a leap year." } else { echo "It is not a leap year."}
 }
 
 #Greatest common divisior (gcd) between 2 integers
-def gcd [a: int, b:int] {
+export def gcd [a: int, b:int] {
 	if $a < $b {
 		gcd $b $a
 	} else if $b == 0 {
@@ -108,7 +108,7 @@ def gcd [a: int, b:int] {
 }
 
 #Least common multiple (lcm) between 2 integers
-def lcm [a: int, b:int] {
+export def lcm [a: int, b:int] {
 	if $a == $b and $b == 0 {
 		0
 	} else {
@@ -117,7 +117,7 @@ def lcm [a: int, b:int] {
 }
 
 #Decimal number to custom base representation
-def dec2base [
+export def dec2base [
 	n: string	#decimal number
 	b: string	#base in [2,16]
 ] {
@@ -142,7 +142,7 @@ def dec2base [
 }
 
 # Scale list to [a,b] interval
-def scale-minmax [a, b,input?] {
+export def scale-minmax [a, b,input?] {
 	let x = if ($input | is-empty) {$in} else {$input}
 
 	let min = ($x | math min)
@@ -152,7 +152,7 @@ def scale-minmax [a, b,input?] {
 }
 
 # Scale every column of a table (separately) to [a,b] interval
-def scale-minmax-table [a, b,input?] {
+export def scale-minmax-table [a, b,input?] {
 	let x = if ($input | is-empty) {$in} else {$input}
 	let n_cols = ($x | transpose | length)
 	let name_cols = ($x | transpose | column2 0)
@@ -163,21 +163,21 @@ def scale-minmax-table [a, b,input?] {
 }
 
 #sin function
-def "math sin" [ ] {
+export def "math sin" [ ] {
     each {|x| "s(" + $"($x)" + ")\n" | bc -l | into decimal }
 }
 
 #cos function
-def "math cos" [ ] {
+export def "math cos" [ ] {
     each {|x| "c(" + $"($x)" + ")\n" | bc -l | into decimal }
 }
 
 #natural log function
-def "math ln" [ ] {
+export def "math ln" [ ] {
     each {|x| "l(" + $"($x)" + ")\n" | bc -l | into decimal }
 }
 
 #exp function
-def "math exp" [ ] {
+export def "math exp" [ ] {
     each {|x| "e(" + $"($x)" + ")\n" | bc -l | into decimal }
 }

--- a/maths/math_functions.nu
+++ b/maths/math_functions.nu
@@ -164,5 +164,5 @@ export def scale-minmax-table [a, b,input?] {
 
 #exp function
 export def "math exp" [ ] {
-    each {|x| "e(" + $"($x)" + ")\n" | bc -l | into decimal }
+    each {|x| (math e) ** $x }
 }


### PR DESCRIPTION
hello there :wave: :wink: 

this PR adds an `export` to all the `def`s inside `maths/math_functions.nu`, otherwise, they can not be used once `use`d` or `overlay use`ed :thinking: 

with this PR, which is a simple `sd "^def" "export def" maths/math_functions.nu` or `:%s/^def/export def` inside `vim`, the functions can be used with either
```bash
use maths/math_functions.nu *
```
or
```bash
overlay use maths/math_functions.nu
```

cheers :yum: 