### PR TITLE
fix: just completions

### DIFF
--- a/custom-completions/just/just-completions.nu
+++ b/custom-completions/just/just-completions.nu
@@ -1,4 +1,4 @@
-export def "nu-complete just recipes" [] {
+def "nu-complete just recipes" [] {
     ^just --unstable --unsorted --dump --dump-format json
         | from json
         | get recipes
@@ -20,7 +20,7 @@ export def "nu-complete just recipes" [] {
         }
 }
 
-export def "nu-complete just args" [context: string, offset: int] {
+def "nu-complete just args" [context: string, offset: int] {
     let r = ($context | split row ' ')
     ^just --unstable -u --dump --dump-format json
         | from json
@@ -32,7 +32,7 @@ export def "nu-complete just args" [context: string, offset: int] {
 
 }
 
-export def j [
+export def just [
     recipes?: string@"nu-complete just recipes"
     ...args: any@"nu-complete just args"
 ] {


### PR DESCRIPTION
this fixes the `just` completions file, as it was previously incorrectly named, exported internal completion helpers, and had the wrong base command name.