### PR TITLE
conda: Disable prompt via env var instead of flag

### DIFF
--- a/virtual_environments/README.md
+++ b/virtual_environments/README.md
@@ -13,9 +13,9 @@ The activation and deactivation commands are exported from the `conda` module.
 >
 ```
 
-Do disable the prompt changes (e.g., to let [Starship](https://starship.rs) include its own), pass a `--no-prompt` flag to `activate`.
-This can be automated by creating an alias `alias "conda activate" = conda activate --no-prompt` to `$nu.config-path`.
-The `activate` command includes custom completions for the environment names.
+The `activate` command also includes custom completions for the environment names.
+To disable the prompt changes (e.g., to let [Starship](https://starship.rs) include its own), set the environment variable `CONDA_NO_PROMPT`.
+To set it globally, add the line `let-env CONDA_NO_PROMPT = true` to `$nu.config-path`.
 
 ## Limitations
 

--- a/virtual_environments/conda.nu
+++ b/virtual_environments/conda.nu
@@ -1,7 +1,6 @@
 # Activate conda environment
 export def-env activate [
     env_name?: string@'nu-complete conda envs' # name of the environment
-    --no-prompt                                # do not update the prompt
 ] {
     let conda_info = (conda info --envs --json | from json)
 
@@ -36,7 +35,7 @@ export def-env activate [
         CONDA_OLD_PATH: $old_path
     } | merge $new_path)
 
-    let new_env = if not $no_prompt {
+    let new_env = if not (has-env CONDA_NO_PROMPT) {
         let old_prompt_command = if (has-env CONDA_OLD_PROMPT_COMMAND) {
             $env.CONDA_OLD_PROMPT_COMMAND
         } else {


### PR DESCRIPTION
Now that the `alias` command became less powerful, there is no good way to disable the prompt globally anymore. This commit fixes it by using an environment variable `CONDA_NO_PROMPT` instead.