### PR TITLE
`conda.nu` : changed `insert` to `merge`

### DIFF
--- a/virtual_environments/conda.nu
+++ b/virtual_environments/conda.nu
@@ -53,13 +53,14 @@ export def-env activate [
             {|| $'($virtual_prompt)' }
         }
 
-        $new_env
-        | insert CONDA_OLD_PROMPT_COMMAND $old_prompt_command
-        | insert PROMPT_COMMAND $new_prompt
+        $new_env | merge {
+            CONDA_OLD_PROMPT_COMMAND: $old_prompt_command
+            PROMPT_COMMAND: $new_prompt
+        }
     } else {
-        $new_env
-        | insert CONDA_OLD_PROMPT_COMMAND $nothing
+        $new_env | merge { CONDA_OLD_PROMPT_COMMAND: $nothing }
     }
+
 
     load-env $new_env
 }


### PR DESCRIPTION
For people that have dynamic prompts (showing the current directory for example), activating a Conda environment would freeze their prompt: the prompt closure would be called once when activating the environment and the resulting string would be set as the new shell prompt. This happened because `insert` can be called with a closure, and if it is, it will execute it and insert the **output value of the closure** in the table, not the closure itself. `merge` doesn't have that side effect.