### PR TITLE
Fix npm-completions: move extern declaration below dependent declarations

### DIFF
--- a/custom-completions/npm/npm-completions.nu
+++ b/custom-completions/npm/npm-completions.nu
@@ -1,6 +1,3 @@
-export extern "npm" [
-  command?: string@"nu-complete npm"
-]
 def "nu-complete npm" [] {
   ^npm -l
   |lines
@@ -10,6 +7,10 @@ def "nu-complete npm" [] {
   |get column4
   |str replace '"' ''
 }
+
+export extern "npm" [
+  command?: string@"nu-complete npm"
+]
 
 def "nu-complete npm run" [] {
   open ./package.json


### PR DESCRIPTION
Looks like nu has gotten stricter about the order in which things must be declared.
After updating to the latest nu available on homebrew (0.79.0), npm-completions broke.
Was able to get it working again this way.