### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @fdncred
+/virtual_environments/ @Hofer-Julian

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @fdncred
+* @nushell/core-team
 /virtual_environments/ @Hofer-Julian


### PR DESCRIPTION
On its own, the only thing this does is request reviews from codeowners. If virtual_environments is touched, @Hofer-Julian will be requested. Otherwise, @fdncred.
Combined with branch protection rules, this can enforce who is allowed to review and merge pull requests touching certain parts of the code.
Administrators can always override this rule.

For it to work, codeowners will need to be granted write access to the repo.