### PR TITLE
Add gpsup, glo, git_current_branch

### DIFF
--- a/git/git.nu
+++ b/git/git.nu
@@ -116,6 +116,10 @@ def git_main_branch [] {
     git remote show origin | lines | str trim | find 'HEAD branch: ' | first | split words | last
 }
 
+def git_current_branch [] {
+    git rev-parse --abbrev-ref HEAD | str trim -c "\n"
+}
+
 export def gmom [] {
     let main = (git_main_branch)
     git merge $"origin/($main)"
@@ -123,7 +127,9 @@ export def gmom [] {
 
 export alias gp = git push
 export alias gpf! = git push --force
+export alias gpsup = git push --set-upstream origin (git_current_branch)
 export alias gl = git pull
+export alias glo = git log --oneline
 export alias ga = git add
 export alias gaa = git add --all
 export alias gapa = git add --patch


### PR DESCRIPTION
This PR adds two aliases and one internal (missing) function.

- `gpsup` --> `git push --set-upstream origin (git_current_branch)` - useful to shorten this mouthful when pushing new branches to upstream
- `glo` --> `git log --oneline` - maybe not as "nu way" as `glg`, but retains some useful info that `glg` does not (like showing the heads of branches and tags)
- `git_current_branch` - used by `gpsup` and some other aliases, missing currently