### PR TITLE
Add `gmom` alias; add missing `git_main_branch` function

### DIFF
--- a/git/git.nu
+++ b/git/git.nu
@@ -112,6 +112,15 @@ export def gm [branch:string@"nu-complete git branches"] {
     git merge $branch
 }
 
+def git_main_branch [] {
+    git remote show origin | lines | str trim | find 'HEAD branch: ' | first | split words | last
+}
+
+export def gmom [] {
+    let main = (git_main_branch)
+    git merge $"origin/($main)"
+}
+
 export alias gp = git push
 export alias gpf! = git push --force
 export alias gl = git pull


### PR DESCRIPTION
This PR addresses two things:

- Adds a handy `gmom` alias, that expands to `git merge origin/main` (or `master`, or whatever the main branch is)
- Adds the missing `git_main_branch` utility function, that `gmom` and some other aliases also depend on