### PR TITLE
Nupass performance 20230502

### DIFF
--- a/sourced/misc/password_generator/ReadMe.md
+++ b/sourced/misc/password_generator/ReadMe.md
@@ -54,7 +54,19 @@ If you're making changes to the script while testing, you can just re-source the
 
 `use nupass.nu`
 
-... which will reload the latest save.
+... which will reload the latest you have saved.
+
+From `nu` version 0.79.1, you can use the standard library, and use its bench command to do a benchmark. Load the standard library by adding `use std` in your `env.nu`, reload, then assuming `nupass.nu` is in your path,  you can benchmark like so: 
+
+```
+std bench --rounds 10 --verbose {nupass 10}
+std bench --rounds 10 --verbose {nupass 100 -v diceware}
+std bench --rounds 10 --verbose {nupass 1000 -v mixnmatch}
+```
+
+If you change the `par-each` to `each` in the main list builders for instance, you'll see a significant performance hit. When I benchmarked `nupass 100`, using just `each` took 7 sec per round, whereas changing to `par-each` dropped that to about 1 sec per round. 
+
+<img width="736" alt="image" src="https://user-images.githubusercontent.com/512328/235553238-48b48f37-0eae-48d3-8afe-e17515cd8325.png">
 
 ### Caveats
 

--- a/sourced/misc/password_generator/nupass.nu
+++ b/sourced/misc/password_generator/nupass.nu
@@ -7,6 +7,7 @@
 #          20230421 - added length of symbol chars to get-random-symbol function
 #          20230422 - added variant flag to generate different styles of passwords
 #          20230501 - refactor to allow number of words to be specified, use list manipulation and reduce to string
+#          20230502 - improve performance on list builders with par-each
 
 #======= NUPASS PASSWORD GENERATOR =======
 # Generate password of 3 dictionary file words, numbers and symbols
@@ -29,15 +30,15 @@ export def main [
   let num_lines = (open ($dictfile) | lines | wrap word | upsert len {|it| $it.word | split chars | length} | where len <= ($word_length) | length)
 
   # Get random words from dictionary file
-  let random_words = (1..$words | each { |i| $dictfile | get-random-word $word_length $num_lines | random-format-word })
+  let random_words = (1..$words | par-each { |i| $dictfile | get-random-word $word_length $num_lines | random-format-word })
 
   # Get some symbols to sprinkle like salt bae
   # Update default symbol chars in symbols flag
   let symbols_len = ($symbols | str length)
-  let random_symbols = (1..$words | each { |i| $symbols | get-random-symbol $symbols $symbols_len })
+  let random_symbols = (1..$words | par-each { |i| $symbols | get-random-symbol $symbols $symbols_len })
 
   # Get some random numbers 
-  let random_numbers = (1..$words |each { |i| (random integer 0..99) })
+  let random_numbers = (1..$words | par-each { |i| (random integer 0..99) })
 
   # Print some vars if debug flag is set
   if $debug { 


### PR DESCRIPTION
Thanks @amtoine for pointing me toward how to benchmark using the std lib. It showed that `par-each` really gives a significant gain, so I updated the script to use that, and explained a little about how to benchmark in the readme. 