### PR TITLE
Removed `math exp`, it is now built-in

### DIFF
--- a/maths/math_functions.nu
+++ b/maths/math_functions.nu
@@ -157,8 +157,3 @@ export def scale-minmax-table [a, b,input?] {
 		($x | column2 $i) | scale-minmax $a $b | wrap ($name_cols | get $i)
 	} | reduce {|it, acc| $acc | merge {$it}}
 }
-
-#exp function
-export def "math exp" [ ] {
-    each {|x| (math e) ** $x }
-}


### PR DESCRIPTION
Support for `math exp` [was added to nu shell](https://github.com/nushell/nushell/pull/8700), so it is no longer needed in nu_scripts.