### PR TITLE
Add `git edit` command and update `git/README.md`

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -1,3 +1,3 @@
-# Git branch cleanup
+# Commands and scripts for Git
 
-Remove any local git branch no longer being tracked in origin / remote repo.
+Take a look at the individual files to learn more.

--- a/git/git.nu
+++ b/git/git.nu
@@ -1,3 +1,8 @@
+# Collection of useful git aliases.
+#
+# Use with:
+# `use <repo_root>/git/git.nu`
+
 export def _git_stat [n]  {
     do -i {
         git log -n $n --pretty=»¦«%h --stat

--- a/git/git_branch_cleanup.nu
+++ b/git/git_branch_cleanup.nu
@@ -1,4 +1,6 @@
 #!/usr/bin/env nu
-
+#
+# Remove any local git branch no longer being tracked in origin / remote repo.
+# To be used as stand-alone script.
 
 git branch -vl | lines | split column " " BranchName Hash Status --collapse-empty | where Status == '[gone]' | each { |it| git branch -D $it.BranchName }

--- a/git/git_edit.nu
+++ b/git/git_edit.nu
@@ -1,0 +1,33 @@
+# Custom command to conveniently edit commits in the history.
+#
+# Use with:
+# `use <repo_root>/git/git_edit.nu`
+#
+# `git edit` starts an interactive rebase to edit a commit in the history, which
+# can be selected from a complection list. An example completion list may look
+# like this:
+#
+# >| git edit
+# 2024d52  upgrade to nu 0.77 (#413)
+# 10bde06  Fix since last release script (#412)
+# 18deb3d  Add `nu-cmd-lang` to `nu_release.nu` (#411)
+# e95f609  Updated conda script to default to base if no arg given (#409)
+# 34235ef  Replace deprecated `str collect` command (#410)
+# 06dd125  Revert "conda activate base if env_name not given (#400)" (#408)
+# ...
+
+# Helper command to get commit of this branch only list to edit
+def "nu-complete git commits" [] {
+  ^git log --pretty="%h %s" | lines | parse "{value} {description}"
+}
+
+# Edit a commit by selecting it as only commit to edit in an interactive rebase
+# run non-interactively.
+export def "git edit" [
+    commit: string@"nu-complete git commits"
+] {
+    # We use `sed` to replace `pick` with `edit`.
+    # `0,/pick/` restricts the sustitution to the range from the beginning until
+    # the first occurence of `pick`.
+    GIT_SEQUENCE_EDITOR="sed -i -e '0,/pick/{s/pick/edit/}'" ^git rebase -i $"($commit)^1"
+}


### PR DESCRIPTION
With the `git edit` command, editing commits in a historic chain becomes super easy.

Let's say you have a chain of commits like this:

```
A - B - C - D - E - HEAD
```

Now a colleague found a bug in commit `B` which you want to fix. All commits after it should reflect this change. Most people would run `git rebase -i HEAD^4` and manually replace the `pick` for an `edit` or `e` in front of the commit to edit. This can be simplified with a custom command which even suggests the commits to go back to (see screenshot).

![git_edit](https://user-images.githubusercontent.com/47532708/225751378-69fee8b5-806f-42fb-9d0b-4e373eb17c9b.png)

If you wonder who even works like this instead of just putting a fix on top: People using [`gerrit`](https://www.gerritcodereview.com/) where every commit is a patchset (like a PR) often have to work like this.