### PR TITLE
Revert "conda activate base if env_name not given"

### DIFF
--- a/virtual_environments/conda.nu
+++ b/virtual_environments/conda.nu
@@ -1,7 +1,7 @@
 # Activate conda environment
 export def-env activate [
-    env_name: string@'nu-complete conda envs' = "base" # name of the environment
-    --no-prompt                                        # do not update the prompt
+    env_name: string@'nu-complete conda envs' # name of the environment
+    --no-prompt                               # do not update the prompt
 ] {
     let conda_info = (conda info --envs --json | from json)
 


### PR DESCRIPTION
Reverts nushell/nu_scripts#400

Reverting because @Tiggax reported `This commit breaks the current autocomplete functionality of environments. code lines 99 - 105 became useless.`