### PR TITLE
clean up kubernetes.nu

### DIFF
--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -221,6 +221,7 @@ export def kg [
     r?: string@"nu-complete kube res"
     --namespace (-n): string@"nu-complete kube ns"
     --jsonpath (-p): string@"nu-complete kube path"
+    --selector (-l): string
     --all (-A):bool
 ] {
     let n = if $all {
@@ -231,6 +232,7 @@ export def kg [
                 [-n $namespace]
             }
     let r = if ($r | is-empty) { [] } else { [$r] }
+    let l = if ($selector | is-empty) { [] } else { [-l $selector] }
     if ($jsonpath | is-empty) {
         kubectl get $n $k $r | from ssv -a
     } else {

--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -181,12 +181,12 @@ export def-env kcconf [name: string@"nu-complete kube ctx"] {
 }
 
 ### common
-export def "nu-complete kube kind without cache" [] {
+def "nu-complete kube kind without cache" [] {
     kubectl api-resources | from ssv -a | get NAME
     | append (kubectl get crd | from ssv -a | get NAME)
 }
 
-export def "nu-complete kube kind" [] {
+def "nu-complete kube kind" [] {
     let ctx = (kube-config)
     let cache = $'($env.HOME)/.cache/nu-complete/k8s-api-resources/($ctx.data.current-context).json'
     ensure-cache-by-lines $cache $ctx.path {||
@@ -354,14 +354,12 @@ export def kgpw [] {
 
 # kubectl edit pod
 export def kep [-n: string@"nu-complete kube ns", pod: string@"nu-complete kube res via name"] {
-    let n = if ($n|is-empty) { [] } else { [-n $n] }
-    kubectl edit pod $n $pod
+    ke -n $n pod $pod
 }
 
 # kubectl describe pod
 export def kdp [-n: string@"nu-complete kube ns", pod: string@"nu-complete kube res via name"] {
-    let n = if ($n|is-empty) { [] } else { [-n $n] }
-    kubectl describe pod $n $pod
+    kd -n $n pod $pod
 }
 
 # kubectl attach (exec -it)
@@ -460,8 +458,7 @@ export def kes [svc: string@"nu-complete kube res via name", -n: string@"nu-comp
 
 # kubectl delete service
 export def kdels [svc: string@"nu-complete kube res via name", -n: string@"nu-complete kube ns"] {
-    let n = if ($n|is-empty) { [] } else { [-n $n] }
-    kubectl delete $n service $svc
+    kdel -n $n service $svc
 }
 
 # kubectl get deployments
@@ -470,7 +467,7 @@ export def kgd [
     --namespace (-n): string@"nu-complete kube ns"
     --jsonpath (-p): string@"nu-complete kube path"
 ] {
-    kg deployments -n $namespace -p $jsonpath $r
+    kg -n $namespace deployments -p $jsonpath $r
 }
 
 # kubectl edit deployment

--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -241,6 +241,7 @@ export def kg [
             | each {|x|
                 {
                     name: $x.metadata.name
+                    kind: $x.kind
                     ns: $x.metadata.namespace
                     created: ($x.metadata.creationTimestamp | into datetime)
                     metadata: $x.metadata

--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -339,12 +339,12 @@ export def kgpa [] {
 }
 
 # kubectl get pods
-export def kgp [-n: string@"nu-complete kube ns"] {
-    let n = if ($n|is-empty) { [] } else { [-n $n] }
-    kubectl get pods $n -o wide | from ssv -a
-    | rename name ready status restarts age ip node
-    | each {|x| ($x| upsert restarts ($x.restarts|split row ' '| get 0 | into int)) }
-    | reject 'NOMINATED NODE' 'READINESS GATES'
+export def kgp [
+    r?: string@"nu-complete kube res via name"
+    --namespace (-n): string@"nu-complete kube ns"
+    --jsonpath (-p): string@"nu-complete kube path"
+] {
+    kg pods -n $namespace -p $jsonpath $r
 }
 
 # kubectl get pods --watch
@@ -445,16 +445,17 @@ export def kcp [
 }
 
 # kubectl get services
-export def kgs [-n: string@"nu-complete kube ns"] {
-    let n = if ($n|is-empty) { [] } else { [-n $n] }
-    kubectl get $n services | from ssv -a
-    | rename name type cluster-ip external-ip ports age selector
+export def kgs [
+    r?: string@"nu-complete kube res via name"
+    --namespace (-n): string@"nu-complete kube ns"
+    --jsonpath (-p): string@"nu-complete kube path"
+] {
+    kg services -n $namespace -p $jsonpath $r
 }
 
 # kubectl edit service
 export def kes [svc: string@"nu-complete kube res via name", -n: string@"nu-complete kube ns"] {
-    let n = if ($n|is-empty) { [] } else { [-n $n] }
-    kubectl edit $n service $svc
+    ke -n $n service $svc
 }
 
 # kubectl delete service
@@ -464,17 +465,17 @@ export def kdels [svc: string@"nu-complete kube res via name", -n: string@"nu-co
 }
 
 # kubectl get deployments
-export def kgd [-n: string@"nu-complete kube ns"] {
-    let n = if ($n|is-empty) { [] } else { [-n $n] }
-    kubectl get $n deployments -o wide | from ssv -a
-    | rename name ready up-to-date available age containers images selector
-    | reject selector
+export def kgd [
+    r?: string@"nu-complete kube res via name"
+    --namespace (-n): string@"nu-complete kube ns"
+    --jsonpath (-p): string@"nu-complete kube path"
+] {
+    kg deployments -n $namespace -p $jsonpath $r
 }
 
 # kubectl edit deployment
 export def ked [d: string@"nu-complete kube res via name", -n: string@"nu-complete kube ns"] {
-    let n = if ($n|is-empty) { [] } else { [-n $n] }
-    kubectl edit $n deployments $d
+    ke -n $n deployments $d
 }
 
 def "nu-complete num9" [] { [1 2 3] }

--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -47,6 +47,7 @@ export-env {
     let-env KUBERNETES_RESOURCE_ABBR = {
         s: services
         d: deployments
+        p: pods
     }
 }
 
@@ -350,13 +351,13 @@ export def kgpw [] {
 }
 
 # kubectl edit pod
-export def kep [-n: string@"nu-complete kube ns", pod: string@"nu-complete kube pods"] {
+export def kep [-n: string@"nu-complete kube ns", pod: string@"nu-complete kube res via name"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl edit pod $n $pod
 }
 
 # kubectl describe pod
-export def kdp [-n: string@"nu-complete kube ns", pod: string@"nu-complete kube pods"] {
+export def kdp [-n: string@"nu-complete kube ns", pod: string@"nu-complete kube res via name"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl describe pod $n $pod
 }
@@ -460,13 +461,6 @@ export def kdels [svc: string@"nu-complete kube res via name", -n: string@"nu-co
     kubectl delete $n service $svc
 }
 
-def "nu-complete kube deployments" [context: string, offset: int] {
-    let ctx = ($context | parse cmd)
-    let ns = (do -i { $ctx | get '-n' })
-    let ns = if ($ns|is-empty) { [] } else { [-n $ns] }
-    kubectl get $ns deployments | from ssv -a | get NAME
-}
-
 # kubectl get deployments
 export def kgd [-n: string@"nu-complete kube ns"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
@@ -476,7 +470,7 @@ export def kgd [-n: string@"nu-complete kube ns"] {
 }
 
 # kubectl edit deployment
-export def ked [d: string@"nu-complete kube deployments", -n: string@"nu-complete kube ns"] {
+export def ked [d: string@"nu-complete kube res via name", -n: string@"nu-complete kube ns"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl edit $n deployments $d
 }
@@ -484,7 +478,7 @@ export def ked [d: string@"nu-complete kube deployments", -n: string@"nu-complet
 def "nu-complete num9" [] { [1 2 3] }
 # kubectl scale deployment
 export def ksd [
-    d: string@"nu-complete kube deployments"
+    d: string@"nu-complete kube res via name"
     num: string@"nu-complete num9"
     -n: string@"nu-complete kube ns"
 ] {
@@ -497,7 +491,7 @@ export def ksd [
 }
 # kubectl scale deployment with reset
 export def ksdr [
-    d: string@"nu-complete kube deployments"
+    d: string@"nu-complete kube res via name"
     num: int@"nu-complete num9"
     -n: string@"nu-complete kube ns"
 ] {
@@ -518,14 +512,14 @@ export alias krsd = kubectl rollout status deployment
 export alias kgrs = kubectl get rs
 
 # kubectl rollout history
-export def krh [-n: string@"nu-complete kube ns", --revision (-v): int, dpl: string@"nu-complete kube deployments"] {
+export def krhd [-n: string@"nu-complete kube ns", --revision (-v): int, dpl: string@"nu-complete kube res via name"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     let v = if ($revision|is-empty) { [] } else { [ $"--revision=($revision)" ] }
     kubectl $n rollout history $"deployment/($dpl)" $v
 }
 
 # kubectl rollout undo
-export def kru [-n: string@"nu-complete kube ns", --revision (-v): int, dpl: string@"nu-complete kube deployments"] {
+export def krud [-n: string@"nu-complete kube ns", --revision (-v): int, dpl: string@"nu-complete kube res via name"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     let v = if ($revision|is-empty) { [] } else { [ $"--to-revision=($revision)" ] }
     kubectl $n rollout undo $"deployment/($dpl)" $v

--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -219,21 +219,23 @@ def "nu-complete kube path" [context: string, offset: int] {
 export def kg [
     k: string@"nu-complete kube kind"
     r?: string@"nu-complete kube res"
-    -n: string@"nu-complete kube ns"
-    -p: string@"nu-complete kube path"
+    --namespace (-n): string@"nu-complete kube ns"
+    --jsonpath (-p): string@"nu-complete kube path"
     --all (-A):bool
 ] {
     let n = if $all {
                 [-A]
-            } else if ($n | is-empty) {
+            } else if ($namespace | is-empty) {
                 []
             } else {
-                [-n $n]
+                [-n $namespace]
             }
-    let p = if ($p | is-empty) { [] } else { [-o $"jsonpath='{($p)}'"] }
     let r = if ($r | is-empty) { [] } else { [$r] }
-    print $'-n ($n), -p ($p)'
-    kubectl get $n $k $p $r | from ssv -a
+    if ($jsonpath | is-empty) {
+        kubectl get $n $k $r | from ssv -a
+    } else {
+        kubectl get $n $k $r $"--output=jsonpath={($jsonpath)}" | from yaml
+    }
 }
 
 # kubectl create

--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -44,34 +44,44 @@ export def `kcache flush` [] {
 
 export-env {
     let-env KUBERNETES_SCHEMA_URL = $"file:///($env.HOME)/.config/kubernetes-json-schema/all.json"
+    let-env KUBERNETES_RESOURCE_ABBR = {
+        s: services
+        d: deployments
+    }
 }
 
 
-### file
+# kubectl apply -f
 export def kaf [p: path] {
     kubectl apply -f $p
 }
 
+# kubectl diff -f
 export def kdf [p: path] {
     kubectl diff -f $p
 }
 
+# kubectl delete -f
 export def kdelf [p: path] {
     kubectl delete -f $p
 }
 
+# kubectl apply -k
 export def kak [p: path] {
     kubectl apply -k $p
 }
 
+# kubectl diff -k
 export def kdk [p: path] {
     kubectl diff -k $p
 }
 
+# kubectl delete -k
 export def kdelk [p: path] {
     kubectl delete -k $p
 }
 
+# kubectl kustomize (template)
 export def kk [p: path] {
     kubectl kustomize $p
 }
@@ -117,10 +127,12 @@ def "nu-complete kube ns" [] {
     }
 }
 
+# kubectl change context
 export def kcc [ctx: string@"nu-complete kube ctx"] {
     kubectl config use-context $ctx
 }
 
+# kubectl (change) namespace
 export def kn [ns: string@"nu-complete kube ns"] {
     kubectl config set-context --current $"--namespace=($ns)"
 }
@@ -186,14 +198,28 @@ export def "nu-complete kube kind" [] {
 def "nu-complete kube res" [context: string, offset: int] {
     let ctx = ($context | parse cmd)
     let def = ($ctx | get args.1)
-    let ns = (do -i { $ctx | get '-n' })
-    let ns = if ($ns|is-empty) { [] } else { [-n $ns] }
+    let ns = if ($ctx.-n? | is-empty) { [] } else { [-n $ctx.-n] }
     kubectl get $ns $def | from ssv -a | get NAME
 }
 
+def "nu-complete kube res via name" [context: string, offset: int] {
+    let ctx = ($context | parse cmd)
+    let cmd = ($ctx | get args.0)
+    let def = ($env.KUBERNETES_RESOURCE_ABBR | get ($cmd | str substring (($cmd | str length) - 1)..))
+    echo $'($cmd), ($def)' | save -a ~/.nulog
+    let ns = if ($ctx.-n? | is-empty) { [] } else { [-n $ctx.-n] }
+    kubectl get $ns $def | from ssv -a | get NAME
+}
+
+def "nu-complete kube path" [context: string, offset: int] {
+}
+
+# kubectl get
 export def kg [
-    r: string@"nu-complete kube kind"
+    k: string@"nu-complete kube kind"
+    r?: string@"nu-complete kube res"
     -n: string@"nu-complete kube ns"
+    -p: string@"nu-complete kube path"
     --all (-A):bool
 ] {
     let n = if $all {
@@ -203,11 +229,13 @@ export def kg [
             } else {
                 [-n $n]
             }
-    #let h = ($d | columns | str kebab-case)
-    #$d | rename ...$h
-    kubectl get $n $r | from ssv -a
+    let p = if ($p | is-empty) { [] } else { [-o $"jsonpath='{($p)}'"] }
+    let r = if ($r | is-empty) { [] } else { [$r] }
+    print $'-n ($n), -p ($p)'
+    kubectl get $n $k $p $r | from ssv -a
 }
 
+# kubectl create
 export def kc [
     r: string@"nu-complete kube kind"
     -n: string@"nu-complete kube ns"
@@ -217,6 +245,7 @@ export def kc [
     kubectl create $n $r $name
 }
 
+# kubectl get -o yaml
 export def ky [
     r: string@"nu-complete kube kind"
     i: string@"nu-complete kube res"
@@ -226,6 +255,7 @@ export def ky [
     kubectl get $n -o yaml $r $i
 }
 
+# kubectl describe
 export def kd [
     r: string@"nu-complete kube kind"
     i: string@"nu-complete kube res"
@@ -235,15 +265,17 @@ export def kd [
     kubectl describe $n $r $i
 }
 
+# kubectl edit
 export def ke [
-    r: string@"nu-complete kube kind"
-    i: string@"nu-complete kube res"
+    k: string@"nu-complete kube kind"
+    r: string@"nu-complete kube res"
     -n: string@"nu-complete kube ns"
 ] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
-    kubectl edit $n $r $i
+    kubectl edit $n $k $r
 }
 
+# kubectl delete
 export def kdel [
     r: string@"nu-complete kube kind"
     i: string@"nu-complete kube res"
@@ -256,13 +288,12 @@ export def kdel [
 }
 
 
-### node
+# kubectl get nodes
 export def kgno [] {
     kubectl get nodes -o wide | from ssv -a
     | rename name status roles age version internal-ip external-ip os kernel runtime
 }
 
-### pods
 def "nu-complete kube pods" [context: string, offset: int] {
     let ctx = ($context | parse cmd)
     let ns = (do -i { $ctx | get '-n' })
@@ -280,6 +311,7 @@ def "nu-complete kube ctns" [context: string, offset: int] {
     kubectl get $ns pod $pod -o jsonpath={.spec.containers[*].name} | split row ' '
 }
 
+# kubectl get pods longfmt
 export def kgpl [] {
     kubectl get pods -o json
     | from json
@@ -295,6 +327,7 @@ export def kgpl [] {
         }}
 }
 
+# kubectl get pods --all
 export def kgpa [] {
     kubectl get pods -o wide -A | from ssv -a
     | rename namespace name ready status restarts age ip node
@@ -302,6 +335,7 @@ export def kgpa [] {
     | reject 'NOMINATED NODE' 'READINESS GATES'
 }
 
+# kubectl get pods
 export def kgp [-n: string@"nu-complete kube ns"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl get pods $n -o wide | from ssv -a
@@ -310,20 +344,24 @@ export def kgp [-n: string@"nu-complete kube ns"] {
     | reject 'NOMINATED NODE' 'READINESS GATES'
 }
 
+# kubectl get pods --watch
 export def kgpw [] {
     kubectl get pods --watch
 }
 
+# kubectl edit pod
 export def kep [-n: string@"nu-complete kube ns", pod: string@"nu-complete kube pods"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl edit pod $n $pod
 }
 
+# kubectl describe pod
 export def kdp [-n: string@"nu-complete kube ns", pod: string@"nu-complete kube pods"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl describe pod $n $pod
 }
 
+# kubectl attach (exec -it)
 export def ka [
     pod: string@"nu-complete kube pods"
     -n: string@"nu-complete kube ns"
@@ -335,6 +373,7 @@ export def ka [
     kubectl exec $n -it $pod $c -- (if ($args|is-empty) { 'bash' } else { $args })
 }
 
+# kubectl logs
 export def kl [
     pod: string@"nu-complete kube pods"
     --namespace(-n): string@"nu-complete kube ns"
@@ -345,6 +384,7 @@ export def kl [
     kubectl logs $n $pod $c
 }
 
+# kubectl logs -f
 export def klf [
     pod: string@"nu-complete kube pods"
     --namespace(-n): string@"nu-complete kube ns"
@@ -358,6 +398,7 @@ export def klf [
 def "nu-complete port forward type" [] {
     [pod svc]
 }
+# kubectl port-forward
 export def kpf [
     res: string@"nu-complete port forward type"
     target: string@"nu-complete kube res"
@@ -388,6 +429,7 @@ def "nu-complete kube cp" [cmd: string, offset: int] {
         $files | append $ctn
     }
 }
+# kubectl cp
 export def kcp [
     lhs: string@"nu-complete kube cp"
     rhs: string@"nu-complete kube cp"
@@ -399,31 +441,25 @@ export def kcp [
     kubectl cp $n $lhs $c $rhs
 }
 
-### service
-def "nu-complete kube service" [context: string, offset: int] {
-    let ctx = ($context | parse cmd)
-    let ns = (do -i { $ctx | get '-n' })
-    let ns = if ($ns|is-empty) { [] } else { [-n $ns] }
-    kubectl get $ns services | from ssv -a | get NAME
-}
-
+# kubectl get services
 export def kgs [-n: string@"nu-complete kube ns"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl get $n services | from ssv -a
     | rename name type cluster-ip external-ip ports age selector
 }
 
-export def kes [svc: string@"nu-complete kube service", -n: string@"nu-complete kube ns"] {
+# kubectl edit service
+export def kes [svc: string@"nu-complete kube res via name", -n: string@"nu-complete kube ns"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl edit $n service $svc
 }
 
-export def kdels [svc: string@"nu-complete kube service", -n: string@"nu-complete kube ns"] {
+# kubectl delete service
+export def kdels [svc: string@"nu-complete kube res via name", -n: string@"nu-complete kube ns"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl delete $n service $svc
 }
 
-### deployments
 def "nu-complete kube deployments" [context: string, offset: int] {
     let ctx = ($context | parse cmd)
     let ns = (do -i { $ctx | get '-n' })
@@ -431,6 +467,7 @@ def "nu-complete kube deployments" [context: string, offset: int] {
     kubectl get $ns deployments | from ssv -a | get NAME
 }
 
+# kubectl get deployments
 export def kgd [-n: string@"nu-complete kube ns"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl get $n deployments -o wide | from ssv -a
@@ -438,12 +475,14 @@ export def kgd [-n: string@"nu-complete kube ns"] {
     | reject selector
 }
 
+# kubectl edit deployment
 export def ked [d: string@"nu-complete kube deployments", -n: string@"nu-complete kube ns"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl edit $n deployments $d
 }
 
 def "nu-complete num9" [] { [1 2 3] }
+# kubectl scale deployment
 export def ksd [
     d: string@"nu-complete kube deployments"
     num: string@"nu-complete num9"
@@ -456,6 +495,7 @@ export def ksd [
         kubectl scale $n deployments $d --replicas $num
     }
 }
+# kubectl scale deployment with reset
 export def ksdr [
     d: string@"nu-complete kube deployments"
     num: int@"nu-complete num9"
@@ -472,13 +512,19 @@ export def ksdr [
     }
 }
 
+# kubectl rollout status deployment
 export alias krsd = kubectl rollout status deployment
+# kubectl get rs
 export alias kgrs = kubectl get rs
+
+# kubectl rollout history
 export def krh [-n: string@"nu-complete kube ns", --revision (-v): int, dpl: string@"nu-complete kube deployments"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     let v = if ($revision|is-empty) { [] } else { [ $"--revision=($revision)" ] }
     kubectl $n rollout history $"deployment/($dpl)" $v
 }
+
+# kubectl rollout undo
 export def kru [-n: string@"nu-complete kube ns", --revision (-v): int, dpl: string@"nu-complete kube deployments"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     let v = if ($revision|is-empty) { [] } else { [ $"--to-revision=($revision)" ] }
@@ -487,7 +533,7 @@ export def kru [-n: string@"nu-complete kube ns", --revision (-v): int, dpl: str
 export alias ksss = kubectl scale statefulset
 export alias krsss = kubectl rollout status statefulset
 
-### kubectl top pod
+# kubectl top pod
 export def ktp [-n: string@"nu-complete kube ns"] {
     let n = if ($n|is-empty) { [] } else { [-n $n] }
     kubectl top pod $n | from ssv -a | rename name cpu mem
@@ -498,6 +544,7 @@ export def ktp [-n: string@"nu-complete kube ns"] {
     } }
 }
 
+# kubectl top pod -all
 export def ktpa [] {
     kubectl top pod -A | from ssv -a | rename namespace name cpu mem
     | each {|x| {
@@ -508,7 +555,7 @@ export def ktpa [] {
     } }
 }
 
-### kube top node
+# kubectl top node
 export def ktn [] {
     kubectl top node | from ssv -a | rename name cpu pcpu mem pmem
     | each {|x| {


### PR DESCRIPTION
- add the original kubectl command as description of abbreviation
- improve `kg`
  - --jsonpath
  - --selector
  - --verbose
  - --watch
- refactor derivative command like kgp, kgs, kdp etc.
  - replace nu-complete kube pods, services, deployments with res via name
  - refactor kep, kdp, kgd, kdels, use parent command such as kg, ke, kd