### PR TITLE
FIX: define a `main` function to `use` the themes modules

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -11,7 +11,7 @@ ls ./themes/themes
 
 To use the `dracula` theme for instance, please run
 ```rust
-use ./themes/themes/dracula.nu *
+use ./themes/themes/dracula.nu
 let-env config = ($env.config | merge {color_config: (dracula)})
 ```
 

--- a/themes/template.nu
+++ b/themes/template.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/3024-day.nu
+++ b/themes/themes/3024-day.nu
@@ -1,4 +1,4 @@
-export def 3024_day [] {
+export def main [] {
     # extra desired values for the 3024_day theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/3024-night.nu
+++ b/themes/themes/3024-night.nu
@@ -1,4 +1,4 @@
-export def 3024_night [] {
+export def main [] {
     # extra desired values for the 3024_night theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/3024.nu
+++ b/themes/themes/3024.nu
@@ -1,4 +1,4 @@
-export def 3024 [] {
+export def main [] {
     # extra desired values for the 3024 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/abyss.nu
+++ b/themes/themes/abyss.nu
@@ -1,4 +1,4 @@
-export def abyss [] {
+export def main [] {
     # extra desired values for the abyss theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/aci.nu
+++ b/themes/themes/aci.nu
@@ -1,4 +1,4 @@
-export def aci [] {
+export def main [] {
     # extra desired values for the aci theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/aco.nu
+++ b/themes/themes/aco.nu
@@ -1,4 +1,4 @@
-export def aco [] {
+export def main [] {
     # extra desired values for the aco theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/adventuretime.nu
+++ b/themes/themes/adventuretime.nu
@@ -1,4 +1,4 @@
-export def adventuretime [] {
+export def main [] {
     # extra desired values for the adventuretime theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/afterglow.nu
+++ b/themes/themes/afterglow.nu
@@ -1,4 +1,4 @@
-export def afterglow [] {
+export def main [] {
     # extra desired values for the afterglow theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/alien-blood.nu
+++ b/themes/themes/alien-blood.nu
@@ -1,4 +1,4 @@
-export def alien_blood [] {
+export def main [] {
     # extra desired values for the alien_blood theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/alucard.nu
+++ b/themes/themes/alucard.nu
@@ -1,4 +1,4 @@
-export def alucard [] {
+export def main [] {
     # extra desired values for the alucard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/amora.nu
+++ b/themes/themes/amora.nu
@@ -1,4 +1,4 @@
-export def amora [] {
+export def main [] {
     # extra desired values for the amora theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/apathy.nu
+++ b/themes/themes/apathy.nu
@@ -1,4 +1,4 @@
-export def apathy [] {
+export def main [] {
     # extra desired values for the apathy theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/apprentice.nu
+++ b/themes/themes/apprentice.nu
@@ -1,4 +1,4 @@
-export def apprentice [] {
+export def main [] {
     # extra desired values for the apprentice theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/argonaut.nu
+++ b/themes/themes/argonaut.nu
@@ -1,4 +1,4 @@
-export def argonaut [] {
+export def main [] {
     # extra desired values for the argonaut theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/arthur.nu
+++ b/themes/themes/arthur.nu
@@ -1,4 +1,4 @@
-export def arthur [] {
+export def main [] {
     # extra desired values for the arthur theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ashes.nu
+++ b/themes/themes/ashes.nu
@@ -1,4 +1,4 @@
-export def ashes [] {
+export def main [] {
     # extra desired values for the ashes theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-cave-light.nu
+++ b/themes/themes/atelier-cave-light.nu
@@ -1,4 +1,4 @@
-export def atelier_cave-light [] {
+export def main [] {
     # extra desired values for the atelier_cave-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-cave.nu
+++ b/themes/themes/atelier-cave.nu
@@ -1,4 +1,4 @@
-export def atelier_cave [] {
+export def main [] {
     # extra desired values for the atelier_cave theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-dune-light.nu
+++ b/themes/themes/atelier-dune-light.nu
@@ -1,4 +1,4 @@
-export def atelier_dune-light [] {
+export def main [] {
     # extra desired values for the atelier_dune-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-dune.nu
+++ b/themes/themes/atelier-dune.nu
@@ -1,4 +1,4 @@
-export def atelier_dune [] {
+export def main [] {
     # extra desired values for the atelier_dune theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-estuary-light.nu
+++ b/themes/themes/atelier-estuary-light.nu
@@ -1,4 +1,4 @@
-export def atelier_estuary-light [] {
+export def main [] {
     # extra desired values for the atelier_estuary-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-estuary.nu
+++ b/themes/themes/atelier-estuary.nu
@@ -1,4 +1,4 @@
-export def atelier_estuary [] {
+export def main [] {
     # extra desired values for the atelier_estuary theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-forest-light.nu
+++ b/themes/themes/atelier-forest-light.nu
@@ -1,4 +1,4 @@
-export def atelier_forest-light [] {
+export def main [] {
     # extra desired values for the atelier_forest-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-forest.nu
+++ b/themes/themes/atelier-forest.nu
@@ -1,4 +1,4 @@
-export def atelier_forest [] {
+export def main [] {
     # extra desired values for the atelier_forest theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-heath-light.nu
+++ b/themes/themes/atelier-heath-light.nu
@@ -1,4 +1,4 @@
-export def atelier_heath-light [] {
+export def main [] {
     # extra desired values for the atelier_heath-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-heath.nu
+++ b/themes/themes/atelier-heath.nu
@@ -1,4 +1,4 @@
-export def atelier_heath [] {
+export def main [] {
     # extra desired values for the atelier_heath theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-lakeside-light.nu
+++ b/themes/themes/atelier-lakeside-light.nu
@@ -1,4 +1,4 @@
-export def atelier_lakeside-light [] {
+export def main [] {
     # extra desired values for the atelier_lakeside-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-lakeside.nu
+++ b/themes/themes/atelier-lakeside.nu
@@ -1,4 +1,4 @@
-export def atelier_lakeside [] {
+export def main [] {
     # extra desired values for the atelier_lakeside theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-plateau-light.nu
+++ b/themes/themes/atelier-plateau-light.nu
@@ -1,4 +1,4 @@
-export def atelier_plateau-light [] {
+export def main [] {
     # extra desired values for the atelier_plateau-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-plateau.nu
+++ b/themes/themes/atelier-plateau.nu
@@ -1,4 +1,4 @@
-export def atelier_plateau [] {
+export def main [] {
     # extra desired values for the atelier_plateau theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-savanna-light.nu
+++ b/themes/themes/atelier-savanna-light.nu
@@ -1,4 +1,4 @@
-export def atelier_savanna-light [] {
+export def main [] {
     # extra desired values for the atelier_savanna-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-savanna.nu
+++ b/themes/themes/atelier-savanna.nu
@@ -1,4 +1,4 @@
-export def atelier_savanna [] {
+export def main [] {
     # extra desired values for the atelier_savanna theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-seaside-light.nu
+++ b/themes/themes/atelier-seaside-light.nu
@@ -1,4 +1,4 @@
-export def atelier_seaside-light [] {
+export def main [] {
     # extra desired values for the atelier_seaside-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-seaside.nu
+++ b/themes/themes/atelier-seaside.nu
@@ -1,4 +1,4 @@
-export def atelier_seaside [] {
+export def main [] {
     # extra desired values for the atelier_seaside theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-sulphurpool-light.nu
+++ b/themes/themes/atelier-sulphurpool-light.nu
@@ -1,4 +1,4 @@
-export def atelier_sulphurpool-light [] {
+export def main [] {
     # extra desired values for the atelier_sulphurpool-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atelier-sulphurpool.nu
+++ b/themes/themes/atelier-sulphurpool.nu
@@ -1,4 +1,4 @@
-export def atelier_sulphurpool [] {
+export def main [] {
     # extra desired values for the atelier_sulphurpool theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atlas.nu
+++ b/themes/themes/atlas.nu
@@ -1,4 +1,4 @@
-export def atlas [] {
+export def main [] {
     # extra desired values for the atlas theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atom-one-light.nu
+++ b/themes/themes/atom-one-light.nu
@@ -1,4 +1,4 @@
-export def atom_one-light [] {
+export def main [] {
     # extra desired values for the atom_one-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/atom.nu
+++ b/themes/themes/atom.nu
@@ -1,4 +1,4 @@
-export def atom [] {
+export def main [] {
     # extra desired values for the atom theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ayu-light.nu
+++ b/themes/themes/ayu-light.nu
@@ -1,4 +1,4 @@
-export def ayu_light [] {
+export def main [] {
     # extra desired values for the ayu_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ayu-mirage-simple-cursor.nu
+++ b/themes/themes/ayu-mirage-simple-cursor.nu
@@ -1,4 +1,4 @@
-export def ayu_mirage-simple-cursor [] {
+export def main [] {
     # extra desired values for the ayu_mirage-simple-cursor theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ayu-mirage.nu
+++ b/themes/themes/ayu-mirage.nu
@@ -1,4 +1,4 @@
-export def ayu_mirage [] {
+export def main [] {
     # extra desired values for the ayu_mirage theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ayu.nu
+++ b/themes/themes/ayu.nu
@@ -1,4 +1,4 @@
-export def ayu [] {
+export def main [] {
     # extra desired values for the ayu theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/azu.nu
+++ b/themes/themes/azu.nu
@@ -1,4 +1,4 @@
-export def azu [] {
+export def main [] {
     # extra desired values for the azu theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/batman.nu
+++ b/themes/themes/batman.nu
@@ -1,4 +1,4 @@
-export def batman [] {
+export def main [] {
     # extra desired values for the batman theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/belafonte-day.nu
+++ b/themes/themes/belafonte-day.nu
@@ -1,4 +1,4 @@
-export def belafonte_day [] {
+export def main [] {
     # extra desired values for the belafonte_day theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/belafonte-night.nu
+++ b/themes/themes/belafonte-night.nu
@@ -1,4 +1,4 @@
-export def belafonte_night [] {
+export def main [] {
     # extra desired values for the belafonte_night theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/bespin.nu
+++ b/themes/themes/bespin.nu
@@ -1,4 +1,4 @@
-export def bespin [] {
+export def main [] {
     # extra desired values for the bespin theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/bim.nu
+++ b/themes/themes/bim.nu
@@ -1,4 +1,4 @@
-export def bim [] {
+export def main [] {
     # extra desired values for the bim theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/birds-of-paradise.nu
+++ b/themes/themes/birds-of-paradise.nu
@@ -1,4 +1,4 @@
-export def birds_of-paradise [] {
+export def main [] {
     # extra desired values for the birds_of-paradise theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-bathory.nu
+++ b/themes/themes/black-metal-bathory.nu
@@ -1,4 +1,4 @@
-export def black_metal-bathory [] {
+export def main [] {
     # extra desired values for the black_metal-bathory theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-burzum.nu
+++ b/themes/themes/black-metal-burzum.nu
@@ -1,4 +1,4 @@
-export def black_metal-burzum [] {
+export def main [] {
     # extra desired values for the black_metal-burzum theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-dark-funeral.nu
+++ b/themes/themes/black-metal-dark-funeral.nu
@@ -1,4 +1,4 @@
-export def black_metal-dark-funeral [] {
+export def main [] {
     # extra desired values for the black_metal-dark-funeral theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-gorgoroth.nu
+++ b/themes/themes/black-metal-gorgoroth.nu
@@ -1,4 +1,4 @@
-export def black_metal-gorgoroth [] {
+export def main [] {
     # extra desired values for the black_metal-gorgoroth theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-immortal.nu
+++ b/themes/themes/black-metal-immortal.nu
@@ -1,4 +1,4 @@
-export def black_metal-immortal [] {
+export def main [] {
     # extra desired values for the black_metal-immortal theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-khold.nu
+++ b/themes/themes/black-metal-khold.nu
@@ -1,4 +1,4 @@
-export def black_metal-khold [] {
+export def main [] {
     # extra desired values for the black_metal-khold theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-marduk.nu
+++ b/themes/themes/black-metal-marduk.nu
@@ -1,4 +1,4 @@
-export def black_metal-marduk [] {
+export def main [] {
     # extra desired values for the black_metal-marduk theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-mayhem.nu
+++ b/themes/themes/black-metal-mayhem.nu
@@ -1,4 +1,4 @@
-export def black_metal-mayhem [] {
+export def main [] {
     # extra desired values for the black_metal-mayhem theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-nile.nu
+++ b/themes/themes/black-metal-nile.nu
@@ -1,4 +1,4 @@
-export def black_metal-nile [] {
+export def main [] {
     # extra desired values for the black_metal-nile theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal-venom.nu
+++ b/themes/themes/black-metal-venom.nu
@@ -1,4 +1,4 @@
-export def black_metal-venom [] {
+export def main [] {
     # extra desired values for the black_metal-venom theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/black-metal.nu
+++ b/themes/themes/black-metal.nu
@@ -1,4 +1,4 @@
-export def black_metal [] {
+export def main [] {
     # extra desired values for the black_metal theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/blazer.nu
+++ b/themes/themes/blazer.nu
@@ -1,4 +1,4 @@
-export def blazer [] {
+export def main [] {
     # extra desired values for the blazer theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/borland.nu
+++ b/themes/themes/borland.nu
@@ -1,4 +1,4 @@
-export def borland [] {
+export def main [] {
     # extra desired values for the borland theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/brewer.nu
+++ b/themes/themes/brewer.nu
@@ -1,4 +1,4 @@
-export def brewer [] {
+export def main [] {
     # extra desired values for the brewer theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/bright-lights.nu
+++ b/themes/themes/bright-lights.nu
@@ -1,4 +1,4 @@
-export def bright_lights [] {
+export def main [] {
     # extra desired values for the bright_lights theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/bright.nu
+++ b/themes/themes/bright.nu
@@ -1,4 +1,4 @@
-export def bright [] {
+export def main [] {
     # extra desired values for the bright theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/broadcast.nu
+++ b/themes/themes/broadcast.nu
@@ -1,4 +1,4 @@
-export def broadcast [] {
+export def main [] {
     # extra desired values for the broadcast theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/brogrammer.nu
+++ b/themes/themes/brogrammer.nu
@@ -1,4 +1,4 @@
-export def brogrammer [] {
+export def main [] {
     # extra desired values for the brogrammer theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/brushtrees-dark.nu
+++ b/themes/themes/brushtrees-dark.nu
@@ -1,4 +1,4 @@
-export def brushtrees_dark [] {
+export def main [] {
     # extra desired values for the brushtrees_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/brushtrees.nu
+++ b/themes/themes/brushtrees.nu
@@ -1,4 +1,4 @@
-export def brushtrees [] {
+export def main [] {
     # extra desired values for the brushtrees theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/c64.nu
+++ b/themes/themes/c64.nu
@@ -1,4 +1,4 @@
-export def c64 [] {
+export def main [] {
     # extra desired values for the c64 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/cai.nu
+++ b/themes/themes/cai.nu
@@ -1,4 +1,4 @@
-export def cai [] {
+export def main [] {
     # extra desired values for the cai theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/chalk.nu
+++ b/themes/themes/chalk.nu
@@ -1,4 +1,4 @@
-export def chalk [] {
+export def main [] {
     # extra desired values for the chalk theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/chalkboard.nu
+++ b/themes/themes/chalkboard.nu
@@ -1,4 +1,4 @@
-export def chalkboard [] {
+export def main [] {
     # extra desired values for the chalkboard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/challenger-deep.nu
+++ b/themes/themes/challenger-deep.nu
@@ -1,4 +1,4 @@
-export def challenger_deep [] {
+export def main [] {
     # extra desired values for the challenger_deep theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ciapre.nu
+++ b/themes/themes/ciapre.nu
@@ -1,4 +1,4 @@
-export def ciapre [] {
+export def main [] {
     # extra desired values for the ciapre theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/circus.nu
+++ b/themes/themes/circus.nu
@@ -1,4 +1,4 @@
-export def circus [] {
+export def main [] {
     # extra desired values for the circus theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/classic-dark.nu
+++ b/themes/themes/classic-dark.nu
@@ -1,4 +1,4 @@
-export def classic_dark [] {
+export def main [] {
     # extra desired values for the classic_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/classic-light.nu
+++ b/themes/themes/classic-light.nu
@@ -1,4 +1,4 @@
-export def classic_light [] {
+export def main [] {
     # extra desired values for the classic_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/clone-of-ubuntu.nu
+++ b/themes/themes/clone-of-ubuntu.nu
@@ -1,4 +1,4 @@
-export def clone_of-ubuntu [] {
+export def main [] {
     # extra desired values for the clone_of-ubuntu theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/clrs.nu
+++ b/themes/themes/clrs.nu
@@ -1,4 +1,4 @@
-export def clrs [] {
+export def main [] {
     # extra desired values for the clrs theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/cobalt-neon.nu
+++ b/themes/themes/cobalt-neon.nu
@@ -1,4 +1,4 @@
-export def cobalt_neon [] {
+export def main [] {
     # extra desired values for the cobalt_neon theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/cobalt2.nu
+++ b/themes/themes/cobalt2.nu
@@ -1,4 +1,4 @@
-export def cobalt2 [] {
+export def main [] {
     # extra desired values for the cobalt2 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/codeschool.nu
+++ b/themes/themes/codeschool.nu
@@ -1,4 +1,4 @@
-export def codeschool [] {
+export def main [] {
     # extra desired values for the codeschool theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/corvine.nu
+++ b/themes/themes/corvine.nu
@@ -1,4 +1,4 @@
-export def corvine [] {
+export def main [] {
     # extra desired values for the corvine theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/crayon-pony-fish.nu
+++ b/themes/themes/crayon-pony-fish.nu
@@ -1,4 +1,4 @@
-export def crayon_pony-fish [] {
+export def main [] {
     # extra desired values for the crayon_pony-fish theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/cupcake.nu
+++ b/themes/themes/cupcake.nu
@@ -1,4 +1,4 @@
-export def cupcake [] {
+export def main [] {
     # extra desired values for the cupcake theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/cupertino.nu
+++ b/themes/themes/cupertino.nu
@@ -1,4 +1,4 @@
-export def cupertino [] {
+export def main [] {
     # extra desired values for the cupertino theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/danqing.nu
+++ b/themes/themes/danqing.nu
@@ -1,4 +1,4 @@
-export def danqing [] {
+export def main [] {
     # extra desired values for the danqing theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/darcula.nu
+++ b/themes/themes/darcula.nu
@@ -1,4 +1,4 @@
-export def darcula [] {
+export def main [] {
     # extra desired values for the darcula theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/dark-pastel.nu
+++ b/themes/themes/dark-pastel.nu
@@ -1,4 +1,4 @@
-export def dark_pastel [] {
+export def main [] {
     # extra desired values for the dark_pastel theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/darkmoss.nu
+++ b/themes/themes/darkmoss.nu
@@ -1,4 +1,4 @@
-export def darkmoss [] {
+export def main [] {
     # extra desired values for the darkmoss theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/darkside.nu
+++ b/themes/themes/darkside.nu
@@ -1,4 +1,4 @@
-export def darkside [] {
+export def main [] {
     # extra desired values for the darkside theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/darktooth.nu
+++ b/themes/themes/darktooth.nu
@@ -1,4 +1,4 @@
-export def darktooth [] {
+export def main [] {
     # extra desired values for the darktooth theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/darkviolet.nu
+++ b/themes/themes/darkviolet.nu
@@ -1,4 +1,4 @@
-export def darkviolet [] {
+export def main [] {
     # extra desired values for the darkviolet theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/decaf.nu
+++ b/themes/themes/decaf.nu
@@ -1,4 +1,4 @@
-export def decaf [] {
+export def main [] {
     # extra desired values for the decaf theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/default-dark.nu
+++ b/themes/themes/default-dark.nu
@@ -1,4 +1,4 @@
-export def default_dark [] {
+export def main [] {
     # extra desired values for the default_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/default-light.nu
+++ b/themes/themes/default-light.nu
@@ -1,4 +1,4 @@
-export def default_light [] {
+export def main [] {
     # extra desired values for the default_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/desert-night.nu
+++ b/themes/themes/desert-night.nu
@@ -1,4 +1,4 @@
-export def desert_night [] {
+export def main [] {
     # extra desired values for the desert_night theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/desert.nu
+++ b/themes/themes/desert.nu
@@ -1,4 +1,4 @@
-export def desert [] {
+export def main [] {
     # extra desired values for the desert theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/dimmed-monokai.nu
+++ b/themes/themes/dimmed-monokai.nu
@@ -1,4 +1,4 @@
-export def dimmed_monokai [] {
+export def main [] {
     # extra desired values for the dimmed_monokai theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/dirtysea.nu
+++ b/themes/themes/dirtysea.nu
@@ -1,4 +1,4 @@
-export def dirtysea [] {
+export def main [] {
     # extra desired values for the dirtysea theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/dot-gov.nu
+++ b/themes/themes/dot-gov.nu
@@ -1,4 +1,4 @@
-export def dot_gov [] {
+export def main [] {
     # extra desired values for the dot_gov theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/dracula.nu
+++ b/themes/themes/dracula.nu
@@ -1,4 +1,4 @@
-export def dracula [] {
+export def main [] {
     # extra desired values for the dracula theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/dumbledore.nu
+++ b/themes/themes/dumbledore.nu
@@ -1,4 +1,4 @@
-export def dumbledore [] {
+export def main [] {
     # extra desired values for the dumbledore theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/duotone-dark.nu
+++ b/themes/themes/duotone-dark.nu
@@ -1,4 +1,4 @@
-export def duotone_dark [] {
+export def main [] {
     # extra desired values for the duotone_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/e-n-c-o-m.nu
+++ b/themes/themes/e-n-c-o-m.nu
@@ -1,4 +1,4 @@
-export def e_n-c-o-m [] {
+export def main [] {
     # extra desired values for the e_n-c-o-m theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/earthsong.nu
+++ b/themes/themes/earthsong.nu
@@ -1,4 +1,4 @@
-export def earthsong [] {
+export def main [] {
     # extra desired values for the earthsong theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/edge-dark.nu
+++ b/themes/themes/edge-dark.nu
@@ -1,4 +1,4 @@
-export def edge_dark [] {
+export def main [] {
     # extra desired values for the edge_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/edge-light.nu
+++ b/themes/themes/edge-light.nu
@@ -1,4 +1,4 @@
-export def edge_light [] {
+export def main [] {
     # extra desired values for the edge_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/eighties.nu
+++ b/themes/themes/eighties.nu
@@ -1,4 +1,4 @@
-export def eighties [] {
+export def main [] {
     # extra desired values for the eighties theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/elemental.nu
+++ b/themes/themes/elemental.nu
@@ -1,4 +1,4 @@
-export def elemental [] {
+export def main [] {
     # extra desired values for the elemental theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/elementary.nu
+++ b/themes/themes/elementary.nu
@@ -1,4 +1,4 @@
-export def elementary [] {
+export def main [] {
     # extra desired values for the elementary theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/elic.nu
+++ b/themes/themes/elic.nu
@@ -1,4 +1,4 @@
-export def elic [] {
+export def main [] {
     # extra desired values for the elic theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/elio.nu
+++ b/themes/themes/elio.nu
@@ -1,4 +1,4 @@
-export def elio [] {
+export def main [] {
     # extra desired values for the elio theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/embark.nu
+++ b/themes/themes/embark.nu
@@ -1,4 +1,4 @@
-export def embark [] {
+export def main [] {
     # extra desired values for the embark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/embers.nu
+++ b/themes/themes/embers.nu
@@ -1,4 +1,4 @@
-export def embers [] {
+export def main [] {
     # extra desired values for the embers theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/equilibrium-dark.nu
+++ b/themes/themes/equilibrium-dark.nu
@@ -1,4 +1,4 @@
-export def equilibrium_dark [] {
+export def main [] {
     # extra desired values for the equilibrium_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/equilibrium-gray-dark.nu
+++ b/themes/themes/equilibrium-gray-dark.nu
@@ -1,4 +1,4 @@
-export def equilibrium_gray-dark [] {
+export def main [] {
     # extra desired values for the equilibrium_gray-dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/equilibrium-gray-light.nu
+++ b/themes/themes/equilibrium-gray-light.nu
@@ -1,4 +1,4 @@
-export def equilibrium_gray-light [] {
+export def main [] {
     # extra desired values for the equilibrium_gray-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/equilibrium-light.nu
+++ b/themes/themes/equilibrium-light.nu
@@ -1,4 +1,4 @@
-export def equilibrium_light [] {
+export def main [] {
     # extra desired values for the equilibrium_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/espresso-libre.nu
+++ b/themes/themes/espresso-libre.nu
@@ -1,4 +1,4 @@
-export def espresso_libre [] {
+export def main [] {
     # extra desired values for the espresso_libre theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/espresso.nu
+++ b/themes/themes/espresso.nu
@@ -1,4 +1,4 @@
-export def espresso [] {
+export def main [] {
     # extra desired values for the espresso theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/eva-dim.nu
+++ b/themes/themes/eva-dim.nu
@@ -1,4 +1,4 @@
-export def eva_dim [] {
+export def main [] {
     # extra desired values for the eva_dim theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/eva.nu
+++ b/themes/themes/eva.nu
@@ -1,4 +1,4 @@
-export def eva [] {
+export def main [] {
     # extra desired values for the eva theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/everforest-light.nu
+++ b/themes/themes/everforest-light.nu
@@ -1,4 +1,4 @@
-export def everforest_light [] {
+export def main [] {
     # extra desired values for the everforest_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/everforest.nu
+++ b/themes/themes/everforest.nu
@@ -1,4 +1,4 @@
-export def everforest [] {
+export def main [] {
     # extra desired values for the everforest theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/falcon.nu
+++ b/themes/themes/falcon.nu
@@ -1,4 +1,4 @@
-export def falcon [] {
+export def main [] {
     # extra desired values for the falcon theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/farin.nu
+++ b/themes/themes/farin.nu
@@ -1,4 +1,4 @@
-export def farin [] {
+export def main [] {
     # extra desired values for the farin theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ffive.nu
+++ b/themes/themes/ffive.nu
@@ -1,4 +1,4 @@
-export def ffive [] {
+export def main [] {
     # extra desired values for the ffive theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/fideloper.nu
+++ b/themes/themes/fideloper.nu
@@ -1,4 +1,4 @@
-export def fideloper [] {
+export def main [] {
     # extra desired values for the fideloper theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/fishtank.nu
+++ b/themes/themes/fishtank.nu
@@ -1,4 +1,4 @@
-export def fishtank [] {
+export def main [] {
     # extra desired values for the fishtank theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/flat.nu
+++ b/themes/themes/flat.nu
@@ -1,4 +1,4 @@
-export def flat [] {
+export def main [] {
     # extra desired values for the flat theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/flatland.nu
+++ b/themes/themes/flatland.nu
@@ -1,4 +1,4 @@
-export def flatland [] {
+export def main [] {
     # extra desired values for the flatland theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/floraverse.nu
+++ b/themes/themes/floraverse.nu
@@ -1,4 +1,4 @@
-export def floraverse [] {
+export def main [] {
     # extra desired values for the floraverse theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/forest-night.nu
+++ b/themes/themes/forest-night.nu
@@ -1,4 +1,4 @@
-export def forest_night [] {
+export def main [] {
     # extra desired values for the forest_night theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/foxnightly.nu
+++ b/themes/themes/foxnightly.nu
@@ -1,4 +1,4 @@
-export def foxnightly [] {
+export def main [] {
     # extra desired values for the foxnightly theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/framer.nu
+++ b/themes/themes/framer.nu
@@ -1,4 +1,4 @@
-export def framer [] {
+export def main [] {
     # extra desired values for the framer theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/freya.nu
+++ b/themes/themes/freya.nu
@@ -1,4 +1,4 @@
-export def freya [] {
+export def main [] {
     # extra desired values for the freya theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/frontend-delight.nu
+++ b/themes/themes/frontend-delight.nu
@@ -1,4 +1,4 @@
-export def frontend_delight [] {
+export def main [] {
     # extra desired values for the frontend_delight theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/frontend-fun-forrest.nu
+++ b/themes/themes/frontend-fun-forrest.nu
@@ -1,4 +1,4 @@
-export def frontend_fun-forrest [] {
+export def main [] {
     # extra desired values for the frontend_fun-forrest theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/frontend-galaxy.nu
+++ b/themes/themes/frontend-galaxy.nu
@@ -1,4 +1,4 @@
-export def frontend_galaxy [] {
+export def main [] {
     # extra desired values for the frontend_galaxy theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/fruit-soda.nu
+++ b/themes/themes/fruit-soda.nu
@@ -1,4 +1,4 @@
-export def fruit_soda [] {
+export def main [] {
     # extra desired values for the fruit_soda theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gigavolt.nu
+++ b/themes/themes/gigavolt.nu
@@ -1,4 +1,4 @@
-export def gigavolt [] {
+export def main [] {
     # extra desired values for the gigavolt theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/github-dark-colorblind.nu
+++ b/themes/themes/github-dark-colorblind.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/github-dark-default.nu
+++ b/themes/themes/github-dark-default.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/github-dark.nu
+++ b/themes/themes/github-dark.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/github-dimmed.nu
+++ b/themes/themes/github-dimmed.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/github-light-colorblind.nu
+++ b/themes/themes/github-light-colorblind.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/github-light-default.nu
+++ b/themes/themes/github-light-default.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/github-light.nu
+++ b/themes/themes/github-light.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/github.nu
+++ b/themes/themes/github.nu
@@ -1,4 +1,4 @@
-export def github [] {
+export def main [] {
     # extra desired values for the github theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/glacier.nu
+++ b/themes/themes/glacier.nu
@@ -1,4 +1,4 @@
-export def glacier [] {
+export def main [] {
     # extra desired values for the glacier theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/goa-base.nu
+++ b/themes/themes/goa-base.nu
@@ -1,4 +1,4 @@
-export def goa_base [] {
+export def main [] {
     # extra desired values for the goa_base theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gooey.nu
+++ b/themes/themes/gooey.nu
@@ -1,4 +1,4 @@
-export def gooey [] {
+export def main [] {
     # extra desired values for the gooey theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/google-dark.nu
+++ b/themes/themes/google-dark.nu
@@ -1,4 +1,4 @@
-export def google_dark [] {
+export def main [] {
     # extra desired values for the google_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/google-light.nu
+++ b/themes/themes/google-light.nu
@@ -1,4 +1,4 @@
-export def google_light [] {
+export def main [] {
     # extra desired values for the google_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/grape.nu
+++ b/themes/themes/grape.nu
@@ -1,4 +1,4 @@
-export def grape [] {
+export def main [] {
     # extra desired values for the grape theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/grass.nu
+++ b/themes/themes/grass.nu
@@ -1,4 +1,4 @@
-export def grass [] {
+export def main [] {
     # extra desired values for the grass theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/grayscale-dark.nu
+++ b/themes/themes/grayscale-dark.nu
@@ -1,4 +1,4 @@
-export def grayscale_dark [] {
+export def main [] {
     # extra desired values for the grayscale_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/grayscale-light.nu
+++ b/themes/themes/grayscale-light.nu
@@ -1,4 +1,4 @@
-export def grayscale_light [] {
+export def main [] {
     # extra desired values for the grayscale_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/green-screen.nu
+++ b/themes/themes/green-screen.nu
@@ -1,4 +1,4 @@
-export def green_screen [] {
+export def main [] {
     # extra desired values for the green_screen theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/greenscreen.nu
+++ b/themes/themes/greenscreen.nu
@@ -1,4 +1,4 @@
-export def greenscreen [] {
+export def main [] {
     # extra desired values for the greenscreen theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbit.nu
+++ b/themes/themes/gruvbit.nu
@@ -1,4 +1,4 @@
-export def gruvbit [] {
+export def main [] {
     # extra desired values for the gruvbit theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-dark-hard.nu
+++ b/themes/themes/gruvbox-dark-hard.nu
@@ -1,4 +1,4 @@
-export def gruvbox_dark-hard [] {
+export def main [] {
     # extra desired values for the gruvbox_dark-hard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-dark-medium.nu
+++ b/themes/themes/gruvbox-dark-medium.nu
@@ -1,4 +1,4 @@
-export def gruvbox_dark-medium [] {
+export def main [] {
     # extra desired values for the gruvbox_dark-medium theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-dark-pale.nu
+++ b/themes/themes/gruvbox-dark-pale.nu
@@ -1,4 +1,4 @@
-export def gruvbox_dark-pale [] {
+export def main [] {
     # extra desired values for the gruvbox_dark-pale theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-dark-soft.nu
+++ b/themes/themes/gruvbox-dark-soft.nu
@@ -1,4 +1,4 @@
-export def gruvbox_dark-soft [] {
+export def main [] {
     # extra desired values for the gruvbox_dark-soft theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-dark.nu
+++ b/themes/themes/gruvbox-dark.nu
@@ -1,4 +1,4 @@
-export def gruvbox_dark [] {
+export def main [] {
     # extra desired values for the gruvbox_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-light-hard.nu
+++ b/themes/themes/gruvbox-light-hard.nu
@@ -1,4 +1,4 @@
-export def gruvbox_light-hard [] {
+export def main [] {
     # extra desired values for the gruvbox_light-hard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-light-medium.nu
+++ b/themes/themes/gruvbox-light-medium.nu
@@ -1,4 +1,4 @@
-export def gruvbox_light-medium [] {
+export def main [] {
     # extra desired values for the gruvbox_light-medium theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-light-soft.nu
+++ b/themes/themes/gruvbox-light-soft.nu
@@ -1,4 +1,4 @@
-export def gruvbox_light-soft [] {
+export def main [] {
     # extra desired values for the gruvbox_light-soft theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-material-dark-hard.nu
+++ b/themes/themes/gruvbox-material-dark-hard.nu
@@ -1,4 +1,4 @@
-export def gruvbox_material-dark-hard [] {
+export def main [] {
     # extra desired values for the gruvbox_material-dark-hard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-material-dark-medium.nu
+++ b/themes/themes/gruvbox-material-dark-medium.nu
@@ -1,4 +1,4 @@
-export def gruvbox_material-dark-medium [] {
+export def main [] {
     # extra desired values for the gruvbox_material-dark-medium theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-material-dark-soft.nu
+++ b/themes/themes/gruvbox-material-dark-soft.nu
@@ -1,4 +1,4 @@
-export def gruvbox_material-dark-soft [] {
+export def main [] {
     # extra desired values for the gruvbox_material-dark-soft theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-material-light-hard.nu
+++ b/themes/themes/gruvbox-material-light-hard.nu
@@ -1,4 +1,4 @@
-export def gruvbox_material-light-hard [] {
+export def main [] {
     # extra desired values for the gruvbox_material-light-hard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-material-light-medium.nu
+++ b/themes/themes/gruvbox-material-light-medium.nu
@@ -1,4 +1,4 @@
-export def gruvbox_material-light-medium [] {
+export def main [] {
     # extra desired values for the gruvbox_material-light-medium theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-material-light-soft.nu
+++ b/themes/themes/gruvbox-material-light-soft.nu
@@ -1,4 +1,4 @@
-export def gruvbox_material-light-soft [] {
+export def main [] {
     # extra desired values for the gruvbox_material-light-soft theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-mix-dark-hard.nu
+++ b/themes/themes/gruvbox-mix-dark-hard.nu
@@ -1,4 +1,4 @@
-export def gruvbox_mix-dark-hard [] {
+export def main [] {
     # extra desired values for the gruvbox_mix-dark-hard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-mix-dark-medium.nu
+++ b/themes/themes/gruvbox-mix-dark-medium.nu
@@ -1,4 +1,4 @@
-export def gruvbox_mix-dark-medium [] {
+export def main [] {
     # extra desired values for the gruvbox_mix-dark-medium theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-mix-dark-soft.nu
+++ b/themes/themes/gruvbox-mix-dark-soft.nu
@@ -1,4 +1,4 @@
-export def gruvbox_mix-dark-soft [] {
+export def main [] {
     # extra desired values for the gruvbox_mix-dark-soft theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-mix-light-hard.nu
+++ b/themes/themes/gruvbox-mix-light-hard.nu
@@ -1,4 +1,4 @@
-export def gruvbox_mix-light-hard [] {
+export def main [] {
     # extra desired values for the gruvbox_mix-light-hard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-mix-light-medium.nu
+++ b/themes/themes/gruvbox-mix-light-medium.nu
@@ -1,4 +1,4 @@
-export def gruvbox_mix-light-medium [] {
+export def main [] {
     # extra desired values for the gruvbox_mix-light-medium theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-mix-light-soft.nu
+++ b/themes/themes/gruvbox-mix-light-soft.nu
@@ -1,4 +1,4 @@
-export def gruvbox_mix-light-soft [] {
+export def main [] {
     # extra desired values for the gruvbox_mix-light-soft theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-original-dark-hard.nu
+++ b/themes/themes/gruvbox-original-dark-hard.nu
@@ -1,4 +1,4 @@
-export def gruvbox_original-dark-hard [] {
+export def main [] {
     # extra desired values for the gruvbox_original-dark-hard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-original-dark-medium.nu
+++ b/themes/themes/gruvbox-original-dark-medium.nu
@@ -1,4 +1,4 @@
-export def gruvbox_original-dark-medium [] {
+export def main [] {
     # extra desired values for the gruvbox_original-dark-medium theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-original-dark-soft.nu
+++ b/themes/themes/gruvbox-original-dark-soft.nu
@@ -1,4 +1,4 @@
-export def gruvbox_original-dark-soft [] {
+export def main [] {
     # extra desired values for the gruvbox_original-dark-soft theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-original-light-hard.nu
+++ b/themes/themes/gruvbox-original-light-hard.nu
@@ -1,4 +1,4 @@
-export def gruvbox_original-light-hard [] {
+export def main [] {
     # extra desired values for the gruvbox_original-light-hard theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-original-light-medium.nu
+++ b/themes/themes/gruvbox-original-light-medium.nu
@@ -1,4 +1,4 @@
-export def gruvbox_original-light-medium [] {
+export def main [] {
     # extra desired values for the gruvbox_original-light-medium theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox-original-light-soft.nu
+++ b/themes/themes/gruvbox-original-light-soft.nu
@@ -1,4 +1,4 @@
-export def gruvbox_original-light-soft [] {
+export def main [] {
     # extra desired values for the gruvbox_original-light-soft theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/gruvbox.nu
+++ b/themes/themes/gruvbox.nu
@@ -1,4 +1,4 @@
-export def gruvbox [] {
+export def main [] {
     # extra desired values for the gruvbox theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/hardcore.nu
+++ b/themes/themes/hardcore.nu
@@ -1,4 +1,4 @@
-export def hardcore [] {
+export def main [] {
     # extra desired values for the hardcore theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/harmonic-dark.nu
+++ b/themes/themes/harmonic-dark.nu
@@ -1,4 +1,4 @@
-export def harmonic_dark [] {
+export def main [] {
     # extra desired values for the harmonic_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/harmonic-light.nu
+++ b/themes/themes/harmonic-light.nu
@@ -1,4 +1,4 @@
-export def harmonic_light [] {
+export def main [] {
     # extra desired values for the harmonic_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/harmonic16-dark.nu
+++ b/themes/themes/harmonic16-dark.nu
@@ -1,4 +1,4 @@
-export def harmonic16_dark [] {
+export def main [] {
     # extra desired values for the harmonic16_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/harmonic16-light.nu
+++ b/themes/themes/harmonic16-light.nu
@@ -1,4 +1,4 @@
-export def harmonic16_light [] {
+export def main [] {
     # extra desired values for the harmonic16_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/harper.nu
+++ b/themes/themes/harper.nu
@@ -1,4 +1,4 @@
-export def harper [] {
+export def main [] {
     # extra desired values for the harper theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/heetch-light.nu
+++ b/themes/themes/heetch-light.nu
@@ -1,4 +1,4 @@
-export def heetch_light [] {
+export def main [] {
     # extra desired values for the heetch_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/heetch.nu
+++ b/themes/themes/heetch.nu
@@ -1,4 +1,4 @@
-export def heetch [] {
+export def main [] {
     # extra desired values for the heetch theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/helios.nu
+++ b/themes/themes/helios.nu
@@ -1,4 +1,4 @@
-export def helios [] {
+export def main [] {
     # extra desired values for the helios theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/hemisu-dark.nu
+++ b/themes/themes/hemisu-dark.nu
@@ -1,4 +1,4 @@
-export def hemisu_dark [] {
+export def main [] {
     # extra desired values for the hemisu_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/hemisu-light.nu
+++ b/themes/themes/hemisu-light.nu
@@ -1,4 +1,4 @@
-export def hemisu_light [] {
+export def main [] {
     # extra desired values for the hemisu_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/highway.nu
+++ b/themes/themes/highway.nu
@@ -1,4 +1,4 @@
-export def highway [] {
+export def main [] {
     # extra desired values for the highway theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/hipster-green.nu
+++ b/themes/themes/hipster-green.nu
@@ -1,4 +1,4 @@
-export def hipster_green [] {
+export def main [] {
     # extra desired values for the hipster_green theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/homebrew.nu
+++ b/themes/themes/homebrew.nu
@@ -1,4 +1,4 @@
-export def homebrew [] {
+export def main [] {
     # extra desired values for the homebrew theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/hopscotch.nu
+++ b/themes/themes/hopscotch.nu
@@ -1,4 +1,4 @@
-export def hopscotch [] {
+export def main [] {
     # extra desired values for the hopscotch theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/horizon-dark.nu
+++ b/themes/themes/horizon-dark.nu
@@ -1,4 +1,4 @@
-export def horizon_dark [] {
+export def main [] {
     # extra desired values for the horizon_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/horizon-light.nu
+++ b/themes/themes/horizon-light.nu
@@ -1,4 +1,4 @@
-export def horizon_light [] {
+export def main [] {
     # extra desired values for the horizon_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/horizon-terminal-dark.nu
+++ b/themes/themes/horizon-terminal-dark.nu
@@ -1,4 +1,4 @@
-export def horizon_terminal-dark [] {
+export def main [] {
     # extra desired values for the horizon_terminal-dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/horizon-terminal-light.nu
+++ b/themes/themes/horizon-terminal-light.nu
@@ -1,4 +1,4 @@
-export def horizon_terminal-light [] {
+export def main [] {
     # extra desired values for the horizon_terminal-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/humanoid-dark.nu
+++ b/themes/themes/humanoid-dark.nu
@@ -1,4 +1,4 @@
-export def humanoid_dark [] {
+export def main [] {
     # extra desired values for the humanoid_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/humanoid-light.nu
+++ b/themes/themes/humanoid-light.nu
@@ -1,4 +1,4 @@
-export def humanoid_light [] {
+export def main [] {
     # extra desired values for the humanoid_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/hurtado.nu
+++ b/themes/themes/hurtado.nu
@@ -1,4 +1,4 @@
-export def hurtado [] {
+export def main [] {
     # extra desired values for the hurtado theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/hybrid.nu
+++ b/themes/themes/hybrid.nu
@@ -1,4 +1,4 @@
-export def hybrid [] {
+export def main [] {
     # extra desired values for the hybrid theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ia-dark.nu
+++ b/themes/themes/ia-dark.nu
@@ -1,4 +1,4 @@
-export def ia_dark [] {
+export def main [] {
     # extra desired values for the ia_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ia-light.nu
+++ b/themes/themes/ia-light.nu
@@ -1,4 +1,4 @@
-export def ia_light [] {
+export def main [] {
     # extra desired values for the ia_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ibm3270.nu
+++ b/themes/themes/ibm3270.nu
@@ -1,4 +1,4 @@
-export def ibm3270 [] {
+export def main [] {
     # extra desired values for the ibm3270 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ic-green-ppl.nu
+++ b/themes/themes/ic-green-ppl.nu
@@ -1,4 +1,4 @@
-export def ic_green-ppl [] {
+export def main [] {
     # extra desired values for the ic_green-ppl theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ic-orange-ppl.nu
+++ b/themes/themes/ic-orange-ppl.nu
@@ -1,4 +1,4 @@
-export def ic_orange-ppl [] {
+export def main [] {
     # extra desired values for the ic_orange-ppl theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/iceberg-light.nu
+++ b/themes/themes/iceberg-light.nu
@@ -1,4 +1,4 @@
-export def iceberg_light [] {
+export def main [] {
     # extra desired values for the iceberg_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/icy.nu
+++ b/themes/themes/icy.nu
@@ -1,4 +1,4 @@
-export def icy [] {
+export def main [] {
     # extra desired values for the icy theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/idle-toes.nu
+++ b/themes/themes/idle-toes.nu
@@ -1,4 +1,4 @@
-export def idle_toes [] {
+export def main [] {
     # extra desired values for the idle_toes theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/idm_3b.nu
+++ b/themes/themes/idm_3b.nu
@@ -1,4 +1,4 @@
-export def idm_3b [] {
+export def main [] {
     # extra desired values for the idm_3b theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ir-black.nu
+++ b/themes/themes/ir-black.nu
@@ -1,4 +1,4 @@
-export def ir_black [] {
+export def main [] {
     # extra desired values for the ir_black theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/irblack.nu
+++ b/themes/themes/irblack.nu
@@ -1,4 +1,4 @@
-export def irblack [] {
+export def main [] {
     # extra desired values for the irblack theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/isotope.nu
+++ b/themes/themes/isotope.nu
@@ -1,4 +1,4 @@
-export def isotope [] {
+export def main [] {
     # extra desired values for the isotope theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/jackie-brown.nu
+++ b/themes/themes/jackie-brown.nu
@@ -1,4 +1,4 @@
-export def jackie_brown [] {
+export def main [] {
     # extra desired values for the jackie_brown theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/japanesque.nu
+++ b/themes/themes/japanesque.nu
@@ -1,4 +1,4 @@
-export def japanesque [] {
+export def main [] {
     # extra desired values for the japanesque theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/jellybeans.nu
+++ b/themes/themes/jellybeans.nu
@@ -1,4 +1,4 @@
-export def jellybeans [] {
+export def main [] {
     # extra desired values for the jellybeans theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/jet-brains-darcula.nu
+++ b/themes/themes/jet-brains-darcula.nu
@@ -1,4 +1,4 @@
-export def jet_brains-darcula [] {
+export def main [] {
     # extra desired values for the jet_brains-darcula theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/jup.nu
+++ b/themes/themes/jup.nu
@@ -1,4 +1,4 @@
-export def jup [] {
+export def main [] {
     # extra desired values for the jup theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/kibble.nu
+++ b/themes/themes/kibble.nu
@@ -1,4 +1,4 @@
-export def kibble [] {
+export def main [] {
     # extra desired values for the kibble theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/kimber.nu
+++ b/themes/themes/kimber.nu
@@ -1,4 +1,4 @@
-export def kimber [] {
+export def main [] {
     # extra desired values for the kimber theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/later-this-evening.nu
+++ b/themes/themes/later-this-evening.nu
@@ -1,4 +1,4 @@
-export def later_this-evening [] {
+export def main [] {
     # extra desired values for the later_this-evening theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/lavandula.nu
+++ b/themes/themes/lavandula.nu
@@ -1,4 +1,4 @@
-export def lavandula [] {
+export def main [] {
     # extra desired values for the lavandula theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/liquid-carbon-transparent.nu
+++ b/themes/themes/liquid-carbon-transparent.nu
@@ -1,4 +1,4 @@
-export def liquid_carbon-transparent [] {
+export def main [] {
     # extra desired values for the liquid_carbon-transparent theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/liquid-carbon.nu
+++ b/themes/themes/liquid-carbon.nu
@@ -1,4 +1,4 @@
-export def liquid_carbon [] {
+export def main [] {
     # extra desired values for the liquid_carbon theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/london-tube.nu
+++ b/themes/themes/london-tube.nu
@@ -1,4 +1,4 @@
-export def london_tube [] {
+export def main [] {
     # extra desired values for the london_tube theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/macintosh.nu
+++ b/themes/themes/macintosh.nu
@@ -1,4 +1,4 @@
-export def macintosh [] {
+export def main [] {
     # extra desired values for the macintosh theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/maia.nu
+++ b/themes/themes/maia.nu
@@ -1,4 +1,4 @@
-export def maia [] {
+export def main [] {
     # extra desired values for the maia theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/man-page.nu
+++ b/themes/themes/man-page.nu
@@ -1,4 +1,4 @@
-export def man_page [] {
+export def main [] {
     # extra desired values for the man_page theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mar.nu
+++ b/themes/themes/mar.nu
@@ -1,4 +1,4 @@
-export def mar [] {
+export def main [] {
     # extra desired values for the mar theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/marrakesh.nu
+++ b/themes/themes/marrakesh.nu
@@ -1,4 +1,4 @@
-export def marrakesh [] {
+export def main [] {
     # extra desired values for the marrakesh theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/materia.nu
+++ b/themes/themes/materia.nu
@@ -1,4 +1,4 @@
-export def materia [] {
+export def main [] {
     # extra desired values for the materia theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/material-dark.nu
+++ b/themes/themes/material-dark.nu
@@ -1,4 +1,4 @@
-export def material_dark [] {
+export def main [] {
     # extra desired values for the material_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/material-darker.nu
+++ b/themes/themes/material-darker.nu
@@ -1,4 +1,4 @@
-export def material_darker [] {
+export def main [] {
     # extra desired values for the material_darker theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/material-lighter.nu
+++ b/themes/themes/material-lighter.nu
@@ -1,4 +1,4 @@
-export def material_lighter [] {
+export def main [] {
     # extra desired values for the material_lighter theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/material-palenight.nu
+++ b/themes/themes/material-palenight.nu
@@ -1,4 +1,4 @@
-export def material_palenight [] {
+export def main [] {
     # extra desired values for the material_palenight theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/material-vivid.nu
+++ b/themes/themes/material-vivid.nu
@@ -1,4 +1,4 @@
-export def material_vivid [] {
+export def main [] {
     # extra desired values for the material_vivid theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/material.nu
+++ b/themes/themes/material.nu
@@ -1,4 +1,4 @@
-export def material [] {
+export def main [] {
     # extra desired values for the material theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mathias.nu
+++ b/themes/themes/mathias.nu
@@ -1,4 +1,4 @@
-export def mathias [] {
+export def main [] {
     # extra desired values for the mathias theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/medallion.nu
+++ b/themes/themes/medallion.nu
@@ -1,4 +1,4 @@
-export def medallion [] {
+export def main [] {
     # extra desired values for the medallion theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mellow-purple.nu
+++ b/themes/themes/mellow-purple.nu
@@ -1,4 +1,4 @@
-export def mellow_purple [] {
+export def main [] {
     # extra desired values for the mellow_purple theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mexico-light.nu
+++ b/themes/themes/mexico-light.nu
@@ -1,4 +1,4 @@
-export def mexico_light [] {
+export def main [] {
     # extra desired values for the mexico_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/miramare.nu
+++ b/themes/themes/miramare.nu
@@ -1,4 +1,4 @@
-export def miramare [] {
+export def main [] {
     # extra desired values for the miramare theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/misterioso.nu
+++ b/themes/themes/misterioso.nu
@@ -1,4 +1,4 @@
-export def misterioso [] {
+export def main [] {
     # extra desired values for the misterioso theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/miu.nu
+++ b/themes/themes/miu.nu
@@ -1,4 +1,4 @@
-export def miu [] {
+export def main [] {
     # extra desired values for the miu theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mocha.nu
+++ b/themes/themes/mocha.nu
@@ -1,4 +1,4 @@
-export def mocha [] {
+export def main [] {
     # extra desired values for the mocha theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/molokai.nu
+++ b/themes/themes/molokai.nu
@@ -1,4 +1,4 @@
-export def molokai [] {
+export def main [] {
     # extra desired values for the molokai theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mona-lisa.nu
+++ b/themes/themes/mona-lisa.nu
@@ -1,4 +1,4 @@
-export def mona_lisa [] {
+export def main [] {
     # extra desired values for the mona_lisa theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mono-amber.nu
+++ b/themes/themes/mono-amber.nu
@@ -1,4 +1,4 @@
-export def mono_amber [] {
+export def main [] {
     # extra desired values for the mono_amber theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mono-cyan.nu
+++ b/themes/themes/mono-cyan.nu
@@ -1,4 +1,4 @@
-export def mono_cyan [] {
+export def main [] {
     # extra desired values for the mono_cyan theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mono-green.nu
+++ b/themes/themes/mono-green.nu
@@ -1,4 +1,4 @@
-export def mono_green [] {
+export def main [] {
     # extra desired values for the mono_green theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mono-red.nu
+++ b/themes/themes/mono-red.nu
@@ -1,4 +1,4 @@
-export def mono_red [] {
+export def main [] {
     # extra desired values for the mono_red theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mono-white.nu
+++ b/themes/themes/mono-white.nu
@@ -1,4 +1,4 @@
-export def mono_white [] {
+export def main [] {
     # extra desired values for the mono_white theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mono-yellow.nu
+++ b/themes/themes/mono-yellow.nu
@@ -1,4 +1,4 @@
-export def mono_yellow [] {
+export def main [] {
     # extra desired values for the mono_yellow theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/monokai-dark.nu
+++ b/themes/themes/monokai-dark.nu
@@ -1,4 +1,4 @@
-export def monokai_dark [] {
+export def main [] {
     # extra desired values for the monokai_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/monokai-soda.nu
+++ b/themes/themes/monokai-soda.nu
@@ -1,4 +1,4 @@
-export def monokai_soda [] {
+export def main [] {
     # extra desired values for the monokai_soda theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/monokai.nu
+++ b/themes/themes/monokai.nu
@@ -1,4 +1,4 @@
-export def monokai [] {
+export def main [] {
     # extra desired values for the monokai theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mountaineer-grey.nu
+++ b/themes/themes/mountaineer-grey.nu
@@ -1,4 +1,4 @@
-export def mountaineer_grey [] {
+export def main [] {
     # extra desired values for the mountaineer_grey theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/mountaineer.nu
+++ b/themes/themes/mountaineer.nu
@@ -1,4 +1,4 @@
-export def mountaineer [] {
+export def main [] {
     # extra desired values for the mountaineer theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/n0tch2k.nu
+++ b/themes/themes/n0tch2k.nu
@@ -1,4 +1,4 @@
-export def n0tch2k [] {
+export def main [] {
     # extra desired values for the n0tch2k theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nebula.nu
+++ b/themes/themes/nebula.nu
@@ -1,4 +1,4 @@
-export def nebula [] {
+export def main [] {
     # extra desired values for the nebula theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/neon-night.nu
+++ b/themes/themes/neon-night.nu
@@ -1,4 +1,4 @@
-export def neon_night [] {
+export def main [] {
     # extra desired values for the neon_night theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/neopolitan.nu
+++ b/themes/themes/neopolitan.nu
@@ -1,4 +1,4 @@
-export def neopolitan [] {
+export def main [] {
     # extra desired values for the neopolitan theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nep.nu
+++ b/themes/themes/nep.nu
@@ -1,4 +1,4 @@
-export def nep [] {
+export def main [] {
     # extra desired values for the nep theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/neutron.nu
+++ b/themes/themes/neutron.nu
@@ -1,4 +1,4 @@
-export def neutron [] {
+export def main [] {
     # extra desired values for the neutron theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nightfly.nu
+++ b/themes/themes/nightfly.nu
@@ -1,4 +1,4 @@
-export def nightfly [] {
+export def main [] {
     # extra desired values for the nightfly theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nightlion-v1.nu
+++ b/themes/themes/nightlion-v1.nu
@@ -1,4 +1,4 @@
-export def nightlion_v1 [] {
+export def main [] {
     # extra desired values for the nightlion_v1 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nightlion-v2.nu
+++ b/themes/themes/nightlion-v2.nu
@@ -1,4 +1,4 @@
-export def nightlion_v2 [] {
+export def main [] {
     # extra desired values for the nightlion_v2 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nighty.nu
+++ b/themes/themes/nighty.nu
@@ -1,4 +1,4 @@
-export def nighty [] {
+export def main [] {
     # extra desired values for the nighty theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nord-alt.nu
+++ b/themes/themes/nord-alt.nu
@@ -1,4 +1,4 @@
-export def nord_alt [] {
+export def main [] {
     # extra desired values for the nord_alt theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nord-light.nu
+++ b/themes/themes/nord-light.nu
@@ -1,4 +1,4 @@
-export def nord_light [] {
+export def main [] {
     # extra desired values for the nord_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nord.nu
+++ b/themes/themes/nord.nu
@@ -1,4 +1,4 @@
-export def nord [] {
+export def main [] {
     # extra desired values for the nord theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/nova.nu
+++ b/themes/themes/nova.nu
@@ -1,4 +1,4 @@
-export def nova [] {
+export def main [] {
     # extra desired values for the nova theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/novel.nu
+++ b/themes/themes/novel.nu
@@ -1,4 +1,4 @@
-export def novel [] {
+export def main [] {
     # extra desired values for the novel theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/obsidian.nu
+++ b/themes/themes/obsidian.nu
@@ -1,4 +1,4 @@
-export def obsidian [] {
+export def main [] {
     # extra desired values for the obsidian theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ocean-dark.nu
+++ b/themes/themes/ocean-dark.nu
@@ -1,4 +1,4 @@
-export def ocean_dark [] {
+export def main [] {
     # extra desired values for the ocean_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ocean.nu
+++ b/themes/themes/ocean.nu
@@ -1,4 +1,4 @@
-export def ocean [] {
+export def main [] {
     # extra desired values for the ocean theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/oceanic-material.nu
+++ b/themes/themes/oceanic-material.nu
@@ -1,4 +1,4 @@
-export def oceanic_material [] {
+export def main [] {
     # extra desired values for the oceanic_material theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/oceanic-next.nu
+++ b/themes/themes/oceanic-next.nu
@@ -1,4 +1,4 @@
-export def oceanic_next [] {
+export def main [] {
     # extra desired values for the oceanic_next theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/oceanicnext.nu
+++ b/themes/themes/oceanicnext.nu
@@ -1,4 +1,4 @@
-export def oceanicnext [] {
+export def main [] {
     # extra desired values for the oceanicnext theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ollie.nu
+++ b/themes/themes/ollie.nu
@@ -1,4 +1,4 @@
-export def ollie [] {
+export def main [] {
     # extra desired values for the ollie theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/one-dark.nu
+++ b/themes/themes/one-dark.nu
@@ -1,4 +1,4 @@
-export def one_dark [] {
+export def main [] {
     # extra desired values for the one_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/one-half-black.nu
+++ b/themes/themes/one-half-black.nu
@@ -1,4 +1,4 @@
-export def one_half-black [] {
+export def main [] {
     # extra desired values for the one_half-black theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/one-half-light.nu
+++ b/themes/themes/one-half-light.nu
@@ -1,4 +1,4 @@
-export def one_half-light [] {
+export def main [] {
     # extra desired values for the one_half-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/one-light.nu
+++ b/themes/themes/one-light.nu
@@ -1,4 +1,4 @@
-export def one_light [] {
+export def main [] {
     # extra desired values for the one_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/onedark.nu
+++ b/themes/themes/onedark.nu
@@ -1,4 +1,4 @@
-export def onedark [] {
+export def main [] {
     # extra desired values for the onedark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/orbital.nu
+++ b/themes/themes/orbital.nu
@@ -1,4 +1,4 @@
-export def orbital [] {
+export def main [] {
     # extra desired values for the orbital theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/outrun-dark.nu
+++ b/themes/themes/outrun-dark.nu
@@ -1,4 +1,4 @@
-export def outrun_dark [] {
+export def main [] {
     # extra desired values for the outrun_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/pali.nu
+++ b/themes/themes/pali.nu
@@ -1,4 +1,4 @@
-export def pali [] {
+export def main [] {
     # extra desired values for the pali theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/palmtree.nu
+++ b/themes/themes/palmtree.nu
@@ -1,4 +1,4 @@
-export def palmtree [] {
+export def main [] {
     # extra desired values for the palmtree theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/papercolor-dark.nu
+++ b/themes/themes/papercolor-dark.nu
@@ -1,4 +1,4 @@
-export def papercolor_dark [] {
+export def main [] {
     # extra desired values for the papercolor_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/papercolor-light.nu
+++ b/themes/themes/papercolor-light.nu
@@ -1,4 +1,4 @@
-export def papercolor_light [] {
+export def main [] {
     # extra desired values for the papercolor_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/paraiso-dark.nu
+++ b/themes/themes/paraiso-dark.nu
@@ -1,4 +1,4 @@
-export def paraiso_dark [] {
+export def main [] {
     # extra desired values for the paraiso_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/paraiso.nu
+++ b/themes/themes/paraiso.nu
@@ -1,4 +1,4 @@
-export def paraiso [] {
+export def main [] {
     # extra desired values for the paraiso theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/pasque.nu
+++ b/themes/themes/pasque.nu
@@ -1,4 +1,4 @@
-export def pasque [] {
+export def main [] {
     # extra desired values for the pasque theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/paul-millr.nu
+++ b/themes/themes/paul-millr.nu
@@ -1,4 +1,4 @@
-export def paul_millr [] {
+export def main [] {
     # extra desired values for the paul_millr theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/pencil-dark.nu
+++ b/themes/themes/pencil-dark.nu
@@ -1,4 +1,4 @@
-export def pencil_dark [] {
+export def main [] {
     # extra desired values for the pencil_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/pencil-light.nu
+++ b/themes/themes/pencil-light.nu
@@ -1,4 +1,4 @@
-export def pencil_light [] {
+export def main [] {
     # extra desired values for the pencil_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/peppermint.nu
+++ b/themes/themes/peppermint.nu
@@ -1,4 +1,4 @@
-export def peppermint [] {
+export def main [] {
     # extra desired values for the peppermint theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/phd.nu
+++ b/themes/themes/phd.nu
@@ -1,4 +1,4 @@
-export def phd [] {
+export def main [] {
     # extra desired values for the phd theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/piatto-light.nu
+++ b/themes/themes/piatto-light.nu
@@ -1,4 +1,4 @@
-export def piatto_light [] {
+export def main [] {
     # extra desired values for the piatto_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/pico.nu
+++ b/themes/themes/pico.nu
@@ -1,4 +1,4 @@
-export def pico [] {
+export def main [] {
     # extra desired values for the pico theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/pnevma.nu
+++ b/themes/themes/pnevma.nu
@@ -1,4 +1,4 @@
-export def pnevma [] {
+export def main [] {
     # extra desired values for the pnevma theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/pop.nu
+++ b/themes/themes/pop.nu
@@ -1,4 +1,4 @@
-export def pop [] {
+export def main [] {
     # extra desired values for the pop theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/porple.nu
+++ b/themes/themes/porple.nu
@@ -1,4 +1,4 @@
-export def porple [] {
+export def main [] {
     # extra desired values for the porple theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/pro.nu
+++ b/themes/themes/pro.nu
@@ -1,4 +1,4 @@
-export def pro [] {
+export def main [] {
     # extra desired values for the pro theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/railscasts.nu
+++ b/themes/themes/railscasts.nu
@@ -1,4 +1,4 @@
-export def railscasts [] {
+export def main [] {
     # extra desired values for the railscasts theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/rebecca.nu
+++ b/themes/themes/rebecca.nu
@@ -1,4 +1,4 @@
-export def rebecca [] {
+export def main [] {
     # extra desired values for the rebecca theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/red-alert.nu
+++ b/themes/themes/red-alert.nu
@@ -1,4 +1,4 @@
-export def red_alert [] {
+export def main [] {
     # extra desired values for the red_alert theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/red-sands.nu
+++ b/themes/themes/red-sands.nu
@@ -1,4 +1,4 @@
-export def red_sands [] {
+export def main [] {
     # extra desired values for the red_sands theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/relaxed-afterglow.nu
+++ b/themes/themes/relaxed-afterglow.nu
@@ -1,4 +1,4 @@
-export def relaxed_afterglow [] {
+export def main [] {
     # extra desired values for the relaxed_afterglow theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/renault-style-light.nu
+++ b/themes/themes/renault-style-light.nu
@@ -1,4 +1,4 @@
-export def renault_style-light [] {
+export def main [] {
     # extra desired values for the renault_style-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/rippedcasts.nu
+++ b/themes/themes/rippedcasts.nu
@@ -1,4 +1,4 @@
-export def rippedcasts [] {
+export def main [] {
     # extra desired values for the rippedcasts theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/rose-pine-dawn.conf.nu
+++ b/themes/themes/rose-pine-dawn.conf.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/rose-pine-dawn.nu
+++ b/themes/themes/rose-pine-dawn.nu
@@ -1,4 +1,4 @@
-export def rose_pine-dawn [] {
+export def main [] {
     # extra desired values for the rose_pine-dawn theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/rose-pine-moon.conf.nu
+++ b/themes/themes/rose-pine-moon.conf.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/rose-pine-moon.nu
+++ b/themes/themes/rose-pine-moon.nu
@@ -1,4 +1,4 @@
-export def rose_pine-moon [] {
+export def main [] {
     # extra desired values for the rose_pine-moon theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/rose-pine.conf.nu
+++ b/themes/themes/rose-pine.conf.nu
@@ -1,4 +1,4 @@
-export def {{theme}} [] {
+export def main [] {
     # extra desired values for the {{theme}} theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/rose-pine.nu
+++ b/themes/themes/rose-pine.nu
@@ -1,4 +1,4 @@
-export def rose_pine [] {
+export def main [] {
     # extra desired values for the rose_pine theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/royal.nu
+++ b/themes/themes/royal.nu
@@ -1,4 +1,4 @@
-export def royal [] {
+export def main [] {
     # extra desired values for the royal theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/sagelight.nu
+++ b/themes/themes/sagelight.nu
@@ -1,4 +1,4 @@
-export def sagelight [] {
+export def main [] {
     # extra desired values for the sagelight theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/sandcastle.nu
+++ b/themes/themes/sandcastle.nu
@@ -1,4 +1,4 @@
-export def sandcastle [] {
+export def main [] {
     # extra desired values for the sandcastle theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/sat.nu
+++ b/themes/themes/sat.nu
@@ -1,4 +1,4 @@
-export def sat [] {
+export def main [] {
     # extra desired values for the sat theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/sea-shells.nu
+++ b/themes/themes/sea-shells.nu
@@ -1,4 +1,4 @@
-export def sea_shells [] {
+export def main [] {
     # extra desired values for the sea_shells theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/seafoam-pastel.nu
+++ b/themes/themes/seafoam-pastel.nu
@@ -1,4 +1,4 @@
-export def seafoam_pastel [] {
+export def main [] {
     # extra desired values for the seafoam_pastel theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/selenized-black.nu
+++ b/themes/themes/selenized-black.nu
@@ -1,4 +1,4 @@
-export def selenized_black [] {
+export def main [] {
     # extra desired values for the selenized_black theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/selenized-dark.nu
+++ b/themes/themes/selenized-dark.nu
@@ -1,4 +1,4 @@
-export def selenized_dark [] {
+export def main [] {
     # extra desired values for the selenized_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/selenized-light.nu
+++ b/themes/themes/selenized-light.nu
@@ -1,4 +1,4 @@
-export def selenized_light [] {
+export def main [] {
     # extra desired values for the selenized_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/selenized-white.nu
+++ b/themes/themes/selenized-white.nu
@@ -1,4 +1,4 @@
-export def selenized_white [] {
+export def main [] {
     # extra desired values for the selenized_white theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/seoul256.nu
+++ b/themes/themes/seoul256.nu
@@ -1,4 +1,4 @@
-export def seoul256 [] {
+export def main [] {
     # extra desired values for the seoul256 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/seti-ui.nu
+++ b/themes/themes/seti-ui.nu
@@ -1,4 +1,4 @@
-export def seti_ui [] {
+export def main [] {
     # extra desired values for the seti_ui theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/seti.nu
+++ b/themes/themes/seti.nu
@@ -1,4 +1,4 @@
-export def seti [] {
+export def main [] {
     # extra desired values for the seti theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/shaman.nu
+++ b/themes/themes/shaman.nu
@@ -1,4 +1,4 @@
-export def shaman [] {
+export def main [] {
     # extra desired values for the shaman theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/shapeshifter.nu
+++ b/themes/themes/shapeshifter.nu
@@ -1,4 +1,4 @@
-export def shapeshifter [] {
+export def main [] {
     # extra desired values for the shapeshifter theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/shel.nu
+++ b/themes/themes/shel.nu
@@ -1,4 +1,4 @@
-export def shel [] {
+export def main [] {
     # extra desired values for the shel theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/sierra.nu
+++ b/themes/themes/sierra.nu
@@ -1,4 +1,4 @@
-export def sierra [] {
+export def main [] {
     # extra desired values for the sierra theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/silk-dark.nu
+++ b/themes/themes/silk-dark.nu
@@ -1,4 +1,4 @@
-export def silk_dark [] {
+export def main [] {
     # extra desired values for the silk_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/silk-light.nu
+++ b/themes/themes/silk-light.nu
@@ -1,4 +1,4 @@
-export def silk_light [] {
+export def main [] {
     # extra desired values for the silk_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/slate.nu
+++ b/themes/themes/slate.nu
@@ -1,4 +1,4 @@
-export def slate [] {
+export def main [] {
     # extra desired values for the slate theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/smyck.nu
+++ b/themes/themes/smyck.nu
@@ -1,4 +1,4 @@
-export def smyck [] {
+export def main [] {
     # extra desired values for the smyck theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/snazzy.nu
+++ b/themes/themes/snazzy.nu
@@ -1,4 +1,4 @@
-export def snazzy [] {
+export def main [] {
     # extra desired values for the snazzy theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/snow-dark.nu
+++ b/themes/themes/snow-dark.nu
@@ -1,4 +1,4 @@
-export def snow_dark [] {
+export def main [] {
     # extra desired values for the snow_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/snow-light.nu
+++ b/themes/themes/snow-light.nu
@@ -1,4 +1,4 @@
-export def snow_light [] {
+export def main [] {
     # extra desired values for the snow_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/soft-server.nu
+++ b/themes/themes/soft-server.nu
@@ -1,4 +1,4 @@
-export def soft_server [] {
+export def main [] {
     # extra desired values for the soft_server theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/solar-flare.nu
+++ b/themes/themes/solar-flare.nu
@@ -1,4 +1,4 @@
-export def solar_flare [] {
+export def main [] {
     # extra desired values for the solar_flare theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/solarflare-light.nu
+++ b/themes/themes/solarflare-light.nu
@@ -1,4 +1,4 @@
-export def solarflare_light [] {
+export def main [] {
     # extra desired values for the solarflare_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/solarflare.nu
+++ b/themes/themes/solarflare.nu
@@ -1,4 +1,4 @@
-export def solarflare [] {
+export def main [] {
     # extra desired values for the solarflare theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/solarized-darcula.nu
+++ b/themes/themes/solarized-darcula.nu
@@ -1,4 +1,4 @@
-export def solarized_darcula [] {
+export def main [] {
     # extra desired values for the solarized_darcula theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/solarized-dark-higher-contrast.nu
+++ b/themes/themes/solarized-dark-higher-contrast.nu
@@ -1,4 +1,4 @@
-export def solarized_dark-higher-contrast [] {
+export def main [] {
     # extra desired values for the solarized_dark-higher-contrast theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/solarized-dark.nu
+++ b/themes/themes/solarized-dark.nu
@@ -1,4 +1,4 @@
-export def solarized_dark [] {
+export def main [] {
     # extra desired values for the solarized_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/solarized-light.nu
+++ b/themes/themes/solarized-light.nu
@@ -1,4 +1,4 @@
-export def solarized_light [] {
+export def main [] {
     # extra desired values for the solarized_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/source-code-x.nu
+++ b/themes/themes/source-code-x.nu
@@ -1,4 +1,4 @@
-export def source_code-x [] {
+export def main [] {
     # extra desired values for the source_code-x theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/sourcerer.nu
+++ b/themes/themes/sourcerer.nu
@@ -1,4 +1,4 @@
-export def sourcerer [] {
+export def main [] {
     # extra desired values for the sourcerer theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/sourcerer2.nu
+++ b/themes/themes/sourcerer2.nu
@@ -1,4 +1,4 @@
-export def sourcerer2 [] {
+export def main [] {
     # extra desired values for the sourcerer2 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/spaceduck.nu
+++ b/themes/themes/spaceduck.nu
@@ -1,4 +1,4 @@
-export def spaceduck [] {
+export def main [] {
     # extra desired values for the spaceduck theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/spacedust.nu
+++ b/themes/themes/spacedust.nu
@@ -1,4 +1,4 @@
-export def spacedust [] {
+export def main [] {
     # extra desired values for the spacedust theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/spacegray-eighties-dull.nu
+++ b/themes/themes/spacegray-eighties-dull.nu
@@ -1,4 +1,4 @@
-export def spacegray_eighties-dull [] {
+export def main [] {
     # extra desired values for the spacegray_eighties-dull theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/spacegray-eighties.nu
+++ b/themes/themes/spacegray-eighties.nu
@@ -1,4 +1,4 @@
-export def spacegray_eighties [] {
+export def main [] {
     # extra desired values for the spacegray_eighties theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/spacegray.nu
+++ b/themes/themes/spacegray.nu
@@ -1,4 +1,4 @@
-export def spacegray [] {
+export def main [] {
     # extra desired values for the spacegray theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/spacemacs.nu
+++ b/themes/themes/spacemacs.nu
@@ -1,4 +1,4 @@
-export def spacemacs [] {
+export def main [] {
     # extra desired values for the spacemacs theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/spiderman.nu
+++ b/themes/themes/spiderman.nu
@@ -1,4 +1,4 @@
-export def spiderman [] {
+export def main [] {
     # extra desired values for the spiderman theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/spring.nu
+++ b/themes/themes/spring.nu
@@ -1,4 +1,4 @@
-export def spring [] {
+export def main [] {
     # extra desired values for the spring theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/square.nu
+++ b/themes/themes/square.nu
@@ -1,4 +1,4 @@
-export def square [] {
+export def main [] {
     # extra desired values for the square theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/srcery.nu
+++ b/themes/themes/srcery.nu
@@ -1,4 +1,4 @@
-export def srcery [] {
+export def main [] {
     # extra desired values for the srcery theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/substrata.nu
+++ b/themes/themes/substrata.nu
@@ -1,4 +1,4 @@
-export def substrata [] {
+export def main [] {
     # extra desired values for the substrata theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/summercamp.nu
+++ b/themes/themes/summercamp.nu
@@ -1,4 +1,4 @@
-export def summercamp [] {
+export def main [] {
     # extra desired values for the summercamp theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/summerfruit-dark.nu
+++ b/themes/themes/summerfruit-dark.nu
@@ -1,4 +1,4 @@
-export def summerfruit_dark [] {
+export def main [] {
     # extra desired values for the summerfruit_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/summerfruit-light.nu
+++ b/themes/themes/summerfruit-light.nu
@@ -1,4 +1,4 @@
-export def summerfruit_light [] {
+export def main [] {
     # extra desired values for the summerfruit_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/sundried.nu
+++ b/themes/themes/sundried.nu
@@ -1,4 +1,4 @@
-export def sundried [] {
+export def main [] {
     # extra desired values for the sundried theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/symphonic.nu
+++ b/themes/themes/symphonic.nu
@@ -1,4 +1,4 @@
-export def symphonic [] {
+export def main [] {
     # extra desired values for the symphonic theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/synth-midnight-dark.nu
+++ b/themes/themes/synth-midnight-dark.nu
@@ -1,4 +1,4 @@
-export def synth_midnight-dark [] {
+export def main [] {
     # extra desired values for the synth_midnight-dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/synth-midnight-light.nu
+++ b/themes/themes/synth-midnight-light.nu
@@ -1,4 +1,4 @@
-export def synth_midnight-light [] {
+export def main [] {
     # extra desired values for the synth_midnight-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tango-dark.nu
+++ b/themes/themes/tango-dark.nu
@@ -1,4 +1,4 @@
-export def tango_dark [] {
+export def main [] {
     # extra desired values for the tango_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tango-light.nu
+++ b/themes/themes/tango-light.nu
@@ -1,4 +1,4 @@
-export def tango_light [] {
+export def main [] {
     # extra desired values for the tango_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tango.nu
+++ b/themes/themes/tango.nu
@@ -1,4 +1,4 @@
-export def tango [] {
+export def main [] {
     # extra desired values for the tango theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/teerb.nu
+++ b/themes/themes/teerb.nu
@@ -1,4 +1,4 @@
-export def teerb [] {
+export def main [] {
     # extra desired values for the teerb theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-autumn.nu
+++ b/themes/themes/tempus-autumn.nu
@@ -1,4 +1,4 @@
-export def tempus_autumn [] {
+export def main [] {
     # extra desired values for the tempus_autumn theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-classic.nu
+++ b/themes/themes/tempus-classic.nu
@@ -1,4 +1,4 @@
-export def tempus_classic [] {
+export def main [] {
     # extra desired values for the tempus_classic theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-dawn.nu
+++ b/themes/themes/tempus-dawn.nu
@@ -1,4 +1,4 @@
-export def tempus_dawn [] {
+export def main [] {
     # extra desired values for the tempus_dawn theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-day.nu
+++ b/themes/themes/tempus-day.nu
@@ -1,4 +1,4 @@
-export def tempus_day [] {
+export def main [] {
     # extra desired values for the tempus_day theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-dusk.nu
+++ b/themes/themes/tempus-dusk.nu
@@ -1,4 +1,4 @@
-export def tempus_dusk [] {
+export def main [] {
     # extra desired values for the tempus_dusk theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-fugit.nu
+++ b/themes/themes/tempus-fugit.nu
@@ -1,4 +1,4 @@
-export def tempus_fugit [] {
+export def main [] {
     # extra desired values for the tempus_fugit theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-future.nu
+++ b/themes/themes/tempus-future.nu
@@ -1,4 +1,4 @@
-export def tempus_future [] {
+export def main [] {
     # extra desired values for the tempus_future theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-night.nu
+++ b/themes/themes/tempus-night.nu
@@ -1,4 +1,4 @@
-export def tempus_night [] {
+export def main [] {
     # extra desired values for the tempus_night theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-past.nu
+++ b/themes/themes/tempus-past.nu
@@ -1,4 +1,4 @@
-export def tempus_past [] {
+export def main [] {
     # extra desired values for the tempus_past theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-rift.nu
+++ b/themes/themes/tempus-rift.nu
@@ -1,4 +1,4 @@
-export def tempus_rift [] {
+export def main [] {
     # extra desired values for the tempus_rift theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-spring.nu
+++ b/themes/themes/tempus-spring.nu
@@ -1,4 +1,4 @@
-export def tempus_spring [] {
+export def main [] {
     # extra desired values for the tempus_spring theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-summer.nu
+++ b/themes/themes/tempus-summer.nu
@@ -1,4 +1,4 @@
-export def tempus_summer [] {
+export def main [] {
     # extra desired values for the tempus_summer theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-tempest.nu
+++ b/themes/themes/tempus-tempest.nu
@@ -1,4 +1,4 @@
-export def tempus_tempest [] {
+export def main [] {
     # extra desired values for the tempus_tempest theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-totus.nu
+++ b/themes/themes/tempus-totus.nu
@@ -1,4 +1,4 @@
-export def tempus_totus [] {
+export def main [] {
     # extra desired values for the tempus_totus theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-warp.nu
+++ b/themes/themes/tempus-warp.nu
@@ -1,4 +1,4 @@
-export def tempus_warp [] {
+export def main [] {
     # extra desired values for the tempus_warp theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tempus-winter.nu
+++ b/themes/themes/tempus-winter.nu
@@ -1,4 +1,4 @@
-export def tempus_winter [] {
+export def main [] {
     # extra desired values for the tempus_winter theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tender.nu
+++ b/themes/themes/tender.nu
@@ -1,4 +1,4 @@
-export def tender [] {
+export def main [] {
     # extra desired values for the tender theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/terminal-basic.nu
+++ b/themes/themes/terminal-basic.nu
@@ -1,4 +1,4 @@
-export def terminal_basic [] {
+export def main [] {
     # extra desired values for the terminal_basic theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/terminix-dark.nu
+++ b/themes/themes/terminix-dark.nu
@@ -1,4 +1,4 @@
-export def terminix_dark [] {
+export def main [] {
     # extra desired values for the terminix_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/thayer-bright.nu
+++ b/themes/themes/thayer-bright.nu
@@ -1,4 +1,4 @@
-export def thayer_bright [] {
+export def main [] {
     # extra desired values for the thayer_bright theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/the-hulk.nu
+++ b/themes/themes/the-hulk.nu
@@ -1,4 +1,4 @@
-export def the_hulk [] {
+export def main [] {
     # extra desired values for the the_hulk theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tin.nu
+++ b/themes/themes/tin.nu
@@ -1,4 +1,4 @@
-export def tin [] {
+export def main [] {
     # extra desired values for the tin theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tokyo-day.nu
+++ b/themes/themes/tokyo-day.nu
@@ -1,4 +1,4 @@
-export def tokyo_day [] {
+export def main [] {
     # extra desired values for the tokyo_day theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tokyo-night.nu
+++ b/themes/themes/tokyo-night.nu
@@ -1,4 +1,4 @@
-export def tokyo_night [] {
+export def main [] {
     # extra desired values for the tokyo_night theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tokyo-storm.nu
+++ b/themes/themes/tokyo-storm.nu
@@ -1,4 +1,4 @@
-export def tokyo_storm [] {
+export def main [] {
     # extra desired values for the tokyo_storm theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tomorrow-night-blue.nu
+++ b/themes/themes/tomorrow-night-blue.nu
@@ -1,4 +1,4 @@
-export def tomorrow_night-blue [] {
+export def main [] {
     # extra desired values for the tomorrow_night-blue theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tomorrow-night-bright.nu
+++ b/themes/themes/tomorrow-night-bright.nu
@@ -1,4 +1,4 @@
-export def tomorrow_night-bright [] {
+export def main [] {
     # extra desired values for the tomorrow_night-bright theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tomorrow-night-eighties.nu
+++ b/themes/themes/tomorrow-night-eighties.nu
@@ -1,4 +1,4 @@
-export def tomorrow_night-eighties [] {
+export def main [] {
     # extra desired values for the tomorrow_night-eighties theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tomorrow-night.nu
+++ b/themes/themes/tomorrow-night.nu
@@ -1,4 +1,4 @@
-export def tomorrow_night [] {
+export def main [] {
     # extra desired values for the tomorrow_night theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tomorrow.nu
+++ b/themes/themes/tomorrow.nu
@@ -1,4 +1,4 @@
-export def tomorrow [] {
+export def main [] {
     # extra desired values for the tomorrow theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/toy-chest.nu
+++ b/themes/themes/toy-chest.nu
@@ -1,4 +1,4 @@
-export def toy_chest [] {
+export def main [] {
     # extra desired values for the toy_chest theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/treehouse.nu
+++ b/themes/themes/treehouse.nu
@@ -1,4 +1,4 @@
-export def treehouse [] {
+export def main [] {
     # extra desired values for the treehouse theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/tube.nu
+++ b/themes/themes/tube.nu
@@ -1,4 +1,4 @@
-export def tube [] {
+export def main [] {
     # extra desired values for the tube theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/twilight.nu
+++ b/themes/themes/twilight.nu
@@ -1,4 +1,4 @@
-export def twilight [] {
+export def main [] {
     # extra desired values for the twilight theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/two-firewatch.nu
+++ b/themes/themes/two-firewatch.nu
@@ -1,4 +1,4 @@
-export def two_firewatch [] {
+export def main [] {
     # extra desired values for the two_firewatch theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/unikitty-dark.nu
+++ b/themes/themes/unikitty-dark.nu
@@ -1,4 +1,4 @@
-export def unikitty_dark [] {
+export def main [] {
     # extra desired values for the unikitty_dark theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/unikitty-light.nu
+++ b/themes/themes/unikitty-light.nu
@@ -1,4 +1,4 @@
-export def unikitty_light [] {
+export def main [] {
     # extra desired values for the unikitty_light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/ura.nu
+++ b/themes/themes/ura.nu
@@ -1,4 +1,4 @@
-export def ura [] {
+export def main [] {
     # extra desired values for the ura theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/urple.nu
+++ b/themes/themes/urple.nu
@@ -1,4 +1,4 @@
-export def urple [] {
+export def main [] {
     # extra desired values for the urple theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/vag.nu
+++ b/themes/themes/vag.nu
@@ -1,4 +1,4 @@
-export def vag [] {
+export def main [] {
     # extra desired values for the vag theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/vaughn.nu
+++ b/themes/themes/vaughn.nu
@@ -1,4 +1,4 @@
-export def vaughn [] {
+export def main [] {
     # extra desired values for the vaughn theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/vibrant-ink.nu
+++ b/themes/themes/vibrant-ink.nu
@@ -1,4 +1,4 @@
-export def vibrant_ink [] {
+export def main [] {
     # extra desired values for the vibrant_ink theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/vs-code-dark-plus.nu
+++ b/themes/themes/vs-code-dark-plus.nu
@@ -1,4 +1,4 @@
-export def vs_code-dark-plus [] {
+export def main [] {
     # extra desired values for the vs_code-dark-plus theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/vulcan.nu
+++ b/themes/themes/vulcan.nu
@@ -1,4 +1,4 @@
-export def vulcan [] {
+export def main [] {
     # extra desired values for the vulcan theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/warm-neon.nu
+++ b/themes/themes/warm-neon.nu
@@ -1,4 +1,4 @@
-export def warm_neon [] {
+export def main [] {
     # extra desired values for the warm_neon theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/wez.nu
+++ b/themes/themes/wez.nu
@@ -1,4 +1,4 @@
-export def wez [] {
+export def main [] {
     # extra desired values for the wez theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/wild-cherry.nu
+++ b/themes/themes/wild-cherry.nu
@@ -1,4 +1,4 @@
-export def wild_cherry [] {
+export def main [] {
     # extra desired values for the wild_cherry theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/windows-10-light.nu
+++ b/themes/themes/windows-10-light.nu
@@ -1,4 +1,4 @@
-export def windows_10-light [] {
+export def main [] {
     # extra desired values for the windows_10-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/windows-10.nu
+++ b/themes/themes/windows-10.nu
@@ -1,4 +1,4 @@
-export def windows_10 [] {
+export def main [] {
     # extra desired values for the windows_10 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/windows-95-light.nu
+++ b/themes/themes/windows-95-light.nu
@@ -1,4 +1,4 @@
-export def windows_95-light [] {
+export def main [] {
     # extra desired values for the windows_95-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/windows-95.nu
+++ b/themes/themes/windows-95.nu
@@ -1,4 +1,4 @@
-export def windows_95 [] {
+export def main [] {
     # extra desired values for the windows_95 theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/windows-highcontrast-light.nu
+++ b/themes/themes/windows-highcontrast-light.nu
@@ -1,4 +1,4 @@
-export def windows_highcontrast-light [] {
+export def main [] {
     # extra desired values for the windows_highcontrast-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/windows-highcontrast.nu
+++ b/themes/themes/windows-highcontrast.nu
@@ -1,4 +1,4 @@
-export def windows_highcontrast [] {
+export def main [] {
     # extra desired values for the windows_highcontrast theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/windows-nt-light.nu
+++ b/themes/themes/windows-nt-light.nu
@@ -1,4 +1,4 @@
-export def windows_nt-light [] {
+export def main [] {
     # extra desired values for the windows_nt-light theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/windows-nt.nu
+++ b/themes/themes/windows-nt.nu
@@ -1,4 +1,4 @@
-export def windows_nt [] {
+export def main [] {
     # extra desired values for the windows_nt theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/wombat.nu
+++ b/themes/themes/wombat.nu
@@ -1,4 +1,4 @@
-export def wombat [] {
+export def main [] {
     # extra desired values for the wombat theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/woodland.nu
+++ b/themes/themes/woodland.nu
@@ -1,4 +1,4 @@
-export def woodland [] {
+export def main [] {
     # extra desired values for the woodland theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/wryan.nu
+++ b/themes/themes/wryan.nu
@@ -1,4 +1,4 @@
-export def wryan [] {
+export def main [] {
     # extra desired values for the wryan theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/xcode-dusk.nu
+++ b/themes/themes/xcode-dusk.nu
@@ -1,4 +1,4 @@
-export def xcode_dusk [] {
+export def main [] {
     # extra desired values for the xcode_dusk theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/yachiyo.nu
+++ b/themes/themes/yachiyo.nu
@@ -1,4 +1,4 @@
-export def yachiyo [] {
+export def main [] {
     # extra desired values for the yachiyo theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal

--- a/themes/themes/zenburn.nu
+++ b/themes/themes/zenburn.nu
@@ -1,4 +1,4 @@
-export def zenburn [] {
+export def main [] {
     # extra desired values for the zenburn theme
     # which do not fit into any nushell theme
     # these colors should be handledd by the terminal


### PR DESCRIPTION
it looks like `nushell` exports of function having the same name as the module they live in has changed :open_mouth: 
for instance, we can not do the following now
```bash
>_ module spam { export def spam [] { "this is spam::spam" } }
Error: nu::parser::named_as_module

  × Can't export command named same as the module.
   ╭─[entry #109:1:1]
 1 │ module spam { export def spam [] { "this is spam::spam" } }
   ·                          ──┬─
   ·                            ╰── can't export from module spam
   ╰────
  help: Module spam can't export command named the same as the module. Either change the module name, or export `main`
        custom command.
```

this is an issue for the `themes/` directory because each module in `themes/themes/` defines a "main" function with the same name as the module itself, e.g. `export def dracula` in `themes/themes/dracula.nu`...

this PR changes this
- use `sd` to change all the modules at once and define `main` functions
- change the template in case the modules are to be generated again from scratch
- update the instructions in the `README`

cheers and good night :relieved: :sleepy: :yum: 