### PR TITLE
FIX `kubernetes.nu` since str lpad and str rpad are deprecated in 0.76

### DIFF
--- a/kubernetes/kubernetes.nu
+++ b/kubernetes/kubernetes.nu
@@ -95,8 +95,8 @@ def "nu-complete kube ctx" [] {
 
     let data = (cat $cache | from json)
     $data.completion | each {|x|
-        let ns = ($x.ns | str rpad -l $data.max.ns -c ' ')
-        let cl = ($x.cluster | str lpad -l $data.max.cluster -c ' ')
+        let ns = ($x.ns | fill -a r -w $data.max.ns -c ' ')
+        let cl = ($x.cluster | fill -a l -w $data.max.cluster -c ' ')
         {value: $x.value, description: $"\t($ns) ($cl)"}
     }
 }


### PR DESCRIPTION
`str rpad` and `str lpad` are deprecated in [0.76](https://www.nushell.sh/blog/2023-02-21-nushell_0_76.html)