### PR TITLE
ultimate_extractor: various fixes

### DIFF
--- a/modules/data_extraction/ultimate_extractor.nu
+++ b/modules/data_extraction/ultimate_extractor.nu
@@ -1,27 +1,26 @@
-#Function to extract archives with different extensions
-export def extract [name:string #name of the archive to extract
-] {
-  let exten = [ [ex com];
-                    ['.tar.bz2' 'tar xjf']
-                    ['.tar.gz' 'tar xzf']
-                    ['.bz2' 'bunzip2']
-                    ['.rar' 'unrar x']
-                    ['.tbz2' 'tar xjf']
-                    ['.tgz' 'tar xzf']
-                    ['.zip' 'unzip']
-                    ['.7z' '/usr/bin/7z x']
-                    ['.deb' 'ar x']
-                    ['.tar.xz' 'tar xvf']
-                    ['.tar.zst' 'tar xvf']
-                    ['.tar' 'tar xvf']
-                    ['.gz' 'gunzip']
-                    ['.Z' 'uncompress']
-                    ]
-
-  let command = ($exten|where $name =~ $it.ex|first)
-  if ($command|is-empty) {
-    echo 'Error! Unsupported file extension'
+# Function to extract archives with different extensions.
+export def extract [name:string] {
+  let handlers = [ [extension command];
+                   ['tar\.bz2|tbz|tbz2' 'tar xvjf']
+                   ['tar\.gz|tgz'       'tar xvzf']
+                   ['tar\.xz|txz'       'tar xvf']
+                   ['tar\.Z'            'tar xvZf']
+                   ['bz2'               'bunzip2']
+                   ['deb'               'ar x']
+                   ['gz'                'gunzip']
+                   ['pkg'               'pkgutil --expand']
+                   ['rar'               'unrar x']
+                   ['tar'               'tar xvf']
+                   ['xz'                'xz --decompress']
+                   ['zip|war|jar|nupkg' 'unzip']
+                   ['Z'                 'uncompress']
+                   ['7z'                '7za x']
+                 ]
+  let maybe_handler = ($handlers | where $name =~ $'\.(($it.extension))$')
+  if ($maybe_handler | is-empty) {
+    error make { msg: "unsupported file extension" }
   } else {
-    nu -c ($command.com + ' ' + $name)
+    let handler = ($maybe_handler | first)
+    nu -c ($handler.command + ' ' + $name)
   }
 }


### PR DESCRIPTION
- fix regex matching
  - . -> \.
  - use $ ot match end of file name
- fix naming of variables (exte -> handlers; command -> maybe_handler)
- combine suffixes with common extractors
- in case of no match, use a proper error