### PR TITLE
Add `nu-cmd-lang` to `nu_release.nu`

### DIFF
--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -20,6 +20,7 @@ let subcrates_wave_1 = [
 ]
 
 let subcrates_wave_2 = [
+    nu-cmd-lang,
     nu-command,
 ]
 


### PR DESCRIPTION
We need to reflect the cratification of `nu-command`

TODO: check if other parts of the dependency tree have changed that would require a reordering.