### PR TITLE
Include `nu-std` in the release script

### DIFF
--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -26,6 +26,7 @@ let subcrates_wave_2 = [
 
 let subcrates_wave_3 = [
     nu-cli,
+    nu-std,
 
     # plugins
     nu_plugin_query,


### PR DESCRIPTION
Only `nu` directly depends on it, so can be part of last wave.
