### PR TITLE
gp: run `git fetch` before `git push` or `git pull`

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -41,7 +41,9 @@ Pull, push and other related to remote repositories
 - `--override` just used to trigger a github actions event (in fact, webhooks can also be used)
 - if branch is specified, we assume it is `git fetch`
     - unless -u is specified: `git push -u`
-- finally, if no branch and above parameters are specified, `git pull` or `git push` will be executed according to the current state.
+- finally, if no branch and above parameters are specified
+    - `git fetch` to update status.
+    - `git pull` or `git push` will be executed according to the current state.
     - if both `ahead` and `behind` exist, only `pull`
 
 ### ga

--- a/modules/git/git-v2.nu
+++ b/modules/git/git-v2.nu
@@ -130,7 +130,6 @@ export def gp [
             git pull $r $a -v
         } else if $s.ahead > 0 {
             git push
-        } else {
         }
     }
 }

--- a/modules/git/git-v2.nu
+++ b/modules/git/git-v2.nu
@@ -122,6 +122,7 @@ export def gp [
             git fetch $remote $branch
         }
     } else {
+        git fetch
         let s = (_git_status)
         if $s.behind > 0 {
             let r = if $rebase { [--rebase] } else { [] }
@@ -130,7 +131,6 @@ export def gp [
         } else if $s.ahead > 0 {
             git push
         } else {
-            git fetch
         }
     }
 }


### PR DESCRIPTION
After testing, I found that even if `git fetch` is executed locally,
when remote repository changed, local repository does not know.

In general scenarios, after the local update, the local will display `ahead`. When you push, the remote changes during the period, and you will be prompted to pull first.

However, `gp` does not work in this mode, so `git fetch` must be used first to get the information.
The problem with this is that one request becomes two requests. 
But the problem is not too serious, I will look into whether there are other solutions.