### PR TITLE
job.nu: update view source usage

### DIFF
--- a/background_task/job.nu
+++ b/background_task/job.nu
@@ -10,7 +10,7 @@ export def spawn [
 ] {
     let config_path = $nu.config-path
     let env_path = $nu.env-path
-    let source_code = (view-source $command | str trim -l -c '{' | str trim -r -c '}')
+    let source_code = (view source $command | str trim -l -c '{' | str trim -r -c '}')
     let job_id = (pueue add -p $"nu --config \"($config_path)\" --env-config \"($env_path)\" -c '($source_code)'")
     {"job_id": $job_id}
 }


### PR DESCRIPTION
Cheers,

minor thing: `view-source` is now `view source` in 0.76. This broke the job.nu which is am using.
