### PR TITLE
Make commands optional

### DIFF
--- a/custom-completions/npm/npm-completions.nu
+++ b/custom-completions/npm/npm-completions.nu
@@ -1,5 +1,5 @@
 export extern "npm" [
-  command: string@"nu-complete npm"
+  command?: string@"nu-complete npm"
 ]
 def "nu-complete npm" [] {
   ^npm -l
@@ -18,7 +18,7 @@ def "nu-complete npm run" [] {
 }
 
 export extern "npm run" [
-  command: string@"nu-complete npm run"
+  command?: string@"nu-complete npm run"
   --workspace(-w)
   --include-workspace-root
   --if-present


### PR DESCRIPTION
Origin: https://github.com/nushell/nushell/issues/6020#issuecomment-1455140004

Fixes valid command to able to be executed, namely `npm` and `npm run`.