### PR TITLE
REFACTOR: make the indentation in the themes more consistent

### DIFF
--- a/themes/make.nu
+++ b/themes/make.nu
@@ -26,29 +26,29 @@ def make-theme [name: string] {
     bool: {|| if $in { "($colors.color14)" } else { "light_gray" } }
     int: "($colors.color7)"
     filesize: {|e|
-      if $e == 0b {
-        "($colors.color7)"
-      } else if $e < 1mb {
-        "($colors.color6)"
-      } else {{ fg: "($colors.color4)" }}
+        if $e == 0b {
+            "($colors.color7)"
+        } else if $e < 1mb {
+            "($colors.color6)"
+        } else {{ fg: "($colors.color4)" }}
     }
     duration: "($colors.color7)"
     date: {|| (char lparen)date now(char rparen) - $in |
-      if $in < 1hr {
-        { fg: "($colors.color1)" attr: "b" }
-      } else if $in < 6hr {
-        "($colors.color1)"
-      } else if $in < 1day {
-        "($colors.color3)"
-      } else if $in < 3day {
-        "($colors.color2)"
-      } else if $in < 1wk {
-        { fg: "($colors.color2)" attr: "b" }
-      } else if $in < 6wk {
-        "($colors.color6)"
-      } else if $in < 52wk {
-        "($colors.color4)"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "($colors.color1)" attr: "b" }
+        } else if $in < 6hr {
+            "($colors.color1)"
+        } else if $in < 1day {
+            "($colors.color3)"
+        } else if $in < 3day {
+            "($colors.color2)"
+        } else if $in < 1wk {
+            { fg: "($colors.color2)" attr: "b" }
+        } else if $in < 6wk {
+            "($colors.color6)"
+        } else if $in < 52wk {
+            "($colors.color4)"
+        } else { "dark_gray" }
     }
     range: "($colors.color7)"
     float: "($colors.color7)"

--- a/themes/themes/3024-day.nu
+++ b/themes/themes/3024-day.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#cdab53" } else { "light_gray" } }
     int: "#a5a2a2"
     filesize: {|e|
-      if $e == 0b {
-        "#a5a2a2"
-      } else if $e < 1mb {
-        "#b5e4f4"
-      } else {{ fg: "#01a0e4" }}
+        if $e == 0b {
+            "#a5a2a2"
+        } else if $e < 1mb {
+            "#b5e4f4"
+        } else {{ fg: "#01a0e4" }}
     }
     duration: "#a5a2a2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#db2d20" attr: "b" }
-      } else if $in < 6hr {
-        "#db2d20"
-      } else if $in < 1day {
-        "#fded02"
-      } else if $in < 3day {
-        "#01a252"
-      } else if $in < 1wk {
-        { fg: "#01a252" attr: "b" }
-      } else if $in < 6wk {
-        "#b5e4f4"
-      } else if $in < 52wk {
-        "#01a0e4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#db2d20" attr: "b" }
+        } else if $in < 6hr {
+            "#db2d20"
+        } else if $in < 1day {
+            "#fded02"
+        } else if $in < 3day {
+            "#01a252"
+        } else if $in < 1wk {
+            { fg: "#01a252" attr: "b" }
+        } else if $in < 6wk {
+            "#b5e4f4"
+        } else if $in < 52wk {
+            "#01a0e4"
+        } else { "dark_gray" }
     }
     range: "#a5a2a2"
     float: "#a5a2a2"

--- a/themes/themes/3024-night.nu
+++ b/themes/themes/3024-night.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#cdab53" } else { "light_gray" } }
     int: "#a5a2a2"
     filesize: {|e|
-      if $e == 0b {
-        "#a5a2a2"
-      } else if $e < 1mb {
-        "#b5e4f4"
-      } else {{ fg: "#01a0e4" }}
+        if $e == 0b {
+            "#a5a2a2"
+        } else if $e < 1mb {
+            "#b5e4f4"
+        } else {{ fg: "#01a0e4" }}
     }
     duration: "#a5a2a2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#db2d20" attr: "b" }
-      } else if $in < 6hr {
-        "#db2d20"
-      } else if $in < 1day {
-        "#fded02"
-      } else if $in < 3day {
-        "#01a252"
-      } else if $in < 1wk {
-        { fg: "#01a252" attr: "b" }
-      } else if $in < 6wk {
-        "#b5e4f4"
-      } else if $in < 52wk {
-        "#01a0e4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#db2d20" attr: "b" }
+        } else if $in < 6hr {
+            "#db2d20"
+        } else if $in < 1day {
+            "#fded02"
+        } else if $in < 3day {
+            "#01a252"
+        } else if $in < 1wk {
+            { fg: "#01a252" attr: "b" }
+        } else if $in < 6wk {
+            "#b5e4f4"
+        } else if $in < 52wk {
+            "#01a0e4"
+        } else { "dark_gray" }
     }
     range: "#a5a2a2"
     float: "#a5a2a2"

--- a/themes/themes/3024.nu
+++ b/themes/themes/3024.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b5e4f4" } else { "light_gray" } }
     int: "#a5a2a2"
     filesize: {|e|
-      if $e == 0b {
-        "#a5a2a2"
-      } else if $e < 1mb {
-        "#b5e4f4"
-      } else {{ fg: "#01a0e4" }}
+        if $e == 0b {
+            "#a5a2a2"
+        } else if $e < 1mb {
+            "#b5e4f4"
+        } else {{ fg: "#01a0e4" }}
     }
     duration: "#a5a2a2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#db2d20" attr: "b" }
-      } else if $in < 6hr {
-        "#db2d20"
-      } else if $in < 1day {
-        "#fded02"
-      } else if $in < 3day {
-        "#01a252"
-      } else if $in < 1wk {
-        { fg: "#01a252" attr: "b" }
-      } else if $in < 6wk {
-        "#b5e4f4"
-      } else if $in < 52wk {
-        "#01a0e4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#db2d20" attr: "b" }
+        } else if $in < 6hr {
+            "#db2d20"
+        } else if $in < 1day {
+            "#fded02"
+        } else if $in < 3day {
+            "#01a252"
+        } else if $in < 1wk {
+            { fg: "#01a252" attr: "b" }
+        } else if $in < 6wk {
+            "#b5e4f4"
+        } else if $in < 52wk {
+            "#01a0e4"
+        } else { "dark_gray" }
     }
     range: "#a5a2a2"
     float: "#a5a2a2"

--- a/themes/themes/abyss.nu
+++ b/themes/themes/abyss.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2592d3" } else { "light_gray" } }
     int: "#a0cce2"
     filesize: {|e|
-      if $e == 0b {
-        "#a0cce2"
-      } else if $e < 1mb {
-        "#2592d3"
-      } else {{ fg: "#277bb1" }}
+        if $e == 0b {
+            "#a0cce2"
+        } else if $e < 1mb {
+            "#2592d3"
+        } else {{ fg: "#277bb1" }}
     }
     duration: "#a0cce2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#48697e" attr: "b" }
-      } else if $in < 6hr {
-        "#48697e"
-      } else if $in < 1day {
-        "#1f6ca1"
-      } else if $in < 3day {
-        "#10598b"
-      } else if $in < 1wk {
-        { fg: "#10598b" attr: "b" }
-      } else if $in < 6wk {
-        "#2592d3"
-      } else if $in < 52wk {
-        "#277bb1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#48697e" attr: "b" }
+        } else if $in < 6hr {
+            "#48697e"
+        } else if $in < 1day {
+            "#1f6ca1"
+        } else if $in < 3day {
+            "#10598b"
+        } else if $in < 1wk {
+            { fg: "#10598b" attr: "b" }
+        } else if $in < 6wk {
+            "#2592d3"
+        } else if $in < 52wk {
+            "#277bb1"
+        } else { "dark_gray" }
     }
     range: "#a0cce2"
     float: "#a0cce2"

--- a/themes/themes/aci.nu
+++ b/themes/themes/aci.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1eff8e" } else { "light_gray" } }
     int: "#b6b6b6"
     filesize: {|e|
-      if $e == 0b {
-        "#b6b6b6"
-      } else if $e < 1mb {
-        "#08ff83"
-      } else {{ fg: "#0883ff" }}
+        if $e == 0b {
+            "#b6b6b6"
+        } else if $e < 1mb {
+            "#08ff83"
+        } else {{ fg: "#0883ff" }}
     }
     duration: "#b6b6b6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0883" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0883"
-      } else if $in < 1day {
-        "#ff8308"
-      } else if $in < 3day {
-        "#83ff08"
-      } else if $in < 1wk {
-        { fg: "#83ff08" attr: "b" }
-      } else if $in < 6wk {
-        "#08ff83"
-      } else if $in < 52wk {
-        "#0883ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0883" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0883"
+        } else if $in < 1day {
+            "#ff8308"
+        } else if $in < 3day {
+            "#83ff08"
+        } else if $in < 1wk {
+            { fg: "#83ff08" attr: "b" }
+        } else if $in < 6wk {
+            "#08ff83"
+        } else if $in < 52wk {
+            "#0883ff"
+        } else { "dark_gray" }
     }
     range: "#b6b6b6"
     float: "#b6b6b6"

--- a/themes/themes/aco.nu
+++ b/themes/themes/aco.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1eff8e" } else { "light_gray" } }
     int: "#bebebe"
     filesize: {|e|
-      if $e == 0b {
-        "#bebebe"
-      } else if $e < 1mb {
-        "#08ff83"
-      } else {{ fg: "#0883ff" }}
+        if $e == 0b {
+            "#bebebe"
+        } else if $e < 1mb {
+            "#08ff83"
+        } else {{ fg: "#0883ff" }}
     }
     duration: "#bebebe"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0883" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0883"
-      } else if $in < 1day {
-        "#ff8308"
-      } else if $in < 3day {
-        "#83ff08"
-      } else if $in < 1wk {
-        { fg: "#83ff08" attr: "b" }
-      } else if $in < 6wk {
-        "#08ff83"
-      } else if $in < 52wk {
-        "#0883ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0883" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0883"
+        } else if $in < 1day {
+            "#ff8308"
+        } else if $in < 3day {
+            "#83ff08"
+        } else if $in < 1wk {
+            { fg: "#83ff08" attr: "b" }
+        } else if $in < 6wk {
+            "#08ff83"
+        } else if $in < 52wk {
+            "#0883ff"
+        } else { "dark_gray" }
     }
     range: "#bebebe"
     float: "#bebebe"

--- a/themes/themes/adventuretime.nu
+++ b/themes/themes/adventuretime.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c8faf4" } else { "light_gray" } }
     int: "#f8dcc0"
     filesize: {|e|
-      if $e == 0b {
-        "#f8dcc0"
-      } else if $e < 1mb {
-        "#70a598"
-      } else {{ fg: "#0f4ac6" }}
+        if $e == 0b {
+            "#f8dcc0"
+        } else if $e < 1mb {
+            "#70a598"
+        } else {{ fg: "#0f4ac6" }}
     }
     duration: "#f8dcc0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bd0013" attr: "b" }
-      } else if $in < 6hr {
-        "#bd0013"
-      } else if $in < 1day {
-        "#e7741e"
-      } else if $in < 3day {
-        "#4ab118"
-      } else if $in < 1wk {
-        { fg: "#4ab118" attr: "b" }
-      } else if $in < 6wk {
-        "#70a598"
-      } else if $in < 52wk {
-        "#0f4ac6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bd0013" attr: "b" }
+        } else if $in < 6hr {
+            "#bd0013"
+        } else if $in < 1day {
+            "#e7741e"
+        } else if $in < 3day {
+            "#4ab118"
+        } else if $in < 1wk {
+            { fg: "#4ab118" attr: "b" }
+        } else if $in < 6wk {
+            "#70a598"
+        } else if $in < 52wk {
+            "#0f4ac6"
+        } else { "dark_gray" }
     }
     range: "#f8dcc0"
     float: "#f8dcc0"

--- a/themes/themes/afterglow.nu
+++ b/themes/themes/afterglow.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7dd6cf" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#7dd6cf"
-      } else {{ fg: "#6c99bb" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#7dd6cf"
+        } else {{ fg: "#6c99bb" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a53c23" attr: "b" }
-      } else if $in < 6hr {
-        "#a53c23"
-      } else if $in < 1day {
-        "#d3a04d"
-      } else if $in < 3day {
-        "#7b9246"
-      } else if $in < 1wk {
-        { fg: "#7b9246" attr: "b" }
-      } else if $in < 6wk {
-        "#7dd6cf"
-      } else if $in < 52wk {
-        "#6c99bb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a53c23" attr: "b" }
+        } else if $in < 6hr {
+            "#a53c23"
+        } else if $in < 1day {
+            "#d3a04d"
+        } else if $in < 3day {
+            "#7b9246"
+        } else if $in < 1wk {
+            { fg: "#7b9246" attr: "b" }
+        } else if $in < 6wk {
+            "#7dd6cf"
+        } else if $in < 52wk {
+            "#6c99bb"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/alien-blood.nu
+++ b/themes/themes/alien-blood.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00e0c4" } else { "light_gray" } }
     int: "#647d75"
     filesize: {|e|
-      if $e == 0b {
-        "#647d75"
-      } else if $e < 1mb {
-        "#327f77"
-      } else {{ fg: "#2f6a7f" }}
+        if $e == 0b {
+            "#647d75"
+        } else if $e < 1mb {
+            "#327f77"
+        } else {{ fg: "#2f6a7f" }}
     }
     duration: "#647d75"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#7f2b27" attr: "b" }
-      } else if $in < 6hr {
-        "#7f2b27"
-      } else if $in < 1day {
-        "#717f24"
-      } else if $in < 3day {
-        "#2f7e25"
-      } else if $in < 1wk {
-        { fg: "#2f7e25" attr: "b" }
-      } else if $in < 6wk {
-        "#327f77"
-      } else if $in < 52wk {
-        "#2f6a7f"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#7f2b27" attr: "b" }
+        } else if $in < 6hr {
+            "#7f2b27"
+        } else if $in < 1day {
+            "#717f24"
+        } else if $in < 3day {
+            "#2f7e25"
+        } else if $in < 1wk {
+            { fg: "#2f7e25" attr: "b" }
+        } else if $in < 6wk {
+            "#327f77"
+        } else if $in < 52wk {
+            "#2f6a7f"
+        } else { "dark_gray" }
     }
     range: "#647d75"
     float: "#647d75"

--- a/themes/themes/alucard.nu
+++ b/themes/themes/alucard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ae9fc" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#0037fc"
-      } else {{ fg: "#3282ff" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#0037fc"
+        } else {{ fg: "#3282ff" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff5555" attr: "b" }
-      } else if $in < 6hr {
-        "#ff5555"
-      } else if $in < 1day {
-        "#7f0a1f"
-      } else if $in < 3day {
-        "#fa0074"
-      } else if $in < 1wk {
-        { fg: "#fa0074" attr: "b" }
-      } else if $in < 6wk {
-        "#0037fc"
-      } else if $in < 52wk {
-        "#3282ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff5555" attr: "b" }
+        } else if $in < 6hr {
+            "#ff5555"
+        } else if $in < 1day {
+            "#7f0a1f"
+        } else if $in < 3day {
+            "#fa0074"
+        } else if $in < 1wk {
+            { fg: "#fa0074" attr: "b" }
+        } else if $in < 6wk {
+            "#0037fc"
+        } else if $in < 52wk {
+            "#3282ff"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/amora.nu
+++ b/themes/themes/amora.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c4d1f5" } else { "light_gray" } }
     int: "#dedbeb"
     filesize: {|e|
-      if $e == 0b {
-        "#dedbeb"
-      } else if $e < 1mb {
-        "#aabae7"
-      } else {{ fg: "#9985d1" }}
+        if $e == 0b {
+            "#dedbeb"
+        } else if $e < 1mb {
+            "#aabae7"
+        } else {{ fg: "#9985d1" }}
     }
     duration: "#dedbeb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ed3f7f" attr: "b" }
-      } else if $in < 6hr {
-        "#ed3f7f"
-      } else if $in < 1day {
-        "#eacac0"
-      } else if $in < 3day {
-        "#a2baa8"
-      } else if $in < 1wk {
-        { fg: "#a2baa8" attr: "b" }
-      } else if $in < 6wk {
-        "#aabae7"
-      } else if $in < 52wk {
-        "#9985d1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ed3f7f" attr: "b" }
+        } else if $in < 6hr {
+            "#ed3f7f"
+        } else if $in < 1day {
+            "#eacac0"
+        } else if $in < 3day {
+            "#a2baa8"
+        } else if $in < 1wk {
+            { fg: "#a2baa8" attr: "b" }
+        } else if $in < 6wk {
+            "#aabae7"
+        } else if $in < 52wk {
+            "#9985d1"
+        } else { "dark_gray" }
     }
     range: "#dedbeb"
     float: "#dedbeb"

--- a/themes/themes/apathy.nu
+++ b/themes/themes/apathy.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#963e4c" } else { "light_gray" } }
     int: "#81b5ac"
     filesize: {|e|
-      if $e == 0b {
-        "#81b5ac"
-      } else if $e < 1mb {
-        "#963e4c"
-      } else {{ fg: "#96883e" }}
+        if $e == 0b {
+            "#81b5ac"
+        } else if $e < 1mb {
+            "#963e4c"
+        } else {{ fg: "#96883e" }}
     }
     duration: "#81b5ac"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#3e9688" attr: "b" }
-      } else if $in < 6hr {
-        "#3e9688"
-      } else if $in < 1day {
-        "#3e4c96"
-      } else if $in < 3day {
-        "#883e96"
-      } else if $in < 1wk {
-        { fg: "#883e96" attr: "b" }
-      } else if $in < 6wk {
-        "#963e4c"
-      } else if $in < 52wk {
-        "#96883e"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#3e9688" attr: "b" }
+        } else if $in < 6hr {
+            "#3e9688"
+        } else if $in < 1day {
+            "#3e4c96"
+        } else if $in < 3day {
+            "#883e96"
+        } else if $in < 1wk {
+            { fg: "#883e96" attr: "b" }
+        } else if $in < 6wk {
+            "#963e4c"
+        } else if $in < 52wk {
+            "#96883e"
+        } else { "dark_gray" }
     }
     range: "#81b5ac"
     float: "#81b5ac"

--- a/themes/themes/apprentice.nu
+++ b/themes/themes/apprentice.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5f875f" } else { "light_gray" } }
     int: "#bcbcbc"
     filesize: {|e|
-      if $e == 0b {
-        "#bcbcbc"
-      } else if $e < 1mb {
-        "#5f875f"
-      } else {{ fg: "#ffffaf" }}
+        if $e == 0b {
+            "#bcbcbc"
+        } else if $e < 1mb {
+            "#5f875f"
+        } else {{ fg: "#ffffaf" }}
     }
     duration: "#bcbcbc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#5f8787"
-      } else if $in < 3day {
-        "#87af87"
-      } else if $in < 1wk {
-        { fg: "#87af87" attr: "b" }
-      } else if $in < 6wk {
-        "#5f875f"
-      } else if $in < 52wk {
-        "#ffffaf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#5f8787"
+        } else if $in < 3day {
+            "#87af87"
+        } else if $in < 1wk {
+            { fg: "#87af87" attr: "b" }
+        } else if $in < 6wk {
+            "#5f875f"
+        } else if $in < 52wk {
+            "#ffffaf"
+        } else { "dark_gray" }
     }
     range: "#bcbcbc"
     float: "#bcbcbc"

--- a/themes/themes/argonaut.nu
+++ b/themes/themes/argonaut.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#67fff0" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#00d8eb"
-      } else {{ fg: "#008df8" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#00d8eb"
+        } else {{ fg: "#008df8" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff000f" attr: "b" }
-      } else if $in < 6hr {
-        "#ff000f"
-      } else if $in < 1day {
-        "#ffb900"
-      } else if $in < 3day {
-        "#8ce10b"
-      } else if $in < 1wk {
-        { fg: "#8ce10b" attr: "b" }
-      } else if $in < 6wk {
-        "#00d8eb"
-      } else if $in < 52wk {
-        "#008df8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff000f" attr: "b" }
+        } else if $in < 6hr {
+            "#ff000f"
+        } else if $in < 1day {
+            "#ffb900"
+        } else if $in < 3day {
+            "#8ce10b"
+        } else if $in < 1wk {
+            { fg: "#8ce10b" attr: "b" }
+        } else if $in < 6wk {
+            "#00d8eb"
+        } else if $in < 52wk {
+            "#008df8"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/arthur.nu
+++ b/themes/themes/arthur.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b0c4de" } else { "light_gray" } }
     int: "#bbaa99"
     filesize: {|e|
-      if $e == 0b {
-        "#bbaa99"
-      } else if $e < 1mb {
-        "#b0c4de"
-      } else {{ fg: "#6495ed" }}
+        if $e == 0b {
+            "#bbaa99"
+        } else if $e < 1mb {
+            "#b0c4de"
+        } else {{ fg: "#6495ed" }}
     }
     duration: "#bbaa99"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cd5c5c" attr: "b" }
-      } else if $in < 6hr {
-        "#cd5c5c"
-      } else if $in < 1day {
-        "#e8ae5b"
-      } else if $in < 3day {
-        "#86af80"
-      } else if $in < 1wk {
-        { fg: "#86af80" attr: "b" }
-      } else if $in < 6wk {
-        "#b0c4de"
-      } else if $in < 52wk {
-        "#6495ed"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cd5c5c" attr: "b" }
+        } else if $in < 6hr {
+            "#cd5c5c"
+        } else if $in < 1day {
+            "#e8ae5b"
+        } else if $in < 3day {
+            "#86af80"
+        } else if $in < 1wk {
+            { fg: "#86af80" attr: "b" }
+        } else if $in < 6wk {
+            "#b0c4de"
+        } else if $in < 52wk {
+            "#6495ed"
+        } else { "dark_gray" }
     }
     range: "#bbaa99"
     float: "#bbaa99"

--- a/themes/themes/ashes.nu
+++ b/themes/themes/ashes.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#95aec7" } else { "light_gray" } }
     int: "#c7ccd1"
     filesize: {|e|
-      if $e == 0b {
-        "#c7ccd1"
-      } else if $e < 1mb {
-        "#95aec7"
-      } else {{ fg: "#ae95c7" }}
+        if $e == 0b {
+            "#c7ccd1"
+        } else if $e < 1mb {
+            "#95aec7"
+        } else {{ fg: "#ae95c7" }}
     }
     duration: "#c7ccd1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c7ae95" attr: "b" }
-      } else if $in < 6hr {
-        "#c7ae95"
-      } else if $in < 1day {
-        "#aec795"
-      } else if $in < 3day {
-        "#95c7ae"
-      } else if $in < 1wk {
-        { fg: "#95c7ae" attr: "b" }
-      } else if $in < 6wk {
-        "#95aec7"
-      } else if $in < 52wk {
-        "#ae95c7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c7ae95" attr: "b" }
+        } else if $in < 6hr {
+            "#c7ae95"
+        } else if $in < 1day {
+            "#aec795"
+        } else if $in < 3day {
+            "#95c7ae"
+        } else if $in < 1wk {
+            { fg: "#95c7ae" attr: "b" }
+        } else if $in < 6wk {
+            "#95aec7"
+        } else if $in < 52wk {
+            "#ae95c7"
+        } else { "dark_gray" }
     }
     range: "#c7ccd1"
     float: "#c7ccd1"

--- a/themes/themes/atelier-cave-light.nu
+++ b/themes/themes/atelier-cave-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#398bc6" } else { "light_gray" } }
     int: "#585260"
     filesize: {|e|
-      if $e == 0b {
-        "#585260"
-      } else if $e < 1mb {
-        "#398bc6"
-      } else {{ fg: "#576ddb" }}
+        if $e == 0b {
+            "#585260"
+        } else if $e < 1mb {
+            "#398bc6"
+        } else {{ fg: "#576ddb" }}
     }
     duration: "#585260"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#be4678" attr: "b" }
-      } else if $in < 6hr {
-        "#be4678"
-      } else if $in < 1day {
-        "#a06e3b"
-      } else if $in < 3day {
-        "#2a9292"
-      } else if $in < 1wk {
-        { fg: "#2a9292" attr: "b" }
-      } else if $in < 6wk {
-        "#398bc6"
-      } else if $in < 52wk {
-        "#576ddb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#be4678" attr: "b" }
+        } else if $in < 6hr {
+            "#be4678"
+        } else if $in < 1day {
+            "#a06e3b"
+        } else if $in < 3day {
+            "#2a9292"
+        } else if $in < 1wk {
+            { fg: "#2a9292" attr: "b" }
+        } else if $in < 6wk {
+            "#398bc6"
+        } else if $in < 52wk {
+            "#576ddb"
+        } else { "dark_gray" }
     }
     range: "#585260"
     float: "#585260"

--- a/themes/themes/atelier-cave.nu
+++ b/themes/themes/atelier-cave.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#398bc6" } else { "light_gray" } }
     int: "#8b8792"
     filesize: {|e|
-      if $e == 0b {
-        "#8b8792"
-      } else if $e < 1mb {
-        "#398bc6"
-      } else {{ fg: "#576ddb" }}
+        if $e == 0b {
+            "#8b8792"
+        } else if $e < 1mb {
+            "#398bc6"
+        } else {{ fg: "#576ddb" }}
     }
     duration: "#8b8792"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#be4678" attr: "b" }
-      } else if $in < 6hr {
-        "#be4678"
-      } else if $in < 1day {
-        "#a06e3b"
-      } else if $in < 3day {
-        "#2a9292"
-      } else if $in < 1wk {
-        { fg: "#2a9292" attr: "b" }
-      } else if $in < 6wk {
-        "#398bc6"
-      } else if $in < 52wk {
-        "#576ddb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#be4678" attr: "b" }
+        } else if $in < 6hr {
+            "#be4678"
+        } else if $in < 1day {
+            "#a06e3b"
+        } else if $in < 3day {
+            "#2a9292"
+        } else if $in < 1wk {
+            { fg: "#2a9292" attr: "b" }
+        } else if $in < 6wk {
+            "#398bc6"
+        } else if $in < 52wk {
+            "#576ddb"
+        } else { "dark_gray" }
     }
     range: "#8b8792"
     float: "#8b8792"

--- a/themes/themes/atelier-dune-light.nu
+++ b/themes/themes/atelier-dune-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1fad83" } else { "light_gray" } }
     int: "#6e6b5e"
     filesize: {|e|
-      if $e == 0b {
-        "#6e6b5e"
-      } else if $e < 1mb {
-        "#1fad83"
-      } else {{ fg: "#6684e1" }}
+        if $e == 0b {
+            "#6e6b5e"
+        } else if $e < 1mb {
+            "#1fad83"
+        } else {{ fg: "#6684e1" }}
     }
     duration: "#6e6b5e"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d73737" attr: "b" }
-      } else if $in < 6hr {
-        "#d73737"
-      } else if $in < 1day {
-        "#ae9513"
-      } else if $in < 3day {
-        "#60ac39"
-      } else if $in < 1wk {
-        { fg: "#60ac39" attr: "b" }
-      } else if $in < 6wk {
-        "#1fad83"
-      } else if $in < 52wk {
-        "#6684e1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d73737" attr: "b" }
+        } else if $in < 6hr {
+            "#d73737"
+        } else if $in < 1day {
+            "#ae9513"
+        } else if $in < 3day {
+            "#60ac39"
+        } else if $in < 1wk {
+            { fg: "#60ac39" attr: "b" }
+        } else if $in < 6wk {
+            "#1fad83"
+        } else if $in < 52wk {
+            "#6684e1"
+        } else { "dark_gray" }
     }
     range: "#6e6b5e"
     float: "#6e6b5e"

--- a/themes/themes/atelier-dune.nu
+++ b/themes/themes/atelier-dune.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1fad83" } else { "light_gray" } }
     int: "#a6a28c"
     filesize: {|e|
-      if $e == 0b {
-        "#a6a28c"
-      } else if $e < 1mb {
-        "#1fad83"
-      } else {{ fg: "#6684e1" }}
+        if $e == 0b {
+            "#a6a28c"
+        } else if $e < 1mb {
+            "#1fad83"
+        } else {{ fg: "#6684e1" }}
     }
     duration: "#a6a28c"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d73737" attr: "b" }
-      } else if $in < 6hr {
-        "#d73737"
-      } else if $in < 1day {
-        "#ae9513"
-      } else if $in < 3day {
-        "#60ac39"
-      } else if $in < 1wk {
-        { fg: "#60ac39" attr: "b" }
-      } else if $in < 6wk {
-        "#1fad83"
-      } else if $in < 52wk {
-        "#6684e1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d73737" attr: "b" }
+        } else if $in < 6hr {
+            "#d73737"
+        } else if $in < 1day {
+            "#ae9513"
+        } else if $in < 3day {
+            "#60ac39"
+        } else if $in < 1wk {
+            { fg: "#60ac39" attr: "b" }
+        } else if $in < 6wk {
+            "#1fad83"
+        } else if $in < 52wk {
+            "#6684e1"
+        } else { "dark_gray" }
     }
     range: "#a6a28c"
     float: "#a6a28c"

--- a/themes/themes/atelier-estuary-light.nu
+++ b/themes/themes/atelier-estuary-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5b9d48" } else { "light_gray" } }
     int: "#5f5e4e"
     filesize: {|e|
-      if $e == 0b {
-        "#5f5e4e"
-      } else if $e < 1mb {
-        "#5b9d48"
-      } else {{ fg: "#36a166" }}
+        if $e == 0b {
+            "#5f5e4e"
+        } else if $e < 1mb {
+            "#5b9d48"
+        } else {{ fg: "#36a166" }}
     }
     duration: "#5f5e4e"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ba6236" attr: "b" }
-      } else if $in < 6hr {
-        "#ba6236"
-      } else if $in < 1day {
-        "#a5980d"
-      } else if $in < 3day {
-        "#7d9726"
-      } else if $in < 1wk {
-        { fg: "#7d9726" attr: "b" }
-      } else if $in < 6wk {
-        "#5b9d48"
-      } else if $in < 52wk {
-        "#36a166"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ba6236" attr: "b" }
+        } else if $in < 6hr {
+            "#ba6236"
+        } else if $in < 1day {
+            "#a5980d"
+        } else if $in < 3day {
+            "#7d9726"
+        } else if $in < 1wk {
+            { fg: "#7d9726" attr: "b" }
+        } else if $in < 6wk {
+            "#5b9d48"
+        } else if $in < 52wk {
+            "#36a166"
+        } else { "dark_gray" }
     }
     range: "#5f5e4e"
     float: "#5f5e4e"

--- a/themes/themes/atelier-estuary.nu
+++ b/themes/themes/atelier-estuary.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5b9d48" } else { "light_gray" } }
     int: "#929181"
     filesize: {|e|
-      if $e == 0b {
-        "#929181"
-      } else if $e < 1mb {
-        "#5b9d48"
-      } else {{ fg: "#36a166" }}
+        if $e == 0b {
+            "#929181"
+        } else if $e < 1mb {
+            "#5b9d48"
+        } else {{ fg: "#36a166" }}
     }
     duration: "#929181"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ba6236" attr: "b" }
-      } else if $in < 6hr {
-        "#ba6236"
-      } else if $in < 1day {
-        "#a5980d"
-      } else if $in < 3day {
-        "#7d9726"
-      } else if $in < 1wk {
-        { fg: "#7d9726" attr: "b" }
-      } else if $in < 6wk {
-        "#5b9d48"
-      } else if $in < 52wk {
-        "#36a166"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ba6236" attr: "b" }
+        } else if $in < 6hr {
+            "#ba6236"
+        } else if $in < 1day {
+            "#a5980d"
+        } else if $in < 3day {
+            "#7d9726"
+        } else if $in < 1wk {
+            { fg: "#7d9726" attr: "b" }
+        } else if $in < 6wk {
+            "#5b9d48"
+        } else if $in < 52wk {
+            "#36a166"
+        } else { "dark_gray" }
     }
     range: "#929181"
     float: "#929181"

--- a/themes/themes/atelier-forest-light.nu
+++ b/themes/themes/atelier-forest-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3d97b8" } else { "light_gray" } }
     int: "#68615e"
     filesize: {|e|
-      if $e == 0b {
-        "#68615e"
-      } else if $e < 1mb {
-        "#3d97b8"
-      } else {{ fg: "#407ee7" }}
+        if $e == 0b {
+            "#68615e"
+        } else if $e < 1mb {
+            "#3d97b8"
+        } else {{ fg: "#407ee7" }}
     }
     duration: "#68615e"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f22c40" attr: "b" }
-      } else if $in < 6hr {
-        "#f22c40"
-      } else if $in < 1day {
-        "#c38418"
-      } else if $in < 3day {
-        "#7b9726"
-      } else if $in < 1wk {
-        { fg: "#7b9726" attr: "b" }
-      } else if $in < 6wk {
-        "#3d97b8"
-      } else if $in < 52wk {
-        "#407ee7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f22c40" attr: "b" }
+        } else if $in < 6hr {
+            "#f22c40"
+        } else if $in < 1day {
+            "#c38418"
+        } else if $in < 3day {
+            "#7b9726"
+        } else if $in < 1wk {
+            { fg: "#7b9726" attr: "b" }
+        } else if $in < 6wk {
+            "#3d97b8"
+        } else if $in < 52wk {
+            "#407ee7"
+        } else { "dark_gray" }
     }
     range: "#68615e"
     float: "#68615e"

--- a/themes/themes/atelier-forest.nu
+++ b/themes/themes/atelier-forest.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3d97b8" } else { "light_gray" } }
     int: "#a8a19f"
     filesize: {|e|
-      if $e == 0b {
-        "#a8a19f"
-      } else if $e < 1mb {
-        "#3d97b8"
-      } else {{ fg: "#407ee7" }}
+        if $e == 0b {
+            "#a8a19f"
+        } else if $e < 1mb {
+            "#3d97b8"
+        } else {{ fg: "#407ee7" }}
     }
     duration: "#a8a19f"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f22c40" attr: "b" }
-      } else if $in < 6hr {
-        "#f22c40"
-      } else if $in < 1day {
-        "#c38418"
-      } else if $in < 3day {
-        "#7b9726"
-      } else if $in < 1wk {
-        { fg: "#7b9726" attr: "b" }
-      } else if $in < 6wk {
-        "#3d97b8"
-      } else if $in < 52wk {
-        "#407ee7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f22c40" attr: "b" }
+        } else if $in < 6hr {
+            "#f22c40"
+        } else if $in < 1day {
+            "#c38418"
+        } else if $in < 3day {
+            "#7b9726"
+        } else if $in < 1wk {
+            { fg: "#7b9726" attr: "b" }
+        } else if $in < 6wk {
+            "#3d97b8"
+        } else if $in < 52wk {
+            "#407ee7"
+        } else { "dark_gray" }
     }
     range: "#a8a19f"
     float: "#a8a19f"

--- a/themes/themes/atelier-heath-light.nu
+++ b/themes/themes/atelier-heath-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#159393" } else { "light_gray" } }
     int: "#695d69"
     filesize: {|e|
-      if $e == 0b {
-        "#695d69"
-      } else if $e < 1mb {
-        "#159393"
-      } else {{ fg: "#516aec" }}
+        if $e == 0b {
+            "#695d69"
+        } else if $e < 1mb {
+            "#159393"
+        } else {{ fg: "#516aec" }}
     }
     duration: "#695d69"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ca402b" attr: "b" }
-      } else if $in < 6hr {
-        "#ca402b"
-      } else if $in < 1day {
-        "#bb8a35"
-      } else if $in < 3day {
-        "#918b3b"
-      } else if $in < 1wk {
-        { fg: "#918b3b" attr: "b" }
-      } else if $in < 6wk {
-        "#159393"
-      } else if $in < 52wk {
-        "#516aec"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ca402b" attr: "b" }
+        } else if $in < 6hr {
+            "#ca402b"
+        } else if $in < 1day {
+            "#bb8a35"
+        } else if $in < 3day {
+            "#918b3b"
+        } else if $in < 1wk {
+            { fg: "#918b3b" attr: "b" }
+        } else if $in < 6wk {
+            "#159393"
+        } else if $in < 52wk {
+            "#516aec"
+        } else { "dark_gray" }
     }
     range: "#695d69"
     float: "#695d69"

--- a/themes/themes/atelier-heath.nu
+++ b/themes/themes/atelier-heath.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#159393" } else { "light_gray" } }
     int: "#ab9bab"
     filesize: {|e|
-      if $e == 0b {
-        "#ab9bab"
-      } else if $e < 1mb {
-        "#159393"
-      } else {{ fg: "#516aec" }}
+        if $e == 0b {
+            "#ab9bab"
+        } else if $e < 1mb {
+            "#159393"
+        } else {{ fg: "#516aec" }}
     }
     duration: "#ab9bab"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ca402b" attr: "b" }
-      } else if $in < 6hr {
-        "#ca402b"
-      } else if $in < 1day {
-        "#bb8a35"
-      } else if $in < 3day {
-        "#918b3b"
-      } else if $in < 1wk {
-        { fg: "#918b3b" attr: "b" }
-      } else if $in < 6wk {
-        "#159393"
-      } else if $in < 52wk {
-        "#516aec"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ca402b" attr: "b" }
+        } else if $in < 6hr {
+            "#ca402b"
+        } else if $in < 1day {
+            "#bb8a35"
+        } else if $in < 3day {
+            "#918b3b"
+        } else if $in < 1wk {
+            { fg: "#918b3b" attr: "b" }
+        } else if $in < 6wk {
+            "#159393"
+        } else if $in < 52wk {
+            "#516aec"
+        } else { "dark_gray" }
     }
     range: "#ab9bab"
     float: "#ab9bab"

--- a/themes/themes/atelier-lakeside-light.nu
+++ b/themes/themes/atelier-lakeside-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2d8f6f" } else { "light_gray" } }
     int: "#516d7b"
     filesize: {|e|
-      if $e == 0b {
-        "#516d7b"
-      } else if $e < 1mb {
-        "#2d8f6f"
-      } else {{ fg: "#257fad" }}
+        if $e == 0b {
+            "#516d7b"
+        } else if $e < 1mb {
+            "#2d8f6f"
+        } else {{ fg: "#257fad" }}
     }
     duration: "#516d7b"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d22d72" attr: "b" }
-      } else if $in < 6hr {
-        "#d22d72"
-      } else if $in < 1day {
-        "#8a8a0f"
-      } else if $in < 3day {
-        "#568c3b"
-      } else if $in < 1wk {
-        { fg: "#568c3b" attr: "b" }
-      } else if $in < 6wk {
-        "#2d8f6f"
-      } else if $in < 52wk {
-        "#257fad"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d22d72" attr: "b" }
+        } else if $in < 6hr {
+            "#d22d72"
+        } else if $in < 1day {
+            "#8a8a0f"
+        } else if $in < 3day {
+            "#568c3b"
+        } else if $in < 1wk {
+            { fg: "#568c3b" attr: "b" }
+        } else if $in < 6wk {
+            "#2d8f6f"
+        } else if $in < 52wk {
+            "#257fad"
+        } else { "dark_gray" }
     }
     range: "#516d7b"
     float: "#516d7b"

--- a/themes/themes/atelier-lakeside.nu
+++ b/themes/themes/atelier-lakeside.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2d8f6f" } else { "light_gray" } }
     int: "#7ea2b4"
     filesize: {|e|
-      if $e == 0b {
-        "#7ea2b4"
-      } else if $e < 1mb {
-        "#2d8f6f"
-      } else {{ fg: "#257fad" }}
+        if $e == 0b {
+            "#7ea2b4"
+        } else if $e < 1mb {
+            "#2d8f6f"
+        } else {{ fg: "#257fad" }}
     }
     duration: "#7ea2b4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d22d72" attr: "b" }
-      } else if $in < 6hr {
-        "#d22d72"
-      } else if $in < 1day {
-        "#8a8a0f"
-      } else if $in < 3day {
-        "#568c3b"
-      } else if $in < 1wk {
-        { fg: "#568c3b" attr: "b" }
-      } else if $in < 6wk {
-        "#2d8f6f"
-      } else if $in < 52wk {
-        "#257fad"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d22d72" attr: "b" }
+        } else if $in < 6hr {
+            "#d22d72"
+        } else if $in < 1day {
+            "#8a8a0f"
+        } else if $in < 3day {
+            "#568c3b"
+        } else if $in < 1wk {
+            { fg: "#568c3b" attr: "b" }
+        } else if $in < 6wk {
+            "#2d8f6f"
+        } else if $in < 52wk {
+            "#257fad"
+        } else { "dark_gray" }
     }
     range: "#7ea2b4"
     float: "#7ea2b4"

--- a/themes/themes/atelier-plateau-light.nu
+++ b/themes/themes/atelier-plateau-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5485b6" } else { "light_gray" } }
     int: "#585050"
     filesize: {|e|
-      if $e == 0b {
-        "#585050"
-      } else if $e < 1mb {
-        "#5485b6"
-      } else {{ fg: "#7272ca" }}
+        if $e == 0b {
+            "#585050"
+        } else if $e < 1mb {
+            "#5485b6"
+        } else {{ fg: "#7272ca" }}
     }
     duration: "#585050"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ca4949" attr: "b" }
-      } else if $in < 6hr {
-        "#ca4949"
-      } else if $in < 1day {
-        "#a06e3b"
-      } else if $in < 3day {
-        "#4b8b8b"
-      } else if $in < 1wk {
-        { fg: "#4b8b8b" attr: "b" }
-      } else if $in < 6wk {
-        "#5485b6"
-      } else if $in < 52wk {
-        "#7272ca"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ca4949" attr: "b" }
+        } else if $in < 6hr {
+            "#ca4949"
+        } else if $in < 1day {
+            "#a06e3b"
+        } else if $in < 3day {
+            "#4b8b8b"
+        } else if $in < 1wk {
+            { fg: "#4b8b8b" attr: "b" }
+        } else if $in < 6wk {
+            "#5485b6"
+        } else if $in < 52wk {
+            "#7272ca"
+        } else { "dark_gray" }
     }
     range: "#585050"
     float: "#585050"

--- a/themes/themes/atelier-plateau.nu
+++ b/themes/themes/atelier-plateau.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5485b6" } else { "light_gray" } }
     int: "#8a8585"
     filesize: {|e|
-      if $e == 0b {
-        "#8a8585"
-      } else if $e < 1mb {
-        "#5485b6"
-      } else {{ fg: "#7272ca" }}
+        if $e == 0b {
+            "#8a8585"
+        } else if $e < 1mb {
+            "#5485b6"
+        } else {{ fg: "#7272ca" }}
     }
     duration: "#8a8585"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ca4949" attr: "b" }
-      } else if $in < 6hr {
-        "#ca4949"
-      } else if $in < 1day {
-        "#a06e3b"
-      } else if $in < 3day {
-        "#4b8b8b"
-      } else if $in < 1wk {
-        { fg: "#4b8b8b" attr: "b" }
-      } else if $in < 6wk {
-        "#5485b6"
-      } else if $in < 52wk {
-        "#7272ca"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ca4949" attr: "b" }
+        } else if $in < 6hr {
+            "#ca4949"
+        } else if $in < 1day {
+            "#a06e3b"
+        } else if $in < 3day {
+            "#4b8b8b"
+        } else if $in < 1wk {
+            { fg: "#4b8b8b" attr: "b" }
+        } else if $in < 6wk {
+            "#5485b6"
+        } else if $in < 52wk {
+            "#7272ca"
+        } else { "dark_gray" }
     }
     range: "#8a8585"
     float: "#8a8585"

--- a/themes/themes/atelier-savanna-light.nu
+++ b/themes/themes/atelier-savanna-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1c9aa0" } else { "light_gray" } }
     int: "#526057"
     filesize: {|e|
-      if $e == 0b {
-        "#526057"
-      } else if $e < 1mb {
-        "#1c9aa0"
-      } else {{ fg: "#478c90" }}
+        if $e == 0b {
+            "#526057"
+        } else if $e < 1mb {
+            "#1c9aa0"
+        } else {{ fg: "#478c90" }}
     }
     duration: "#526057"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b16139" attr: "b" }
-      } else if $in < 6hr {
-        "#b16139"
-      } else if $in < 1day {
-        "#a07e3b"
-      } else if $in < 3day {
-        "#489963"
-      } else if $in < 1wk {
-        { fg: "#489963" attr: "b" }
-      } else if $in < 6wk {
-        "#1c9aa0"
-      } else if $in < 52wk {
-        "#478c90"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b16139" attr: "b" }
+        } else if $in < 6hr {
+            "#b16139"
+        } else if $in < 1day {
+            "#a07e3b"
+        } else if $in < 3day {
+            "#489963"
+        } else if $in < 1wk {
+            { fg: "#489963" attr: "b" }
+        } else if $in < 6wk {
+            "#1c9aa0"
+        } else if $in < 52wk {
+            "#478c90"
+        } else { "dark_gray" }
     }
     range: "#526057"
     float: "#526057"

--- a/themes/themes/atelier-savanna.nu
+++ b/themes/themes/atelier-savanna.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1c9aa0" } else { "light_gray" } }
     int: "#87928a"
     filesize: {|e|
-      if $e == 0b {
-        "#87928a"
-      } else if $e < 1mb {
-        "#1c9aa0"
-      } else {{ fg: "#478c90" }}
+        if $e == 0b {
+            "#87928a"
+        } else if $e < 1mb {
+            "#1c9aa0"
+        } else {{ fg: "#478c90" }}
     }
     duration: "#87928a"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b16139" attr: "b" }
-      } else if $in < 6hr {
-        "#b16139"
-      } else if $in < 1day {
-        "#a07e3b"
-      } else if $in < 3day {
-        "#489963"
-      } else if $in < 1wk {
-        { fg: "#489963" attr: "b" }
-      } else if $in < 6wk {
-        "#1c9aa0"
-      } else if $in < 52wk {
-        "#478c90"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b16139" attr: "b" }
+        } else if $in < 6hr {
+            "#b16139"
+        } else if $in < 1day {
+            "#a07e3b"
+        } else if $in < 3day {
+            "#489963"
+        } else if $in < 1wk {
+            { fg: "#489963" attr: "b" }
+        } else if $in < 6wk {
+            "#1c9aa0"
+        } else if $in < 52wk {
+            "#478c90"
+        } else { "dark_gray" }
     }
     range: "#87928a"
     float: "#87928a"

--- a/themes/themes/atelier-seaside-light.nu
+++ b/themes/themes/atelier-seaside-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1999b3" } else { "light_gray" } }
     int: "#5e6e5e"
     filesize: {|e|
-      if $e == 0b {
-        "#5e6e5e"
-      } else if $e < 1mb {
-        "#1999b3"
-      } else {{ fg: "#3d62f5" }}
+        if $e == 0b {
+            "#5e6e5e"
+        } else if $e < 1mb {
+            "#1999b3"
+        } else {{ fg: "#3d62f5" }}
     }
     duration: "#5e6e5e"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e6193c" attr: "b" }
-      } else if $in < 6hr {
-        "#e6193c"
-      } else if $in < 1day {
-        "#98981b"
-      } else if $in < 3day {
-        "#29a329"
-      } else if $in < 1wk {
-        { fg: "#29a329" attr: "b" }
-      } else if $in < 6wk {
-        "#1999b3"
-      } else if $in < 52wk {
-        "#3d62f5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e6193c" attr: "b" }
+        } else if $in < 6hr {
+            "#e6193c"
+        } else if $in < 1day {
+            "#98981b"
+        } else if $in < 3day {
+            "#29a329"
+        } else if $in < 1wk {
+            { fg: "#29a329" attr: "b" }
+        } else if $in < 6wk {
+            "#1999b3"
+        } else if $in < 52wk {
+            "#3d62f5"
+        } else { "dark_gray" }
     }
     range: "#5e6e5e"
     float: "#5e6e5e"

--- a/themes/themes/atelier-seaside.nu
+++ b/themes/themes/atelier-seaside.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1999b3" } else { "light_gray" } }
     int: "#8ca68c"
     filesize: {|e|
-      if $e == 0b {
-        "#8ca68c"
-      } else if $e < 1mb {
-        "#1999b3"
-      } else {{ fg: "#3d62f5" }}
+        if $e == 0b {
+            "#8ca68c"
+        } else if $e < 1mb {
+            "#1999b3"
+        } else {{ fg: "#3d62f5" }}
     }
     duration: "#8ca68c"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e6193c" attr: "b" }
-      } else if $in < 6hr {
-        "#e6193c"
-      } else if $in < 1day {
-        "#98981b"
-      } else if $in < 3day {
-        "#29a329"
-      } else if $in < 1wk {
-        { fg: "#29a329" attr: "b" }
-      } else if $in < 6wk {
-        "#1999b3"
-      } else if $in < 52wk {
-        "#3d62f5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e6193c" attr: "b" }
+        } else if $in < 6hr {
+            "#e6193c"
+        } else if $in < 1day {
+            "#98981b"
+        } else if $in < 3day {
+            "#29a329"
+        } else if $in < 1wk {
+            { fg: "#29a329" attr: "b" }
+        } else if $in < 6wk {
+            "#1999b3"
+        } else if $in < 52wk {
+            "#3d62f5"
+        } else { "dark_gray" }
     }
     range: "#8ca68c"
     float: "#8ca68c"

--- a/themes/themes/atelier-sulphurpool-light.nu
+++ b/themes/themes/atelier-sulphurpool-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#22a2c9" } else { "light_gray" } }
     int: "#5e6687"
     filesize: {|e|
-      if $e == 0b {
-        "#5e6687"
-      } else if $e < 1mb {
-        "#22a2c9"
-      } else {{ fg: "#3d8fd1" }}
+        if $e == 0b {
+            "#5e6687"
+        } else if $e < 1mb {
+            "#22a2c9"
+        } else {{ fg: "#3d8fd1" }}
     }
     duration: "#5e6687"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c94922" attr: "b" }
-      } else if $in < 6hr {
-        "#c94922"
-      } else if $in < 1day {
-        "#c08b30"
-      } else if $in < 3day {
-        "#ac9739"
-      } else if $in < 1wk {
-        { fg: "#ac9739" attr: "b" }
-      } else if $in < 6wk {
-        "#22a2c9"
-      } else if $in < 52wk {
-        "#3d8fd1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c94922" attr: "b" }
+        } else if $in < 6hr {
+            "#c94922"
+        } else if $in < 1day {
+            "#c08b30"
+        } else if $in < 3day {
+            "#ac9739"
+        } else if $in < 1wk {
+            { fg: "#ac9739" attr: "b" }
+        } else if $in < 6wk {
+            "#22a2c9"
+        } else if $in < 52wk {
+            "#3d8fd1"
+        } else { "dark_gray" }
     }
     range: "#5e6687"
     float: "#5e6687"

--- a/themes/themes/atelier-sulphurpool.nu
+++ b/themes/themes/atelier-sulphurpool.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#22a2c9" } else { "light_gray" } }
     int: "#979db4"
     filesize: {|e|
-      if $e == 0b {
-        "#979db4"
-      } else if $e < 1mb {
-        "#22a2c9"
-      } else {{ fg: "#3d8fd1" }}
+        if $e == 0b {
+            "#979db4"
+        } else if $e < 1mb {
+            "#22a2c9"
+        } else {{ fg: "#3d8fd1" }}
     }
     duration: "#979db4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c94922" attr: "b" }
-      } else if $in < 6hr {
-        "#c94922"
-      } else if $in < 1day {
-        "#c08b30"
-      } else if $in < 3day {
-        "#ac9739"
-      } else if $in < 1wk {
-        { fg: "#ac9739" attr: "b" }
-      } else if $in < 6wk {
-        "#22a2c9"
-      } else if $in < 52wk {
-        "#3d8fd1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c94922" attr: "b" }
+        } else if $in < 6hr {
+            "#c94922"
+        } else if $in < 1day {
+            "#c08b30"
+        } else if $in < 3day {
+            "#ac9739"
+        } else if $in < 1wk {
+            { fg: "#ac9739" attr: "b" }
+        } else if $in < 6wk {
+            "#22a2c9"
+        } else if $in < 52wk {
+            "#3d8fd1"
+        } else { "dark_gray" }
     }
     range: "#979db4"
     float: "#979db4"

--- a/themes/themes/atlas.nu
+++ b/themes/themes/atlas.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#14747e" } else { "light_gray" } }
     int: "#a1a19a"
     filesize: {|e|
-      if $e == 0b {
-        "#a1a19a"
-      } else if $e < 1mb {
-        "#14747e"
-      } else {{ fg: "#5dd7b9" }}
+        if $e == 0b {
+            "#a1a19a"
+        } else if $e < 1mb {
+            "#14747e"
+        } else {{ fg: "#5dd7b9" }}
     }
     duration: "#a1a19a"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff5a67" attr: "b" }
-      } else if $in < 6hr {
-        "#ff5a67"
-      } else if $in < 1day {
-        "#ffcc1b"
-      } else if $in < 3day {
-        "#7fc06e"
-      } else if $in < 1wk {
-        { fg: "#7fc06e" attr: "b" }
-      } else if $in < 6wk {
-        "#14747e"
-      } else if $in < 52wk {
-        "#5dd7b9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff5a67" attr: "b" }
+        } else if $in < 6hr {
+            "#ff5a67"
+        } else if $in < 1day {
+            "#ffcc1b"
+        } else if $in < 3day {
+            "#7fc06e"
+        } else if $in < 1wk {
+            { fg: "#7fc06e" attr: "b" }
+        } else if $in < 6wk {
+            "#14747e"
+        } else if $in < 52wk {
+            "#5dd7b9"
+        } else { "dark_gray" }
     }
     range: "#a1a19a"
     float: "#a1a19a"

--- a/themes/themes/atom-one-light.nu
+++ b/themes/themes/atom-one-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3e953a" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#3e953a"
-      } else {{ fg: "#2f5af3" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#3e953a"
+        } else {{ fg: "#2f5af3" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#de3d35" attr: "b" }
-      } else if $in < 6hr {
-        "#de3d35"
-      } else if $in < 1day {
-        "#d2b67b"
-      } else if $in < 3day {
-        "#3e953a"
-      } else if $in < 1wk {
-        { fg: "#3e953a" attr: "b" }
-      } else if $in < 6wk {
-        "#3e953a"
-      } else if $in < 52wk {
-        "#2f5af3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#de3d35" attr: "b" }
+        } else if $in < 6hr {
+            "#de3d35"
+        } else if $in < 1day {
+            "#d2b67b"
+        } else if $in < 3day {
+            "#3e953a"
+        } else if $in < 1wk {
+            { fg: "#3e953a" attr: "b" }
+        } else if $in < 6wk {
+            "#3e953a"
+        } else if $in < 52wk {
+            "#2f5af3"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/atom.nu
+++ b/themes/themes/atom.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#85befd" } else { "light_gray" } }
     int: "#e0e0e0"
     filesize: {|e|
-      if $e == 0b {
-        "#e0e0e0"
-      } else if $e < 1mb {
-        "#85befd"
-      } else {{ fg: "#85befd" }}
+        if $e == 0b {
+            "#e0e0e0"
+        } else if $e < 1mb {
+            "#85befd"
+        } else {{ fg: "#85befd" }}
     }
     duration: "#e0e0e0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fd5ff1" attr: "b" }
-      } else if $in < 6hr {
-        "#fd5ff1"
-      } else if $in < 1day {
-        "#ffd7b1"
-      } else if $in < 3day {
-        "#87c38a"
-      } else if $in < 1wk {
-        { fg: "#87c38a" attr: "b" }
-      } else if $in < 6wk {
-        "#85befd"
-      } else if $in < 52wk {
-        "#85befd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fd5ff1" attr: "b" }
+        } else if $in < 6hr {
+            "#fd5ff1"
+        } else if $in < 1day {
+            "#ffd7b1"
+        } else if $in < 3day {
+            "#87c38a"
+        } else if $in < 1wk {
+            { fg: "#87c38a" attr: "b" }
+        } else if $in < 6wk {
+            "#85befd"
+        } else if $in < 52wk {
+            "#85befd"
+        } else { "dark_gray" }
     }
     range: "#e0e0e0"
     float: "#e0e0e0"

--- a/themes/themes/ayu-light.nu
+++ b/themes/themes/ayu-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7ff0cb" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#4cbe99"
-      } else {{ fg: "#41a6d9" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#4cbe99"
+        } else {{ fg: "#41a6d9" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff3333" attr: "b" }
-      } else if $in < 6hr {
-        "#ff3333"
-      } else if $in < 1day {
-        "#f19618"
-      } else if $in < 3day {
-        "#86b200"
-      } else if $in < 1wk {
-        { fg: "#86b200" attr: "b" }
-      } else if $in < 6wk {
-        "#4cbe99"
-      } else if $in < 52wk {
-        "#41a6d9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff3333" attr: "b" }
+        } else if $in < 6hr {
+            "#ff3333"
+        } else if $in < 1day {
+            "#f19618"
+        } else if $in < 3day {
+            "#86b200"
+        } else if $in < 1wk {
+            { fg: "#86b200" attr: "b" }
+        } else if $in < 6wk {
+            "#4cbe99"
+        } else if $in < 52wk {
+            "#41a6d9"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/ayu-mirage-simple-cursor.nu
+++ b/themes/themes/ayu-mirage-simple-cursor.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#95e6cb" } else { "light_gray" } }
     int: "#c7c7c7"
     filesize: {|e|
-      if $e == 0b {
-        "#c7c7c7"
-      } else if $e < 1mb {
-        "#90e1c6"
-      } else {{ fg: "#6dcbfa" }}
+        if $e == 0b {
+            "#c7c7c7"
+        } else if $e < 1mb {
+            "#90e1c6"
+        } else {{ fg: "#6dcbfa" }}
     }
     duration: "#c7c7c7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ed8274" attr: "b" }
-      } else if $in < 6hr {
-        "#ed8274"
-      } else if $in < 1day {
-        "#fad07b"
-      } else if $in < 3day {
-        "#a6cc70"
-      } else if $in < 1wk {
-        { fg: "#a6cc70" attr: "b" }
-      } else if $in < 6wk {
-        "#90e1c6"
-      } else if $in < 52wk {
-        "#6dcbfa"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ed8274" attr: "b" }
+        } else if $in < 6hr {
+            "#ed8274"
+        } else if $in < 1day {
+            "#fad07b"
+        } else if $in < 3day {
+            "#a6cc70"
+        } else if $in < 1wk {
+            { fg: "#a6cc70" attr: "b" }
+        } else if $in < 6wk {
+            "#90e1c6"
+        } else if $in < 52wk {
+            "#6dcbfa"
+        } else { "dark_gray" }
     }
     range: "#c7c7c7"
     float: "#c7c7c7"

--- a/themes/themes/ayu-mirage.nu
+++ b/themes/themes/ayu-mirage.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#95e6cb" } else { "light_gray" } }
     int: "#c7c7c7"
     filesize: {|e|
-      if $e == 0b {
-        "#c7c7c7"
-      } else if $e < 1mb {
-        "#90e1c6"
-      } else {{ fg: "#6dcbfa" }}
+        if $e == 0b {
+            "#c7c7c7"
+        } else if $e < 1mb {
+            "#90e1c6"
+        } else {{ fg: "#6dcbfa" }}
     }
     duration: "#c7c7c7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ed8274" attr: "b" }
-      } else if $in < 6hr {
-        "#ed8274"
-      } else if $in < 1day {
-        "#fad07b"
-      } else if $in < 3day {
-        "#a6cc70"
-      } else if $in < 1wk {
-        { fg: "#a6cc70" attr: "b" }
-      } else if $in < 6wk {
-        "#90e1c6"
-      } else if $in < 52wk {
-        "#6dcbfa"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ed8274" attr: "b" }
+        } else if $in < 6hr {
+            "#ed8274"
+        } else if $in < 1day {
+            "#fad07b"
+        } else if $in < 3day {
+            "#a6cc70"
+        } else if $in < 1wk {
+            { fg: "#a6cc70" attr: "b" }
+        } else if $in < 6wk {
+            "#90e1c6"
+        } else if $in < 52wk {
+            "#6dcbfa"
+        } else { "dark_gray" }
     }
     range: "#c7c7c7"
     float: "#c7c7c7"

--- a/themes/themes/ayu.nu
+++ b/themes/themes/ayu.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c7fffc" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#95e5cb"
-      } else {{ fg: "#36a3d9" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#95e5cb"
+        } else {{ fg: "#36a3d9" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff3333" attr: "b" }
-      } else if $in < 6hr {
-        "#ff3333"
-      } else if $in < 1day {
-        "#e6c446"
-      } else if $in < 3day {
-        "#b8cc52"
-      } else if $in < 1wk {
-        { fg: "#b8cc52" attr: "b" }
-      } else if $in < 6wk {
-        "#95e5cb"
-      } else if $in < 52wk {
-        "#36a3d9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff3333" attr: "b" }
+        } else if $in < 6hr {
+            "#ff3333"
+        } else if $in < 1day {
+            "#e6c446"
+        } else if $in < 3day {
+            "#b8cc52"
+        } else if $in < 1wk {
+            { fg: "#b8cc52" attr: "b" }
+        } else if $in < 6wk {
+            "#95e5cb"
+        } else if $in < 52wk {
+            "#36a3d9"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/azu.nu
+++ b/themes/themes/azu.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b8d6d3" } else { "light_gray" } }
     int: "#e6e6e6"
     filesize: {|e|
-      if $e == 0b {
-        "#e6e6e6"
-      } else if $e < 1mb {
-        "#6daca4"
-      } else {{ fg: "#6d74ac" }}
+        if $e == 0b {
+            "#e6e6e6"
+        } else if $e < 1mb {
+            "#6daca4"
+        } else {{ fg: "#6d74ac" }}
     }
     duration: "#e6e6e6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ac6d74" attr: "b" }
-      } else if $in < 6hr {
-        "#ac6d74"
-      } else if $in < 1day {
-        "#aca46d"
-      } else if $in < 3day {
-        "#74ac6d"
-      } else if $in < 1wk {
-        { fg: "#74ac6d" attr: "b" }
-      } else if $in < 6wk {
-        "#6daca4"
-      } else if $in < 52wk {
-        "#6d74ac"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ac6d74" attr: "b" }
+        } else if $in < 6hr {
+            "#ac6d74"
+        } else if $in < 1day {
+            "#aca46d"
+        } else if $in < 3day {
+            "#74ac6d"
+        } else if $in < 1wk {
+            { fg: "#74ac6d" attr: "b" }
+        } else if $in < 6wk {
+            "#6daca4"
+        } else if $in < 52wk {
+            "#6d74ac"
+        } else { "dark_gray" }
     }
     range: "#e6e6e6"
     float: "#e6e6e6"

--- a/themes/themes/batman.nu
+++ b/themes/themes/batman.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a2a2a5" } else { "light_gray" } }
     int: "#c5c5be"
     filesize: {|e|
-      if $e == 0b {
-        "#c5c5be"
-      } else if $e < 1mb {
-        "#615f5e"
-      } else {{ fg: "#737074" }}
+        if $e == 0b {
+            "#c5c5be"
+        } else if $e < 1mb {
+            "#615f5e"
+        } else {{ fg: "#737074" }}
     }
     duration: "#c5c5be"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e6db43" attr: "b" }
-      } else if $in < 6hr {
-        "#e6db43"
-      } else if $in < 1day {
-        "#f3fd21"
-      } else if $in < 3day {
-        "#c8be46"
-      } else if $in < 1wk {
-        { fg: "#c8be46" attr: "b" }
-      } else if $in < 6wk {
-        "#615f5e"
-      } else if $in < 52wk {
-        "#737074"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e6db43" attr: "b" }
+        } else if $in < 6hr {
+            "#e6db43"
+        } else if $in < 1day {
+            "#f3fd21"
+        } else if $in < 3day {
+            "#c8be46"
+        } else if $in < 1wk {
+            { fg: "#c8be46" attr: "b" }
+        } else if $in < 6wk {
+            "#615f5e"
+        } else if $in < 52wk {
+            "#737074"
+        } else { "dark_gray" }
     }
     range: "#c5c5be"
     float: "#c5c5be"

--- a/themes/themes/belafonte-day.nu
+++ b/themes/themes/belafonte-day.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#989a9c" } else { "light_gray" } }
     int: "#968c83"
     filesize: {|e|
-      if $e == 0b {
-        "#968c83"
-      } else if $e < 1mb {
-        "#989a9c"
-      } else {{ fg: "#426a79" }}
+        if $e == 0b {
+            "#968c83"
+        } else if $e < 1mb {
+            "#989a9c"
+        } else {{ fg: "#426a79" }}
     }
     duration: "#968c83"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#be100e" attr: "b" }
-      } else if $in < 6hr {
-        "#be100e"
-      } else if $in < 1day {
-        "#eaa549"
-      } else if $in < 3day {
-        "#858162"
-      } else if $in < 1wk {
-        { fg: "#858162" attr: "b" }
-      } else if $in < 6wk {
-        "#989a9c"
-      } else if $in < 52wk {
-        "#426a79"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#be100e" attr: "b" }
+        } else if $in < 6hr {
+            "#be100e"
+        } else if $in < 1day {
+            "#eaa549"
+        } else if $in < 3day {
+            "#858162"
+        } else if $in < 1wk {
+            { fg: "#858162" attr: "b" }
+        } else if $in < 6wk {
+            "#989a9c"
+        } else if $in < 52wk {
+            "#426a79"
+        } else { "dark_gray" }
     }
     range: "#968c83"
     float: "#968c83"

--- a/themes/themes/belafonte-night.nu
+++ b/themes/themes/belafonte-night.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#989a9c" } else { "light_gray" } }
     int: "#968c83"
     filesize: {|e|
-      if $e == 0b {
-        "#968c83"
-      } else if $e < 1mb {
-        "#989a9c"
-      } else {{ fg: "#426a79" }}
+        if $e == 0b {
+            "#968c83"
+        } else if $e < 1mb {
+            "#989a9c"
+        } else {{ fg: "#426a79" }}
     }
     duration: "#968c83"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#be100e" attr: "b" }
-      } else if $in < 6hr {
-        "#be100e"
-      } else if $in < 1day {
-        "#eaa549"
-      } else if $in < 3day {
-        "#858162"
-      } else if $in < 1wk {
-        { fg: "#858162" attr: "b" }
-      } else if $in < 6wk {
-        "#989a9c"
-      } else if $in < 52wk {
-        "#426a79"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#be100e" attr: "b" }
+        } else if $in < 6hr {
+            "#be100e"
+        } else if $in < 1day {
+            "#eaa549"
+        } else if $in < 3day {
+            "#858162"
+        } else if $in < 1wk {
+            { fg: "#858162" attr: "b" }
+        } else if $in < 6wk {
+            "#989a9c"
+        } else if $in < 52wk {
+            "#426a79"
+        } else { "dark_gray" }
     }
     range: "#968c83"
     float: "#968c83"

--- a/themes/themes/bespin.nu
+++ b/themes/themes/bespin.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#afc4db" } else { "light_gray" } }
     int: "#8a8986"
     filesize: {|e|
-      if $e == 0b {
-        "#8a8986"
-      } else if $e < 1mb {
-        "#afc4db"
-      } else {{ fg: "#5ea6ea" }}
+        if $e == 0b {
+            "#8a8986"
+        } else if $e < 1mb {
+            "#afc4db"
+        } else {{ fg: "#5ea6ea" }}
     }
     duration: "#8a8986"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cf6a4c" attr: "b" }
-      } else if $in < 6hr {
-        "#cf6a4c"
-      } else if $in < 1day {
-        "#f9ee98"
-      } else if $in < 3day {
-        "#54be0d"
-      } else if $in < 1wk {
-        { fg: "#54be0d" attr: "b" }
-      } else if $in < 6wk {
-        "#afc4db"
-      } else if $in < 52wk {
-        "#5ea6ea"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cf6a4c" attr: "b" }
+        } else if $in < 6hr {
+            "#cf6a4c"
+        } else if $in < 1day {
+            "#f9ee98"
+        } else if $in < 3day {
+            "#54be0d"
+        } else if $in < 1wk {
+            { fg: "#54be0d" attr: "b" }
+        } else if $in < 6wk {
+            "#afc4db"
+        } else if $in < 52wk {
+            "#5ea6ea"
+        } else { "dark_gray" }
     }
     range: "#8a8986"
     float: "#8a8986"

--- a/themes/themes/bim.nu
+++ b/themes/themes/bim.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#81eeb2" } else { "light_gray" } }
     int: "#918988"
     filesize: {|e|
-      if $e == 0b {
-        "#918988"
-      } else if $e < 1mb {
-        "#5eeea0"
-      } else {{ fg: "#5ea2ec" }}
+        if $e == 0b {
+            "#918988"
+        } else if $e < 1mb {
+            "#5eeea0"
+        } else {{ fg: "#5ea2ec" }}
     }
     duration: "#918988"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f557a0" attr: "b" }
-      } else if $in < 6hr {
-        "#f557a0"
-      } else if $in < 1day {
-        "#f5a255"
-      } else if $in < 3day {
-        "#a9ee55"
-      } else if $in < 1wk {
-        { fg: "#a9ee55" attr: "b" }
-      } else if $in < 6wk {
-        "#5eeea0"
-      } else if $in < 52wk {
-        "#5ea2ec"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f557a0" attr: "b" }
+        } else if $in < 6hr {
+            "#f557a0"
+        } else if $in < 1day {
+            "#f5a255"
+        } else if $in < 3day {
+            "#a9ee55"
+        } else if $in < 1wk {
+            { fg: "#a9ee55" attr: "b" }
+        } else if $in < 6wk {
+            "#5eeea0"
+        } else if $in < 52wk {
+            "#5ea2ec"
+        } else { "dark_gray" }
     }
     range: "#918988"
     float: "#918988"

--- a/themes/themes/birds-of-paradise.nu
+++ b/themes/themes/birds-of-paradise.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#93cfd7" } else { "light_gray" } }
     int: "#e0dbb7"
     filesize: {|e|
-      if $e == 0b {
-        "#e0dbb7"
-      } else if $e < 1mb {
-        "#74a6ad"
-      } else {{ fg: "#5a86ad" }}
+        if $e == 0b {
+            "#e0dbb7"
+        } else if $e < 1mb {
+            "#74a6ad"
+        } else {{ fg: "#5a86ad" }}
     }
     duration: "#e0dbb7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#be2d26" attr: "b" }
-      } else if $in < 6hr {
-        "#be2d26"
-      } else if $in < 1day {
-        "#e99d2a"
-      } else if $in < 3day {
-        "#6ba18a"
-      } else if $in < 1wk {
-        { fg: "#6ba18a" attr: "b" }
-      } else if $in < 6wk {
-        "#74a6ad"
-      } else if $in < 52wk {
-        "#5a86ad"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#be2d26" attr: "b" }
+        } else if $in < 6hr {
+            "#be2d26"
+        } else if $in < 1day {
+            "#e99d2a"
+        } else if $in < 3day {
+            "#6ba18a"
+        } else if $in < 1wk {
+            { fg: "#6ba18a" attr: "b" }
+        } else if $in < 6wk {
+            "#74a6ad"
+        } else if $in < 52wk {
+            "#5a86ad"
+        } else { "dark_gray" }
     }
     range: "#e0dbb7"
     float: "#e0dbb7"

--- a/themes/themes/black-metal-bathory.nu
+++ b/themes/themes/black-metal-bathory.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#e78a53"
-      } else if $in < 3day {
-        "#fbcb97"
-      } else if $in < 1wk {
-        { fg: "#fbcb97" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#e78a53"
+        } else if $in < 3day {
+            "#fbcb97"
+        } else if $in < 1wk {
+            { fg: "#fbcb97" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal-burzum.nu
+++ b/themes/themes/black-metal-burzum.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#99bbaa"
-      } else if $in < 3day {
-        "#ddeecc"
-      } else if $in < 1wk {
-        { fg: "#ddeecc" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#99bbaa"
+        } else if $in < 3day {
+            "#ddeecc"
+        } else if $in < 1wk {
+            { fg: "#ddeecc" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal-dark-funeral.nu
+++ b/themes/themes/black-metal-dark-funeral.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#5f81a5"
-      } else if $in < 3day {
-        "#d0dfee"
-      } else if $in < 1wk {
-        { fg: "#d0dfee" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#5f81a5"
+        } else if $in < 3day {
+            "#d0dfee"
+        } else if $in < 1wk {
+            { fg: "#d0dfee" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal-gorgoroth.nu
+++ b/themes/themes/black-metal-gorgoroth.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#8c7f70"
-      } else if $in < 3day {
-        "#9b8d7f"
-      } else if $in < 1wk {
-        { fg: "#9b8d7f" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#8c7f70"
+        } else if $in < 3day {
+            "#9b8d7f"
+        } else if $in < 1wk {
+            { fg: "#9b8d7f" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal-immortal.nu
+++ b/themes/themes/black-metal-immortal.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#556677"
-      } else if $in < 3day {
-        "#7799bb"
-      } else if $in < 1wk {
-        { fg: "#7799bb" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#556677"
+        } else if $in < 3day {
+            "#7799bb"
+        } else if $in < 1wk {
+            { fg: "#7799bb" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal-khold.nu
+++ b/themes/themes/black-metal-khold.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#974b46"
-      } else if $in < 3day {
-        "#eceee3"
-      } else if $in < 1wk {
-        { fg: "#eceee3" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#974b46"
+        } else if $in < 3day {
+            "#eceee3"
+        } else if $in < 1wk {
+            { fg: "#eceee3" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal-marduk.nu
+++ b/themes/themes/black-metal-marduk.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#626b67"
-      } else if $in < 3day {
-        "#a5aaa7"
-      } else if $in < 1wk {
-        { fg: "#a5aaa7" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#626b67"
+        } else if $in < 3day {
+            "#a5aaa7"
+        } else if $in < 1wk {
+            { fg: "#a5aaa7" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal-mayhem.nu
+++ b/themes/themes/black-metal-mayhem.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#eecc6c"
-      } else if $in < 3day {
-        "#f3ecd4"
-      } else if $in < 1wk {
-        { fg: "#f3ecd4" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#eecc6c"
+        } else if $in < 3day {
+            "#f3ecd4"
+        } else if $in < 1wk {
+            { fg: "#f3ecd4" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal-nile.nu
+++ b/themes/themes/black-metal-nile.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#777755"
-      } else if $in < 3day {
-        "#aa9988"
-      } else if $in < 1wk {
-        { fg: "#aa9988" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#777755"
+        } else if $in < 3day {
+            "#aa9988"
+        } else if $in < 1wk {
+            { fg: "#aa9988" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal-venom.nu
+++ b/themes/themes/black-metal-venom.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#79241f"
-      } else if $in < 3day {
-        "#f8f7f2"
-      } else if $in < 1wk {
-        { fg: "#f8f7f2" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#79241f"
+        } else if $in < 3day {
+            "#f8f7f2"
+        } else if $in < 1wk {
+            { fg: "#f8f7f2" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/black-metal.nu
+++ b/themes/themes/black-metal.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aaaaaa" } else { "light_gray" } }
     int: "#c1c1c1"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c1c1"
-      } else if $e < 1mb {
-        "#aaaaaa"
-      } else {{ fg: "#888888" }}
+        if $e == 0b {
+            "#c1c1c1"
+        } else if $e < 1mb {
+            "#aaaaaa"
+        } else {{ fg: "#888888" }}
     }
     duration: "#c1c1c1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f8787" attr: "b" }
-      } else if $in < 6hr {
-        "#5f8787"
-      } else if $in < 1day {
-        "#a06666"
-      } else if $in < 3day {
-        "#dd9999"
-      } else if $in < 1wk {
-        { fg: "#dd9999" attr: "b" }
-      } else if $in < 6wk {
-        "#aaaaaa"
-      } else if $in < 52wk {
-        "#888888"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f8787" attr: "b" }
+        } else if $in < 6hr {
+            "#5f8787"
+        } else if $in < 1day {
+            "#a06666"
+        } else if $in < 3day {
+            "#dd9999"
+        } else if $in < 1wk {
+            { fg: "#dd9999" attr: "b" }
+        } else if $in < 6wk {
+            "#aaaaaa"
+        } else if $in < 52wk {
+            "#888888"
+        } else { "dark_gray" }
     }
     range: "#c1c1c1"
     float: "#c1c1c1"

--- a/themes/themes/blazer.nu
+++ b/themes/themes/blazer.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#bddbdb" } else { "light_gray" } }
     int: "#d9d9d9"
     filesize: {|e|
-      if $e == 0b {
-        "#d9d9d9"
-      } else if $e < 1mb {
-        "#7ab8b8"
-      } else {{ fg: "#7a7ab8" }}
+        if $e == 0b {
+            "#d9d9d9"
+        } else if $e < 1mb {
+            "#7ab8b8"
+        } else {{ fg: "#7a7ab8" }}
     }
     duration: "#d9d9d9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b87a7a" attr: "b" }
-      } else if $in < 6hr {
-        "#b87a7a"
-      } else if $in < 1day {
-        "#b8b87a"
-      } else if $in < 3day {
-        "#7ab87a"
-      } else if $in < 1wk {
-        { fg: "#7ab87a" attr: "b" }
-      } else if $in < 6wk {
-        "#7ab8b8"
-      } else if $in < 52wk {
-        "#7a7ab8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b87a7a" attr: "b" }
+        } else if $in < 6hr {
+            "#b87a7a"
+        } else if $in < 1day {
+            "#b8b87a"
+        } else if $in < 3day {
+            "#7ab87a"
+        } else if $in < 1wk {
+            { fg: "#7ab87a" attr: "b" }
+        } else if $in < 6wk {
+            "#7ab8b8"
+        } else if $in < 52wk {
+            "#7a7ab8"
+        } else { "dark_gray" }
     }
     range: "#d9d9d9"
     float: "#d9d9d9"

--- a/themes/themes/borland.nu
+++ b/themes/themes/borland.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#dfdffe" } else { "light_gray" } }
     int: "#eeeeee"
     filesize: {|e|
-      if $e == 0b {
-        "#eeeeee"
-      } else if $e < 1mb {
-        "#c6c5fe"
-      } else {{ fg: "#96cbfe" }}
+        if $e == 0b {
+            "#eeeeee"
+        } else if $e < 1mb {
+            "#c6c5fe"
+        } else {{ fg: "#96cbfe" }}
     }
     duration: "#eeeeee"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff6c60" attr: "b" }
-      } else if $in < 6hr {
-        "#ff6c60"
-      } else if $in < 1day {
-        "#ffffb6"
-      } else if $in < 3day {
-        "#a8ff60"
-      } else if $in < 1wk {
-        { fg: "#a8ff60" attr: "b" }
-      } else if $in < 6wk {
-        "#c6c5fe"
-      } else if $in < 52wk {
-        "#96cbfe"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff6c60" attr: "b" }
+        } else if $in < 6hr {
+            "#ff6c60"
+        } else if $in < 1day {
+            "#ffffb6"
+        } else if $in < 3day {
+            "#a8ff60"
+        } else if $in < 1wk {
+            { fg: "#a8ff60" attr: "b" }
+        } else if $in < 6wk {
+            "#c6c5fe"
+        } else if $in < 52wk {
+            "#96cbfe"
+        } else { "dark_gray" }
     }
     range: "#eeeeee"
     float: "#eeeeee"

--- a/themes/themes/brewer.nu
+++ b/themes/themes/brewer.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#80b1d3" } else { "light_gray" } }
     int: "#b7b8b9"
     filesize: {|e|
-      if $e == 0b {
-        "#b7b8b9"
-      } else if $e < 1mb {
-        "#80b1d3"
-      } else {{ fg: "#3182bd" }}
+        if $e == 0b {
+            "#b7b8b9"
+        } else if $e < 1mb {
+            "#80b1d3"
+        } else {{ fg: "#3182bd" }}
     }
     duration: "#b7b8b9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e31a1c" attr: "b" }
-      } else if $in < 6hr {
-        "#e31a1c"
-      } else if $in < 1day {
-        "#dca060"
-      } else if $in < 3day {
-        "#31a354"
-      } else if $in < 1wk {
-        { fg: "#31a354" attr: "b" }
-      } else if $in < 6wk {
-        "#80b1d3"
-      } else if $in < 52wk {
-        "#3182bd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e31a1c" attr: "b" }
+        } else if $in < 6hr {
+            "#e31a1c"
+        } else if $in < 1day {
+            "#dca060"
+        } else if $in < 3day {
+            "#31a354"
+        } else if $in < 1wk {
+            { fg: "#31a354" attr: "b" }
+        } else if $in < 6wk {
+            "#80b1d3"
+        } else if $in < 52wk {
+            "#3182bd"
+        } else { "dark_gray" }
     }
     range: "#b7b8b9"
     float: "#b7b8b9"

--- a/themes/themes/bright-lights.nu
+++ b/themes/themes/bright-lights.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#6cbeb5" } else { "light_gray" } }
     int: "#c1c8d6"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c8d6"
-      } else if $e < 1mb {
-        "#6cbeb5"
-      } else {{ fg: "#75d3ff" }}
+        if $e == 0b {
+            "#c1c8d6"
+        } else if $e < 1mb {
+            "#6cbeb5"
+        } else {{ fg: "#75d3ff" }}
     }
     duration: "#c1c8d6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff355b" attr: "b" }
-      } else if $in < 6hr {
-        "#ff355b"
-      } else if $in < 1day {
-        "#ffc150"
-      } else if $in < 3day {
-        "#b6e875"
-      } else if $in < 1wk {
-        { fg: "#b6e875" attr: "b" }
-      } else if $in < 6wk {
-        "#6cbeb5"
-      } else if $in < 52wk {
-        "#75d3ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff355b" attr: "b" }
+        } else if $in < 6hr {
+            "#ff355b"
+        } else if $in < 1day {
+            "#ffc150"
+        } else if $in < 3day {
+            "#b6e875"
+        } else if $in < 1wk {
+            { fg: "#b6e875" attr: "b" }
+        } else if $in < 6wk {
+            "#6cbeb5"
+        } else if $in < 52wk {
+            "#75d3ff"
+        } else { "dark_gray" }
     }
     range: "#c1c8d6"
     float: "#c1c8d6"

--- a/themes/themes/bright.nu
+++ b/themes/themes/bright.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#76c7b7" } else { "light_gray" } }
     int: "#e0e0e0"
     filesize: {|e|
-      if $e == 0b {
-        "#e0e0e0"
-      } else if $e < 1mb {
-        "#76c7b7"
-      } else {{ fg: "#6fb3d2" }}
+        if $e == 0b {
+            "#e0e0e0"
+        } else if $e < 1mb {
+            "#76c7b7"
+        } else {{ fg: "#6fb3d2" }}
     }
     duration: "#e0e0e0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb0120" attr: "b" }
-      } else if $in < 6hr {
-        "#fb0120"
-      } else if $in < 1day {
-        "#fda331"
-      } else if $in < 3day {
-        "#a1c659"
-      } else if $in < 1wk {
-        { fg: "#a1c659" attr: "b" }
-      } else if $in < 6wk {
-        "#76c7b7"
-      } else if $in < 52wk {
-        "#6fb3d2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb0120" attr: "b" }
+        } else if $in < 6hr {
+            "#fb0120"
+        } else if $in < 1day {
+            "#fda331"
+        } else if $in < 3day {
+            "#a1c659"
+        } else if $in < 1wk {
+            { fg: "#a1c659" attr: "b" }
+        } else if $in < 6wk {
+            "#76c7b7"
+        } else if $in < 52wk {
+            "#6fb3d2"
+        } else { "dark_gray" }
     }
     range: "#e0e0e0"
     float: "#e0e0e0"

--- a/themes/themes/broadcast.nu
+++ b/themes/themes/broadcast.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a0cef0" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#6e9cbe"
-      } else {{ fg: "#6d9cbe" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#6e9cbe"
+        } else {{ fg: "#6d9cbe" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#da4939" attr: "b" }
-      } else if $in < 6hr {
-        "#da4939"
-      } else if $in < 1day {
-        "#ffd24a"
-      } else if $in < 3day {
-        "#519f50"
-      } else if $in < 1wk {
-        { fg: "#519f50" attr: "b" }
-      } else if $in < 6wk {
-        "#6e9cbe"
-      } else if $in < 52wk {
-        "#6d9cbe"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#da4939" attr: "b" }
+        } else if $in < 6hr {
+            "#da4939"
+        } else if $in < 1day {
+            "#ffd24a"
+        } else if $in < 3day {
+            "#519f50"
+        } else if $in < 1wk {
+            { fg: "#519f50" attr: "b" }
+        } else if $in < 6wk {
+            "#6e9cbe"
+        } else if $in < 52wk {
+            "#6d9cbe"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/brogrammer.nu
+++ b/themes/themes/brogrammer.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1081d6" } else { "light_gray" } }
     int: "#4e5ab7"
     filesize: {|e|
-      if $e == 0b {
-        "#4e5ab7"
-      } else if $e < 1mb {
-        "#1081d6"
-      } else {{ fg: "#5350b9" }}
+        if $e == 0b {
+            "#4e5ab7"
+        } else if $e < 1mb {
+            "#1081d6"
+        } else {{ fg: "#5350b9" }}
     }
     duration: "#4e5ab7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d6dbe5" attr: "b" }
-      } else if $in < 6hr {
-        "#d6dbe5"
-      } else if $in < 1day {
-        "#1dd361"
-      } else if $in < 3day {
-        "#f3bd09"
-      } else if $in < 1wk {
-        { fg: "#f3bd09" attr: "b" }
-      } else if $in < 6wk {
-        "#1081d6"
-      } else if $in < 52wk {
-        "#5350b9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d6dbe5" attr: "b" }
+        } else if $in < 6hr {
+            "#d6dbe5"
+        } else if $in < 1day {
+            "#1dd361"
+        } else if $in < 3day {
+            "#f3bd09"
+        } else if $in < 1wk {
+            { fg: "#f3bd09" attr: "b" }
+        } else if $in < 6wk {
+            "#1081d6"
+        } else if $in < 52wk {
+            "#5350b9"
+        } else { "dark_gray" }
     }
     range: "#4e5ab7"
     float: "#4e5ab7"

--- a/themes/themes/brushtrees-dark.nu
+++ b/themes/themes/brushtrees-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#86b3b3" } else { "light_gray" } }
     int: "#b0c5c8"
     filesize: {|e|
-      if $e == 0b {
-        "#b0c5c8"
-      } else if $e < 1mb {
-        "#86b3b3"
-      } else {{ fg: "#868cb3" }}
+        if $e == 0b {
+            "#b0c5c8"
+        } else if $e < 1mb {
+            "#86b3b3"
+        } else {{ fg: "#868cb3" }}
     }
     duration: "#b0c5c8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b38686" attr: "b" }
-      } else if $in < 6hr {
-        "#b38686"
-      } else if $in < 1day {
-        "#aab386"
-      } else if $in < 3day {
-        "#87b386"
-      } else if $in < 1wk {
-        { fg: "#87b386" attr: "b" }
-      } else if $in < 6wk {
-        "#86b3b3"
-      } else if $in < 52wk {
-        "#868cb3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b38686" attr: "b" }
+        } else if $in < 6hr {
+            "#b38686"
+        } else if $in < 1day {
+            "#aab386"
+        } else if $in < 3day {
+            "#87b386"
+        } else if $in < 1wk {
+            { fg: "#87b386" attr: "b" }
+        } else if $in < 6wk {
+            "#86b3b3"
+        } else if $in < 52wk {
+            "#868cb3"
+        } else { "dark_gray" }
     }
     range: "#b0c5c8"
     float: "#b0c5c8"

--- a/themes/themes/brushtrees.nu
+++ b/themes/themes/brushtrees.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#86b3b3" } else { "light_gray" } }
     int: "#6d828e"
     filesize: {|e|
-      if $e == 0b {
-        "#6d828e"
-      } else if $e < 1mb {
-        "#86b3b3"
-      } else {{ fg: "#868cb3" }}
+        if $e == 0b {
+            "#6d828e"
+        } else if $e < 1mb {
+            "#86b3b3"
+        } else {{ fg: "#868cb3" }}
     }
     duration: "#6d828e"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b38686" attr: "b" }
-      } else if $in < 6hr {
-        "#b38686"
-      } else if $in < 1day {
-        "#aab386"
-      } else if $in < 3day {
-        "#87b386"
-      } else if $in < 1wk {
-        { fg: "#87b386" attr: "b" }
-      } else if $in < 6wk {
-        "#86b3b3"
-      } else if $in < 52wk {
-        "#868cb3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b38686" attr: "b" }
+        } else if $in < 6hr {
+            "#b38686"
+        } else if $in < 1day {
+            "#aab386"
+        } else if $in < 3day {
+            "#87b386"
+        } else if $in < 1wk {
+            { fg: "#87b386" attr: "b" }
+        } else if $in < 6wk {
+            "#86b3b3"
+        } else if $in < 52wk {
+            "#868cb3"
+        } else { "dark_gray" }
     }
     range: "#6d828e"
     float: "#6d828e"

--- a/themes/themes/c64.nu
+++ b/themes/themes/c64.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#67b6bd" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#67b6bd"
-      } else {{ fg: "#40318d" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#67b6bd"
+        } else {{ fg: "#40318d" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#883932" attr: "b" }
-      } else if $in < 6hr {
-        "#883932"
-      } else if $in < 1day {
-        "#bfce72"
-      } else if $in < 3day {
-        "#55a049"
-      } else if $in < 1wk {
-        { fg: "#55a049" attr: "b" }
-      } else if $in < 6wk {
-        "#67b6bd"
-      } else if $in < 52wk {
-        "#40318d"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#883932" attr: "b" }
+        } else if $in < 6hr {
+            "#883932"
+        } else if $in < 1day {
+            "#bfce72"
+        } else if $in < 3day {
+            "#55a049"
+        } else if $in < 1wk {
+            { fg: "#55a049" attr: "b" }
+        } else if $in < 6wk {
+            "#67b6bd"
+        } else if $in < 52wk {
+            "#40318d"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/cai.nu
+++ b/themes/themes/cai.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8de9d4" } else { "light_gray" } }
     int: "#808080"
     filesize: {|e|
-      if $e == 0b {
-        "#808080"
-      } else if $e < 1mb {
-        "#27caa4"
-      } else {{ fg: "#274dca" }}
+        if $e == 0b {
+            "#808080"
+        } else if $e < 1mb {
+            "#27caa4"
+        } else {{ fg: "#274dca" }}
     }
     duration: "#808080"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ca274d" attr: "b" }
-      } else if $in < 6hr {
-        "#ca274d"
-      } else if $in < 1day {
-        "#caa427"
-      } else if $in < 3day {
-        "#4dca27"
-      } else if $in < 1wk {
-        { fg: "#4dca27" attr: "b" }
-      } else if $in < 6wk {
-        "#27caa4"
-      } else if $in < 52wk {
-        "#274dca"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ca274d" attr: "b" }
+        } else if $in < 6hr {
+            "#ca274d"
+        } else if $in < 1day {
+            "#caa427"
+        } else if $in < 3day {
+            "#4dca27"
+        } else if $in < 1wk {
+            { fg: "#4dca27" attr: "b" }
+        } else if $in < 6wk {
+            "#27caa4"
+        } else if $in < 52wk {
+            "#274dca"
+        } else { "dark_gray" }
     }
     range: "#808080"
     float: "#808080"

--- a/themes/themes/chalk.nu
+++ b/themes/themes/chalk.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#12cfc0" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#12cfc0"
-      } else {{ fg: "#6fc2ef" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#12cfc0"
+        } else {{ fg: "#6fc2ef" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb9fb1" attr: "b" }
-      } else if $in < 6hr {
-        "#fb9fb1"
-      } else if $in < 1day {
-        "#ddb26f"
-      } else if $in < 3day {
-        "#acc267"
-      } else if $in < 1wk {
-        { fg: "#acc267" attr: "b" }
-      } else if $in < 6wk {
-        "#12cfc0"
-      } else if $in < 52wk {
-        "#6fc2ef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb9fb1" attr: "b" }
+        } else if $in < 6hr {
+            "#fb9fb1"
+        } else if $in < 1day {
+            "#ddb26f"
+        } else if $in < 3day {
+            "#acc267"
+        } else if $in < 1wk {
+            { fg: "#acc267" attr: "b" }
+        } else if $in < 6wk {
+            "#12cfc0"
+        } else if $in < 52wk {
+            "#6fc2ef"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/chalkboard.nu
+++ b/themes/themes/chalkboard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#aadadb" } else { "light_gray" } }
     int: "#d9d9d9"
     filesize: {|e|
-      if $e == 0b {
-        "#d9d9d9"
-      } else if $e < 1mb {
-        "#72c2c3"
-      } else {{ fg: "#7372c3" }}
+        if $e == 0b {
+            "#d9d9d9"
+        } else if $e < 1mb {
+            "#72c2c3"
+        } else {{ fg: "#7372c3" }}
     }
     duration: "#d9d9d9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c37372" attr: "b" }
-      } else if $in < 6hr {
-        "#c37372"
-      } else if $in < 1day {
-        "#c2c372"
-      } else if $in < 3day {
-        "#72c373"
-      } else if $in < 1wk {
-        { fg: "#72c373" attr: "b" }
-      } else if $in < 6wk {
-        "#72c2c3"
-      } else if $in < 52wk {
-        "#7372c3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c37372" attr: "b" }
+        } else if $in < 6hr {
+            "#c37372"
+        } else if $in < 1day {
+            "#c2c372"
+        } else if $in < 3day {
+            "#72c373"
+        } else if $in < 1wk {
+            { fg: "#72c373" attr: "b" }
+        } else if $in < 6wk {
+            "#72c2c3"
+        } else if $in < 52wk {
+            "#7372c3"
+        } else { "dark_gray" }
     }
     range: "#d9d9d9"
     float: "#d9d9d9"

--- a/themes/themes/challenger-deep.nu
+++ b/themes/themes/challenger-deep.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#63f2f1" } else { "light_gray" } }
     int: "#cbe3e7"
     filesize: {|e|
-      if $e == 0b {
-        "#cbe3e7"
-      } else if $e < 1mb {
-        "#aaffe4"
-      } else {{ fg: "#91ddff" }}
+        if $e == 0b {
+            "#cbe3e7"
+        } else if $e < 1mb {
+            "#aaffe4"
+        } else {{ fg: "#91ddff" }}
     }
     duration: "#cbe3e7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff8080" attr: "b" }
-      } else if $in < 6hr {
-        "#ff8080"
-      } else if $in < 1day {
-        "#ffe9aa"
-      } else if $in < 3day {
-        "#95ffa4"
-      } else if $in < 1wk {
-        { fg: "#95ffa4" attr: "b" }
-      } else if $in < 6wk {
-        "#aaffe4"
-      } else if $in < 52wk {
-        "#91ddff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff8080" attr: "b" }
+        } else if $in < 6hr {
+            "#ff8080"
+        } else if $in < 1day {
+            "#ffe9aa"
+        } else if $in < 3day {
+            "#95ffa4"
+        } else if $in < 1wk {
+            { fg: "#95ffa4" attr: "b" }
+        } else if $in < 6wk {
+            "#aaffe4"
+        } else if $in < 52wk {
+            "#91ddff"
+        } else { "dark_gray" }
     }
     range: "#cbe3e7"
     float: "#cbe3e7"

--- a/themes/themes/ciapre.nu
+++ b/themes/themes/ciapre.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#f3dbb2" } else { "light_gray" } }
     int: "#aea47f"
     filesize: {|e|
-      if $e == 0b {
-        "#aea47f"
-      } else if $e < 1mb {
-        "#5c4f4b"
-      } else {{ fg: "#576d8c" }}
+        if $e == 0b {
+            "#aea47f"
+        } else if $e < 1mb {
+            "#5c4f4b"
+        } else {{ fg: "#576d8c" }}
     }
     duration: "#aea47f"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#810009" attr: "b" }
-      } else if $in < 6hr {
-        "#810009"
-      } else if $in < 1day {
-        "#cc8b3f"
-      } else if $in < 3day {
-        "#48513b"
-      } else if $in < 1wk {
-        { fg: "#48513b" attr: "b" }
-      } else if $in < 6wk {
-        "#5c4f4b"
-      } else if $in < 52wk {
-        "#576d8c"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#810009" attr: "b" }
+        } else if $in < 6hr {
+            "#810009"
+        } else if $in < 1day {
+            "#cc8b3f"
+        } else if $in < 3day {
+            "#48513b"
+        } else if $in < 1wk {
+            { fg: "#48513b" attr: "b" }
+        } else if $in < 6wk {
+            "#5c4f4b"
+        } else if $in < 52wk {
+            "#576d8c"
+        } else { "dark_gray" }
     }
     range: "#aea47f"
     float: "#aea47f"

--- a/themes/themes/circus.nu
+++ b/themes/themes/circus.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4bb1a7" } else { "light_gray" } }
     int: "#a7a7a7"
     filesize: {|e|
-      if $e == 0b {
-        "#a7a7a7"
-      } else if $e < 1mb {
-        "#4bb1a7"
-      } else {{ fg: "#639ee4" }}
+        if $e == 0b {
+            "#a7a7a7"
+        } else if $e < 1mb {
+            "#4bb1a7"
+        } else {{ fg: "#639ee4" }}
     }
     duration: "#a7a7a7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dc657d" attr: "b" }
-      } else if $in < 6hr {
-        "#dc657d"
-      } else if $in < 1day {
-        "#c3ba63"
-      } else if $in < 3day {
-        "#84b97c"
-      } else if $in < 1wk {
-        { fg: "#84b97c" attr: "b" }
-      } else if $in < 6wk {
-        "#4bb1a7"
-      } else if $in < 52wk {
-        "#639ee4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dc657d" attr: "b" }
+        } else if $in < 6hr {
+            "#dc657d"
+        } else if $in < 1day {
+            "#c3ba63"
+        } else if $in < 3day {
+            "#84b97c"
+        } else if $in < 1wk {
+            { fg: "#84b97c" attr: "b" }
+        } else if $in < 6wk {
+            "#4bb1a7"
+        } else if $in < 52wk {
+            "#639ee4"
+        } else { "dark_gray" }
     }
     range: "#a7a7a7"
     float: "#a7a7a7"

--- a/themes/themes/classic-dark.nu
+++ b/themes/themes/classic-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#75b5aa" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#75b5aa"
-      } else {{ fg: "#6a9fb5" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#75b5aa"
+        } else {{ fg: "#6a9fb5" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ac4142" attr: "b" }
-      } else if $in < 6hr {
-        "#ac4142"
-      } else if $in < 1day {
-        "#f4bf75"
-      } else if $in < 3day {
-        "#90a959"
-      } else if $in < 1wk {
-        { fg: "#90a959" attr: "b" }
-      } else if $in < 6wk {
-        "#75b5aa"
-      } else if $in < 52wk {
-        "#6a9fb5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ac4142" attr: "b" }
+        } else if $in < 6hr {
+            "#ac4142"
+        } else if $in < 1day {
+            "#f4bf75"
+        } else if $in < 3day {
+            "#90a959"
+        } else if $in < 1wk {
+            { fg: "#90a959" attr: "b" }
+        } else if $in < 6wk {
+            "#75b5aa"
+        } else if $in < 52wk {
+            "#6a9fb5"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/classic-light.nu
+++ b/themes/themes/classic-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#75b5aa" } else { "light_gray" } }
     int: "#303030"
     filesize: {|e|
-      if $e == 0b {
-        "#303030"
-      } else if $e < 1mb {
-        "#75b5aa"
-      } else {{ fg: "#6a9fb5" }}
+        if $e == 0b {
+            "#303030"
+        } else if $e < 1mb {
+            "#75b5aa"
+        } else {{ fg: "#6a9fb5" }}
     }
     duration: "#303030"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ac4142" attr: "b" }
-      } else if $in < 6hr {
-        "#ac4142"
-      } else if $in < 1day {
-        "#f4bf75"
-      } else if $in < 3day {
-        "#90a959"
-      } else if $in < 1wk {
-        { fg: "#90a959" attr: "b" }
-      } else if $in < 6wk {
-        "#75b5aa"
-      } else if $in < 52wk {
-        "#6a9fb5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ac4142" attr: "b" }
+        } else if $in < 6hr {
+            "#ac4142"
+        } else if $in < 1day {
+            "#f4bf75"
+        } else if $in < 3day {
+            "#90a959"
+        } else if $in < 1wk {
+            { fg: "#90a959" attr: "b" }
+        } else if $in < 6wk {
+            "#75b5aa"
+        } else if $in < 52wk {
+            "#6a9fb5"
+        } else { "dark_gray" }
     }
     range: "#303030"
     float: "#303030"

--- a/themes/themes/clone-of-ubuntu.nu
+++ b/themes/themes/clone-of-ubuntu.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#34e2e2" } else { "light_gray" } }
     int: "#d3d7cf"
     filesize: {|e|
-      if $e == 0b {
-        "#d3d7cf"
-      } else if $e < 1mb {
-        "#06989a"
-      } else {{ fg: "#3465a4" }}
+        if $e == 0b {
+            "#d3d7cf"
+        } else if $e < 1mb {
+            "#06989a"
+        } else {{ fg: "#3465a4" }}
     }
     duration: "#d3d7cf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc0000" attr: "b" }
-      } else if $in < 6hr {
-        "#cc0000"
-      } else if $in < 1day {
-        "#c4a000"
-      } else if $in < 3day {
-        "#4e9a06"
-      } else if $in < 1wk {
-        { fg: "#4e9a06" attr: "b" }
-      } else if $in < 6wk {
-        "#06989a"
-      } else if $in < 52wk {
-        "#3465a4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc0000" attr: "b" }
+        } else if $in < 6hr {
+            "#cc0000"
+        } else if $in < 1day {
+            "#c4a000"
+        } else if $in < 3day {
+            "#4e9a06"
+        } else if $in < 1wk {
+            { fg: "#4e9a06" attr: "b" }
+        } else if $in < 6wk {
+            "#06989a"
+        } else if $in < 52wk {
+            "#3465a4"
+        } else { "dark_gray" }
     }
     range: "#d3d7cf"
     float: "#d3d7cf"

--- a/themes/themes/clrs.nu
+++ b/themes/themes/clrs.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3ad5ce" } else { "light_gray" } }
     int: "#b3b3b3"
     filesize: {|e|
-      if $e == 0b {
-        "#b3b3b3"
-      } else if $e < 1mb {
-        "#33c3c1"
-      } else {{ fg: "#135cd0" }}
+        if $e == 0b {
+            "#b3b3b3"
+        } else if $e < 1mb {
+            "#33c3c1"
+        } else {{ fg: "#135cd0" }}
     }
     duration: "#b3b3b3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f8282a" attr: "b" }
-      } else if $in < 6hr {
-        "#f8282a"
-      } else if $in < 1day {
-        "#fa701d"
-      } else if $in < 3day {
-        "#328a5d"
-      } else if $in < 1wk {
-        { fg: "#328a5d" attr: "b" }
-      } else if $in < 6wk {
-        "#33c3c1"
-      } else if $in < 52wk {
-        "#135cd0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f8282a" attr: "b" }
+        } else if $in < 6hr {
+            "#f8282a"
+        } else if $in < 1day {
+            "#fa701d"
+        } else if $in < 3day {
+            "#328a5d"
+        } else if $in < 1wk {
+            { fg: "#328a5d" attr: "b" }
+        } else if $in < 6wk {
+            "#33c3c1"
+        } else if $in < 52wk {
+            "#135cd0"
+        } else { "dark_gray" }
     }
     range: "#b3b3b3"
     float: "#b3b3b3"

--- a/themes/themes/cobalt-neon.nu
+++ b/themes/themes/cobalt-neon.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#6cbc67" } else { "light_gray" } }
     int: "#ba46b2"
     filesize: {|e|
-      if $e == 0b {
-        "#ba46b2"
-      } else if $e < 1mb {
-        "#8ff586"
-      } else {{ fg: "#8ff586" }}
+        if $e == 0b {
+            "#ba46b2"
+        } else if $e < 1mb {
+            "#8ff586"
+        } else {{ fg: "#8ff586" }}
     }
     duration: "#ba46b2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff2320" attr: "b" }
-      } else if $in < 6hr {
-        "#ff2320"
-      } else if $in < 1day {
-        "#e9e75c"
-      } else if $in < 3day {
-        "#3ba5ff"
-      } else if $in < 1wk {
-        { fg: "#3ba5ff" attr: "b" }
-      } else if $in < 6wk {
-        "#8ff586"
-      } else if $in < 52wk {
-        "#8ff586"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff2320" attr: "b" }
+        } else if $in < 6hr {
+            "#ff2320"
+        } else if $in < 1day {
+            "#e9e75c"
+        } else if $in < 3day {
+            "#3ba5ff"
+        } else if $in < 1wk {
+            { fg: "#3ba5ff" attr: "b" }
+        } else if $in < 6wk {
+            "#8ff586"
+        } else if $in < 52wk {
+            "#8ff586"
+        } else { "dark_gray" }
     }
     range: "#ba46b2"
     float: "#ba46b2"

--- a/themes/themes/cobalt2.nu
+++ b/themes/themes/cobalt2.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#6ae3fa" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#00bbbb"
-      } else {{ fg: "#1460d2" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#00bbbb"
+        } else {{ fg: "#1460d2" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0000" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0000"
-      } else if $in < 1day {
-        "#ffe50a"
-      } else if $in < 3day {
-        "#38de21"
-      } else if $in < 1wk {
-        { fg: "#38de21" attr: "b" }
-      } else if $in < 6wk {
-        "#00bbbb"
-      } else if $in < 52wk {
-        "#1460d2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0000" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0000"
+        } else if $in < 1day {
+            "#ffe50a"
+        } else if $in < 3day {
+            "#38de21"
+        } else if $in < 1wk {
+            { fg: "#38de21" attr: "b" }
+        } else if $in < 6wk {
+            "#00bbbb"
+        } else if $in < 52wk {
+            "#1460d2"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/codeschool.nu
+++ b/themes/themes/codeschool.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b02f30" } else { "light_gray" } }
     int: "#9ea7a6"
     filesize: {|e|
-      if $e == 0b {
-        "#9ea7a6"
-      } else if $e < 1mb {
-        "#b02f30"
-      } else {{ fg: "#484d79" }}
+        if $e == 0b {
+            "#9ea7a6"
+        } else if $e < 1mb {
+            "#b02f30"
+        } else {{ fg: "#484d79" }}
     }
     duration: "#9ea7a6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#2a5491" attr: "b" }
-      } else if $in < 6hr {
-        "#2a5491"
-      } else if $in < 1day {
-        "#a03b1e"
-      } else if $in < 3day {
-        "#237986"
-      } else if $in < 1wk {
-        { fg: "#237986" attr: "b" }
-      } else if $in < 6wk {
-        "#b02f30"
-      } else if $in < 52wk {
-        "#484d79"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#2a5491" attr: "b" }
+        } else if $in < 6hr {
+            "#2a5491"
+        } else if $in < 1day {
+            "#a03b1e"
+        } else if $in < 3day {
+            "#237986"
+        } else if $in < 1wk {
+            { fg: "#237986" attr: "b" }
+        } else if $in < 6wk {
+            "#b02f30"
+        } else if $in < 52wk {
+            "#484d79"
+        } else { "dark_gray" }
     }
     range: "#9ea7a6"
     float: "#9ea7a6"

--- a/themes/themes/corvine.nu
+++ b/themes/themes/corvine.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5fd7d7" } else { "light_gray" } }
     int: "#c6c6c6"
     filesize: {|e|
-      if $e == 0b {
-        "#c6c6c6"
-      } else if $e < 1mb {
-        "#87d7d7"
-      } else {{ fg: "#87afd7" }}
+        if $e == 0b {
+            "#c6c6c6"
+        } else if $e < 1mb {
+            "#87d7d7"
+        } else {{ fg: "#87afd7" }}
     }
     duration: "#c6c6c6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d78787" attr: "b" }
-      } else if $in < 6hr {
-        "#d78787"
-      } else if $in < 1day {
-        "#d7d7af"
-      } else if $in < 3day {
-        "#87af5f"
-      } else if $in < 1wk {
-        { fg: "#87af5f" attr: "b" }
-      } else if $in < 6wk {
-        "#87d7d7"
-      } else if $in < 52wk {
-        "#87afd7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d78787" attr: "b" }
+        } else if $in < 6hr {
+            "#d78787"
+        } else if $in < 1day {
+            "#d7d7af"
+        } else if $in < 3day {
+            "#87af5f"
+        } else if $in < 1wk {
+            { fg: "#87af5f" attr: "b" }
+        } else if $in < 6wk {
+            "#87d7d7"
+        } else if $in < 52wk {
+            "#87afd7"
+        } else { "dark_gray" }
     }
     range: "#c6c6c6"
     float: "#c6c6c6"

--- a/themes/themes/crayon-pony-fish.nu
+++ b/themes/themes/crayon-pony-fish.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ffceaf" } else { "light_gray" } }
     int: "#68525a"
     filesize: {|e|
-      if $e == 0b {
-        "#68525a"
-      } else if $e < 1mb {
-        "#e8a866"
-      } else {{ fg: "#8c87b0" }}
+        if $e == 0b {
+            "#68525a"
+        } else if $e < 1mb {
+            "#e8a866"
+        } else {{ fg: "#8c87b0" }}
     }
     duration: "#68525a"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#91002b" attr: "b" }
-      } else if $in < 6hr {
-        "#91002b"
-      } else if $in < 1day {
-        "#ab311b"
-      } else if $in < 3day {
-        "#579524"
-      } else if $in < 1wk {
-        { fg: "#579524" attr: "b" }
-      } else if $in < 6wk {
-        "#e8a866"
-      } else if $in < 52wk {
-        "#8c87b0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#91002b" attr: "b" }
+        } else if $in < 6hr {
+            "#91002b"
+        } else if $in < 1day {
+            "#ab311b"
+        } else if $in < 3day {
+            "#579524"
+        } else if $in < 1wk {
+            { fg: "#579524" attr: "b" }
+        } else if $in < 6wk {
+            "#e8a866"
+        } else if $in < 52wk {
+            "#8c87b0"
+        } else { "dark_gray" }
     }
     range: "#68525a"
     float: "#68525a"

--- a/themes/themes/cupcake.nu
+++ b/themes/themes/cupcake.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#69a9a7" } else { "light_gray" } }
     int: "#8b8198"
     filesize: {|e|
-      if $e == 0b {
-        "#8b8198"
-      } else if $e < 1mb {
-        "#69a9a7"
-      } else {{ fg: "#7297b9" }}
+        if $e == 0b {
+            "#8b8198"
+        } else if $e < 1mb {
+            "#69a9a7"
+        } else {{ fg: "#7297b9" }}
     }
     duration: "#8b8198"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d57e85" attr: "b" }
-      } else if $in < 6hr {
-        "#d57e85"
-      } else if $in < 1day {
-        "#dcb16c"
-      } else if $in < 3day {
-        "#a3b367"
-      } else if $in < 1wk {
-        { fg: "#a3b367" attr: "b" }
-      } else if $in < 6wk {
-        "#69a9a7"
-      } else if $in < 52wk {
-        "#7297b9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d57e85" attr: "b" }
+        } else if $in < 6hr {
+            "#d57e85"
+        } else if $in < 1day {
+            "#dcb16c"
+        } else if $in < 3day {
+            "#a3b367"
+        } else if $in < 1wk {
+            { fg: "#a3b367" attr: "b" }
+        } else if $in < 6wk {
+            "#69a9a7"
+        } else if $in < 52wk {
+            "#7297b9"
+        } else { "dark_gray" }
     }
     range: "#8b8198"
     float: "#8b8198"

--- a/themes/themes/cupertino.nu
+++ b/themes/themes/cupertino.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#318495" } else { "light_gray" } }
     int: "#404040"
     filesize: {|e|
-      if $e == 0b {
-        "#404040"
-      } else if $e < 1mb {
-        "#318495"
-      } else {{ fg: "#0000ff" }}
+        if $e == 0b {
+            "#404040"
+        } else if $e < 1mb {
+            "#318495"
+        } else {{ fg: "#0000ff" }}
     }
     duration: "#404040"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c41a15" attr: "b" }
-      } else if $in < 6hr {
-        "#c41a15"
-      } else if $in < 1day {
-        "#826b28"
-      } else if $in < 3day {
-        "#007400"
-      } else if $in < 1wk {
-        { fg: "#007400" attr: "b" }
-      } else if $in < 6wk {
-        "#318495"
-      } else if $in < 52wk {
-        "#0000ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c41a15" attr: "b" }
+        } else if $in < 6hr {
+            "#c41a15"
+        } else if $in < 1day {
+            "#826b28"
+        } else if $in < 3day {
+            "#007400"
+        } else if $in < 1wk {
+            { fg: "#007400" attr: "b" }
+        } else if $in < 6wk {
+            "#318495"
+        } else if $in < 52wk {
+            "#0000ff"
+        } else { "dark_gray" }
     }
     range: "#404040"
     float: "#404040"

--- a/themes/themes/danqing.nu
+++ b/themes/themes/danqing.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#30dff3" } else { "light_gray" } }
     int: "#e0f0ef"
     filesize: {|e|
-      if $e == 0b {
-        "#e0f0ef"
-      } else if $e < 1mb {
-        "#30dff3"
-      } else {{ fg: "#b0a4e3" }}
+        if $e == 0b {
+            "#e0f0ef"
+        } else if $e < 1mb {
+            "#30dff3"
+        } else {{ fg: "#b0a4e3" }}
     }
     duration: "#e0f0ef"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f9906f" attr: "b" }
-      } else if $in < 6hr {
-        "#f9906f"
-      } else if $in < 1day {
-        "#f0c239"
-      } else if $in < 3day {
-        "#8ab361"
-      } else if $in < 1wk {
-        { fg: "#8ab361" attr: "b" }
-      } else if $in < 6wk {
-        "#30dff3"
-      } else if $in < 52wk {
-        "#b0a4e3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f9906f" attr: "b" }
+        } else if $in < 6hr {
+            "#f9906f"
+        } else if $in < 1day {
+            "#f0c239"
+        } else if $in < 3day {
+            "#8ab361"
+        } else if $in < 1wk {
+            { fg: "#8ab361" attr: "b" }
+        } else if $in < 6wk {
+            "#30dff3"
+        } else if $in < 52wk {
+            "#b0a4e3"
+        } else { "dark_gray" }
     }
     range: "#e0f0ef"
     float: "#e0f0ef"

--- a/themes/themes/darcula.nu
+++ b/themes/themes/darcula.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#629755" } else { "light_gray" } }
     int: "#a9b7c6"
     filesize: {|e|
-      if $e == 0b {
-        "#a9b7c6"
-      } else if $e < 1mb {
-        "#629755"
-      } else {{ fg: "#9876aa" }}
+        if $e == 0b {
+            "#a9b7c6"
+        } else if $e < 1mb {
+            "#629755"
+        } else {{ fg: "#9876aa" }}
     }
     duration: "#a9b7c6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#4eade5" attr: "b" }
-      } else if $in < 6hr {
-        "#4eade5"
-      } else if $in < 1day {
-        "#bbb529"
-      } else if $in < 3day {
-        "#6a8759"
-      } else if $in < 1wk {
-        { fg: "#6a8759" attr: "b" }
-      } else if $in < 6wk {
-        "#629755"
-      } else if $in < 52wk {
-        "#9876aa"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#4eade5" attr: "b" }
+        } else if $in < 6hr {
+            "#4eade5"
+        } else if $in < 1day {
+            "#bbb529"
+        } else if $in < 3day {
+            "#6a8759"
+        } else if $in < 1wk {
+            { fg: "#6a8759" attr: "b" }
+        } else if $in < 6wk {
+            "#629755"
+        } else if $in < 52wk {
+            "#9876aa"
+        } else { "dark_gray" }
     }
     range: "#a9b7c6"
     float: "#a9b7c6"

--- a/themes/themes/dark-pastel.nu
+++ b/themes/themes/dark-pastel.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#55ffff" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#55ffff"
-      } else {{ fg: "#5555ff" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#55ffff"
+        } else {{ fg: "#5555ff" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff5555" attr: "b" }
-      } else if $in < 6hr {
-        "#ff5555"
-      } else if $in < 1day {
-        "#ffff55"
-      } else if $in < 3day {
-        "#55ff55"
-      } else if $in < 1wk {
-        { fg: "#55ff55" attr: "b" }
-      } else if $in < 6wk {
-        "#55ffff"
-      } else if $in < 52wk {
-        "#5555ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff5555" attr: "b" }
+        } else if $in < 6hr {
+            "#ff5555"
+        } else if $in < 1day {
+            "#ffff55"
+        } else if $in < 3day {
+            "#55ff55"
+        } else if $in < 1wk {
+            { fg: "#55ff55" attr: "b" }
+        } else if $in < 6wk {
+            "#55ffff"
+        } else if $in < 52wk {
+            "#5555ff"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/darkmoss.nu
+++ b/themes/themes/darkmoss.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#66d9ef" } else { "light_gray" } }
     int: "#c7c7a5"
     filesize: {|e|
-      if $e == 0b {
-        "#c7c7a5"
-      } else if $e < 1mb {
-        "#66d9ef"
-      } else {{ fg: "#498091" }}
+        if $e == 0b {
+            "#c7c7a5"
+        } else if $e < 1mb {
+            "#66d9ef"
+        } else {{ fg: "#498091" }}
     }
     duration: "#c7c7a5"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff4658" attr: "b" }
-      } else if $in < 6hr {
-        "#ff4658"
-      } else if $in < 1day {
-        "#fdb11f"
-      } else if $in < 3day {
-        "#499180"
-      } else if $in < 1wk {
-        { fg: "#499180" attr: "b" }
-      } else if $in < 6wk {
-        "#66d9ef"
-      } else if $in < 52wk {
-        "#498091"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff4658" attr: "b" }
+        } else if $in < 6hr {
+            "#ff4658"
+        } else if $in < 1day {
+            "#fdb11f"
+        } else if $in < 3day {
+            "#499180"
+        } else if $in < 1wk {
+            { fg: "#499180" attr: "b" }
+        } else if $in < 6wk {
+            "#66d9ef"
+        } else if $in < 52wk {
+            "#498091"
+        } else { "dark_gray" }
     }
     range: "#c7c7a5"
     float: "#c7c7a5"

--- a/themes/themes/darkside.nu
+++ b/themes/themes/darkside.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3d97e2" } else { "light_gray" } }
     int: "#bababa"
     filesize: {|e|
-      if $e == 0b {
-        "#bababa"
-      } else if $e < 1mb {
-        "#1c98e8"
-      } else {{ fg: "#1c98e8" }}
+        if $e == 0b {
+            "#bababa"
+        } else if $e < 1mb {
+            "#1c98e8"
+        } else {{ fg: "#1c98e8" }}
     }
     duration: "#bababa"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e8341c" attr: "b" }
-      } else if $in < 6hr {
-        "#e8341c"
-      } else if $in < 1day {
-        "#f2d42c"
-      } else if $in < 3day {
-        "#68c256"
-      } else if $in < 1wk {
-        { fg: "#68c256" attr: "b" }
-      } else if $in < 6wk {
-        "#1c98e8"
-      } else if $in < 52wk {
-        "#1c98e8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e8341c" attr: "b" }
+        } else if $in < 6hr {
+            "#e8341c"
+        } else if $in < 1day {
+            "#f2d42c"
+        } else if $in < 3day {
+            "#68c256"
+        } else if $in < 1wk {
+            { fg: "#68c256" attr: "b" }
+        } else if $in < 6wk {
+            "#1c98e8"
+        } else if $in < 52wk {
+            "#1c98e8"
+        } else { "dark_gray" }
     }
     range: "#bababa"
     float: "#bababa"

--- a/themes/themes/darktooth.nu
+++ b/themes/themes/darktooth.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ba59b" } else { "light_gray" } }
     int: "#a89984"
     filesize: {|e|
-      if $e == 0b {
-        "#a89984"
-      } else if $e < 1mb {
-        "#8ba59b"
-      } else {{ fg: "#0d6678" }}
+        if $e == 0b {
+            "#a89984"
+        } else if $e < 1mb {
+            "#8ba59b"
+        } else {{ fg: "#0d6678" }}
     }
     duration: "#a89984"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb543f" attr: "b" }
-      } else if $in < 6hr {
-        "#fb543f"
-      } else if $in < 1day {
-        "#fac03b"
-      } else if $in < 3day {
-        "#95c085"
-      } else if $in < 1wk {
-        { fg: "#95c085" attr: "b" }
-      } else if $in < 6wk {
-        "#8ba59b"
-      } else if $in < 52wk {
-        "#0d6678"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb543f" attr: "b" }
+        } else if $in < 6hr {
+            "#fb543f"
+        } else if $in < 1day {
+            "#fac03b"
+        } else if $in < 3day {
+            "#95c085"
+        } else if $in < 1wk {
+            { fg: "#95c085" attr: "b" }
+        } else if $in < 6wk {
+            "#8ba59b"
+        } else if $in < 52wk {
+            "#0d6678"
+        } else { "dark_gray" }
     }
     range: "#a89984"
     float: "#a89984"

--- a/themes/themes/darkviolet.nu
+++ b/themes/themes/darkviolet.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#40dfff" } else { "light_gray" } }
     int: "#b08ae6"
     filesize: {|e|
-      if $e == 0b {
-        "#b08ae6"
-      } else if $e < 1mb {
-        "#40dfff"
-      } else {{ fg: "#4136d9" }}
+        if $e == 0b {
+            "#b08ae6"
+        } else if $e < 1mb {
+            "#40dfff"
+        } else {{ fg: "#4136d9" }}
     }
     duration: "#b08ae6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a82ee6" attr: "b" }
-      } else if $in < 6hr {
-        "#a82ee6"
-      } else if $in < 1day {
-        "#f29df2"
-      } else if $in < 3day {
-        "#4595e6"
-      } else if $in < 1wk {
-        { fg: "#4595e6" attr: "b" }
-      } else if $in < 6wk {
-        "#40dfff"
-      } else if $in < 52wk {
-        "#4136d9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a82ee6" attr: "b" }
+        } else if $in < 6hr {
+            "#a82ee6"
+        } else if $in < 1day {
+            "#f29df2"
+        } else if $in < 3day {
+            "#4595e6"
+        } else if $in < 1wk {
+            { fg: "#4595e6" attr: "b" }
+        } else if $in < 6wk {
+            "#40dfff"
+        } else if $in < 52wk {
+            "#4136d9"
+        } else { "dark_gray" }
     }
     range: "#b08ae6"
     float: "#b08ae6"

--- a/themes/themes/decaf.nu
+++ b/themes/themes/decaf.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#bed6ff" } else { "light_gray" } }
     int: "#cccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#cccccc"
-      } else if $e < 1mb {
-        "#bed6ff"
-      } else {{ fg: "#90bee1" }}
+        if $e == 0b {
+            "#cccccc"
+        } else if $e < 1mb {
+            "#bed6ff"
+        } else {{ fg: "#90bee1" }}
     }
     duration: "#cccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff7f7b" attr: "b" }
-      } else if $in < 6hr {
-        "#ff7f7b"
-      } else if $in < 1day {
-        "#ffd67c"
-      } else if $in < 3day {
-        "#beda78"
-      } else if $in < 1wk {
-        { fg: "#beda78" attr: "b" }
-      } else if $in < 6wk {
-        "#bed6ff"
-      } else if $in < 52wk {
-        "#90bee1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff7f7b" attr: "b" }
+        } else if $in < 6hr {
+            "#ff7f7b"
+        } else if $in < 1day {
+            "#ffd67c"
+        } else if $in < 3day {
+            "#beda78"
+        } else if $in < 1wk {
+            { fg: "#beda78" attr: "b" }
+        } else if $in < 6wk {
+            "#bed6ff"
+        } else if $in < 52wk {
+            "#90bee1"
+        } else { "dark_gray" }
     }
     range: "#cccccc"
     float: "#cccccc"

--- a/themes/themes/default-dark.nu
+++ b/themes/themes/default-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#86c1b9" } else { "light_gray" } }
     int: "#d8d8d8"
     filesize: {|e|
-      if $e == 0b {
-        "#d8d8d8"
-      } else if $e < 1mb {
-        "#86c1b9"
-      } else {{ fg: "#7cafc2" }}
+        if $e == 0b {
+            "#d8d8d8"
+        } else if $e < 1mb {
+            "#86c1b9"
+        } else {{ fg: "#7cafc2" }}
     }
     duration: "#d8d8d8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ab4642" attr: "b" }
-      } else if $in < 6hr {
-        "#ab4642"
-      } else if $in < 1day {
-        "#f7ca88"
-      } else if $in < 3day {
-        "#a1b56c"
-      } else if $in < 1wk {
-        { fg: "#a1b56c" attr: "b" }
-      } else if $in < 6wk {
-        "#86c1b9"
-      } else if $in < 52wk {
-        "#7cafc2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ab4642" attr: "b" }
+        } else if $in < 6hr {
+            "#ab4642"
+        } else if $in < 1day {
+            "#f7ca88"
+        } else if $in < 3day {
+            "#a1b56c"
+        } else if $in < 1wk {
+            { fg: "#a1b56c" attr: "b" }
+        } else if $in < 6wk {
+            "#86c1b9"
+        } else if $in < 52wk {
+            "#7cafc2"
+        } else { "dark_gray" }
     }
     range: "#d8d8d8"
     float: "#d8d8d8"

--- a/themes/themes/default-light.nu
+++ b/themes/themes/default-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#86c1b9" } else { "light_gray" } }
     int: "#383838"
     filesize: {|e|
-      if $e == 0b {
-        "#383838"
-      } else if $e < 1mb {
-        "#86c1b9"
-      } else {{ fg: "#7cafc2" }}
+        if $e == 0b {
+            "#383838"
+        } else if $e < 1mb {
+            "#86c1b9"
+        } else {{ fg: "#7cafc2" }}
     }
     duration: "#383838"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ab4642" attr: "b" }
-      } else if $in < 6hr {
-        "#ab4642"
-      } else if $in < 1day {
-        "#f7ca88"
-      } else if $in < 3day {
-        "#a1b56c"
-      } else if $in < 1wk {
-        { fg: "#a1b56c" attr: "b" }
-      } else if $in < 6wk {
-        "#86c1b9"
-      } else if $in < 52wk {
-        "#7cafc2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ab4642" attr: "b" }
+        } else if $in < 6hr {
+            "#ab4642"
+        } else if $in < 1day {
+            "#f7ca88"
+        } else if $in < 3day {
+            "#a1b56c"
+        } else if $in < 1wk {
+            { fg: "#a1b56c" attr: "b" }
+        } else if $in < 6wk {
+            "#86c1b9"
+        } else if $in < 52wk {
+            "#7cafc2"
+        } else { "dark_gray" }
     }
     range: "#383838"
     float: "#383838"

--- a/themes/themes/desert-night.nu
+++ b/themes/themes/desert-night.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#bfab36" } else { "light_gray" } }
     int: "#87765d"
     filesize: {|e|
-      if $e == 0b {
-        "#87765d"
-      } else if $e < 1mb {
-        "#bfab36"
-      } else {{ fg: "#949fb4" }}
+        if $e == 0b {
+            "#87765d"
+        } else if $e < 1mb {
+            "#bfab36"
+        } else {{ fg: "#949fb4" }}
     }
     duration: "#87765d"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e56b55" attr: "b" }
-      } else if $in < 6hr {
-        "#e56b55"
-      } else if $in < 1day {
-        "#e18245"
-      } else if $in < 3day {
-        "#99b05f"
-      } else if $in < 1wk {
-        { fg: "#99b05f" attr: "b" }
-      } else if $in < 6wk {
-        "#bfab36"
-      } else if $in < 52wk {
-        "#949fb4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e56b55" attr: "b" }
+        } else if $in < 6hr {
+            "#e56b55"
+        } else if $in < 1day {
+            "#e18245"
+        } else if $in < 3day {
+            "#99b05f"
+        } else if $in < 1wk {
+            { fg: "#99b05f" attr: "b" }
+        } else if $in < 6wk {
+            "#bfab36"
+        } else if $in < 52wk {
+            "#949fb4"
+        } else { "dark_gray" }
     }
     range: "#87765d"
     float: "#87765d"

--- a/themes/themes/desert.nu
+++ b/themes/themes/desert.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ffd700" } else { "light_gray" } }
     int: "#f5deb3"
     filesize: {|e|
-      if $e == 0b {
-        "#f5deb3"
-      } else if $e < 1mb {
-        "#ffa0a0"
-      } else {{ fg: "#cd853f" }}
+        if $e == 0b {
+            "#f5deb3"
+        } else if $e < 1mb {
+            "#ffa0a0"
+        } else {{ fg: "#cd853f" }}
     }
     duration: "#f5deb3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff2b2b" attr: "b" }
-      } else if $in < 6hr {
-        "#ff2b2b"
-      } else if $in < 1day {
-        "#f0e68c"
-      } else if $in < 3day {
-        "#98fb98"
-      } else if $in < 1wk {
-        { fg: "#98fb98" attr: "b" }
-      } else if $in < 6wk {
-        "#ffa0a0"
-      } else if $in < 52wk {
-        "#cd853f"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff2b2b" attr: "b" }
+        } else if $in < 6hr {
+            "#ff2b2b"
+        } else if $in < 1day {
+            "#f0e68c"
+        } else if $in < 3day {
+            "#98fb98"
+        } else if $in < 1wk {
+            { fg: "#98fb98" attr: "b" }
+        } else if $in < 6wk {
+            "#ffa0a0"
+        } else if $in < 52wk {
+            "#cd853f"
+        } else { "dark_gray" }
     }
     range: "#f5deb3"
     float: "#f5deb3"

--- a/themes/themes/dimmed-monokai.nu
+++ b/themes/themes/dimmed-monokai.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2e706d" } else { "light_gray" } }
     int: "#b9bcba"
     filesize: {|e|
-      if $e == 0b {
-        "#b9bcba"
-      } else if $e < 1mb {
-        "#578fa4"
-      } else {{ fg: "#4f76a1" }}
+        if $e == 0b {
+            "#b9bcba"
+        } else if $e < 1mb {
+            "#578fa4"
+        } else {{ fg: "#4f76a1" }}
     }
     duration: "#b9bcba"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#be3f48" attr: "b" }
-      } else if $in < 6hr {
-        "#be3f48"
-      } else if $in < 1day {
-        "#c5a635"
-      } else if $in < 3day {
-        "#879a3b"
-      } else if $in < 1wk {
-        { fg: "#879a3b" attr: "b" }
-      } else if $in < 6wk {
-        "#578fa4"
-      } else if $in < 52wk {
-        "#4f76a1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#be3f48" attr: "b" }
+        } else if $in < 6hr {
+            "#be3f48"
+        } else if $in < 1day {
+            "#c5a635"
+        } else if $in < 3day {
+            "#879a3b"
+        } else if $in < 1wk {
+            { fg: "#879a3b" attr: "b" }
+        } else if $in < 6wk {
+            "#578fa4"
+        } else if $in < 52wk {
+            "#4f76a1"
+        } else { "dark_gray" }
     }
     range: "#b9bcba"
     float: "#b9bcba"

--- a/themes/themes/dirtysea.nu
+++ b/themes/themes/dirtysea.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#755b00" } else { "light_gray" } }
     int: "#000000"
     filesize: {|e|
-      if $e == 0b {
-        "#000000"
-      } else if $e < 1mb {
-        "#755b00"
-      } else {{ fg: "#007300" }}
+        if $e == 0b {
+            "#000000"
+        } else if $e < 1mb {
+            "#755b00"
+        } else {{ fg: "#007300" }}
     }
     duration: "#000000"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#840000" attr: "b" }
-      } else if $in < 6hr {
-        "#840000"
-      } else if $in < 1day {
-        "#755b00"
-      } else if $in < 3day {
-        "#730073"
-      } else if $in < 1wk {
-        { fg: "#730073" attr: "b" }
-      } else if $in < 6wk {
-        "#755b00"
-      } else if $in < 52wk {
-        "#007300"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#840000" attr: "b" }
+        } else if $in < 6hr {
+            "#840000"
+        } else if $in < 1day {
+            "#755b00"
+        } else if $in < 3day {
+            "#730073"
+        } else if $in < 1wk {
+            { fg: "#730073" attr: "b" }
+        } else if $in < 6wk {
+            "#755b00"
+        } else if $in < 52wk {
+            "#007300"
+        } else { "dark_gray" }
     }
     range: "#000000"
     float: "#000000"

--- a/themes/themes/dot-gov.nu
+++ b/themes/themes/dot-gov.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8bd1ed" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#8bd1ed"
-      } else {{ fg: "#16b1df" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#8bd1ed"
+        } else {{ fg: "#16b1df" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bf081d" attr: "b" }
-      } else if $in < 6hr {
-        "#bf081d"
-      } else if $in < 1day {
-        "#f6bb33"
-      } else if $in < 3day {
-        "#3d9751"
-      } else if $in < 1wk {
-        { fg: "#3d9751" attr: "b" }
-      } else if $in < 6wk {
-        "#8bd1ed"
-      } else if $in < 52wk {
-        "#16b1df"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bf081d" attr: "b" }
+        } else if $in < 6hr {
+            "#bf081d"
+        } else if $in < 1day {
+            "#f6bb33"
+        } else if $in < 3day {
+            "#3d9751"
+        } else if $in < 1wk {
+            { fg: "#3d9751" attr: "b" }
+        } else if $in < 6wk {
+            "#8bd1ed"
+        } else if $in < 52wk {
+            "#16b1df"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/dracula.nu
+++ b/themes/themes/dracula.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a1efe4" } else { "light_gray" } }
     int: "#e9e9f4"
     filesize: {|e|
-      if $e == 0b {
-        "#e9e9f4"
-      } else if $e < 1mb {
-        "#a1efe4"
-      } else {{ fg: "#62d6e8" }}
+        if $e == 0b {
+            "#e9e9f4"
+        } else if $e < 1mb {
+            "#a1efe4"
+        } else {{ fg: "#62d6e8" }}
     }
     duration: "#e9e9f4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ea51b2" attr: "b" }
-      } else if $in < 6hr {
-        "#ea51b2"
-      } else if $in < 1day {
-        "#00f769"
-      } else if $in < 3day {
-        "#ebff87"
-      } else if $in < 1wk {
-        { fg: "#ebff87" attr: "b" }
-      } else if $in < 6wk {
-        "#a1efe4"
-      } else if $in < 52wk {
-        "#62d6e8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ea51b2" attr: "b" }
+        } else if $in < 6hr {
+            "#ea51b2"
+        } else if $in < 1day {
+            "#00f769"
+        } else if $in < 3day {
+            "#ebff87"
+        } else if $in < 1wk {
+            { fg: "#ebff87" attr: "b" }
+        } else if $in < 6wk {
+            "#a1efe4"
+        } else if $in < 52wk {
+            "#62d6e8"
+        } else { "dark_gray" }
     }
     range: "#e9e9f4"
     float: "#e9e9f4"

--- a/themes/themes/dumbledore.nu
+++ b/themes/themes/dumbledore.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#25de50" } else { "light_gray" } }
     int: "#850000"
     filesize: {|e|
-      if $e == 0b {
-        "#850000"
-      } else if $e < 1mb {
-        "#008aff"
-      } else {{ fg: "#415baf" }}
+        if $e == 0b {
+            "#850000"
+        } else if $e < 1mb {
+            "#008aff"
+        } else {{ fg: "#415baf" }}
     }
     duration: "#850000"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ae0000" attr: "b" }
-      } else if $in < 6hr {
-        "#ae0000"
-      } else if $in < 1day {
-        "#f0c75e"
-      } else if $in < 3day {
-        "#3e7c54"
-      } else if $in < 1wk {
-        { fg: "#3e7c54" attr: "b" }
-      } else if $in < 6wk {
-        "#008aff"
-      } else if $in < 52wk {
-        "#415baf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ae0000" attr: "b" }
+        } else if $in < 6hr {
+            "#ae0000"
+        } else if $in < 1day {
+            "#f0c75e"
+        } else if $in < 3day {
+            "#3e7c54"
+        } else if $in < 1wk {
+            { fg: "#3e7c54" attr: "b" }
+        } else if $in < 6wk {
+            "#008aff"
+        } else if $in < 52wk {
+            "#415baf"
+        } else { "dark_gray" }
     }
     range: "#850000"
     float: "#850000"

--- a/themes/themes/duotone-dark.nu
+++ b/themes/themes/duotone-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2388ff" } else { "light_gray" } }
     int: "#b6a0ff"
     filesize: {|e|
-      if $e == 0b {
-        "#b6a0ff"
-      } else if $e < 1mb {
-        "#2388ff"
-      } else {{ fg: "#ffc183" }}
+        if $e == 0b {
+            "#b6a0ff"
+        } else if $e < 1mb {
+            "#2388ff"
+        } else {{ fg: "#ffc183" }}
     }
     duration: "#b6a0ff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d8393d" attr: "b" }
-      } else if $in < 6hr {
-        "#d8393d"
-      } else if $in < 1day {
-        "#d8b76e"
-      } else if $in < 3day {
-        "#2dcc72"
-      } else if $in < 1wk {
-        { fg: "#2dcc72" attr: "b" }
-      } else if $in < 6wk {
-        "#2388ff"
-      } else if $in < 52wk {
-        "#ffc183"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d8393d" attr: "b" }
+        } else if $in < 6hr {
+            "#d8393d"
+        } else if $in < 1day {
+            "#d8b76e"
+        } else if $in < 3day {
+            "#2dcc72"
+        } else if $in < 1wk {
+            { fg: "#2dcc72" attr: "b" }
+        } else if $in < 6wk {
+            "#2388ff"
+        } else if $in < 52wk {
+            "#ffc183"
+        } else { "dark_gray" }
     }
     range: "#b6a0ff"
     float: "#b6a0ff"

--- a/themes/themes/e-n-c-o-m.nu
+++ b/themes/themes/e-n-c-o-m.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00cdcd" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#008b8b"
-      } else {{ fg: "#0081ff" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#008b8b"
+        } else {{ fg: "#0081ff" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9f0000" attr: "b" }
-      } else if $in < 6hr {
-        "#9f0000"
-      } else if $in < 1day {
-        "#ffcf00"
-      } else if $in < 3day {
-        "#008b00"
-      } else if $in < 1wk {
-        { fg: "#008b00" attr: "b" }
-      } else if $in < 6wk {
-        "#008b8b"
-      } else if $in < 52wk {
-        "#0081ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9f0000" attr: "b" }
+        } else if $in < 6hr {
+            "#9f0000"
+        } else if $in < 1day {
+            "#ffcf00"
+        } else if $in < 3day {
+            "#008b00"
+        } else if $in < 1wk {
+            { fg: "#008b00" attr: "b" }
+        } else if $in < 6wk {
+            "#008b8b"
+        } else if $in < 52wk {
+            "#0081ff"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/earthsong.nu
+++ b/themes/themes/earthsong.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#84f088" } else { "light_gray" } }
     int: "#e5c6aa"
     filesize: {|e|
-      if $e == 0b {
-        "#e5c6aa"
-      } else if $e < 1mb {
-        "#509552"
-      } else {{ fg: "#1398b9" }}
+        if $e == 0b {
+            "#e5c6aa"
+        } else if $e < 1mb {
+            "#509552"
+        } else {{ fg: "#1398b9" }}
     }
     duration: "#e5c6aa"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c94234" attr: "b" }
-      } else if $in < 6hr {
-        "#c94234"
-      } else if $in < 1day {
-        "#f5ae2e"
-      } else if $in < 3day {
-        "#85c54c"
-      } else if $in < 1wk {
-        { fg: "#85c54c" attr: "b" }
-      } else if $in < 6wk {
-        "#509552"
-      } else if $in < 52wk {
-        "#1398b9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c94234" attr: "b" }
+        } else if $in < 6hr {
+            "#c94234"
+        } else if $in < 1day {
+            "#f5ae2e"
+        } else if $in < 3day {
+            "#85c54c"
+        } else if $in < 1wk {
+            { fg: "#85c54c" attr: "b" }
+        } else if $in < 6wk {
+            "#509552"
+        } else if $in < 52wk {
+            "#1398b9"
+        } else { "dark_gray" }
     }
     range: "#e5c6aa"
     float: "#e5c6aa"

--- a/themes/themes/edge-dark.nu
+++ b/themes/themes/edge-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5ebaa5" } else { "light_gray" } }
     int: "#b7bec9"
     filesize: {|e|
-      if $e == 0b {
-        "#b7bec9"
-      } else if $e < 1mb {
-        "#5ebaa5"
-      } else {{ fg: "#73b3e7" }}
+        if $e == 0b {
+            "#b7bec9"
+        } else if $e < 1mb {
+            "#5ebaa5"
+        } else {{ fg: "#73b3e7" }}
     }
     duration: "#b7bec9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e77171" attr: "b" }
-      } else if $in < 6hr {
-        "#e77171"
-      } else if $in < 1day {
-        "#dbb774"
-      } else if $in < 3day {
-        "#a1bf78"
-      } else if $in < 1wk {
-        { fg: "#a1bf78" attr: "b" }
-      } else if $in < 6wk {
-        "#5ebaa5"
-      } else if $in < 52wk {
-        "#73b3e7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e77171" attr: "b" }
+        } else if $in < 6hr {
+            "#e77171"
+        } else if $in < 1day {
+            "#dbb774"
+        } else if $in < 3day {
+            "#a1bf78"
+        } else if $in < 1wk {
+            { fg: "#a1bf78" attr: "b" }
+        } else if $in < 6wk {
+            "#5ebaa5"
+        } else if $in < 52wk {
+            "#73b3e7"
+        } else { "dark_gray" }
     }
     range: "#b7bec9"
     float: "#b7bec9"

--- a/themes/themes/edge-light.nu
+++ b/themes/themes/edge-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#509c93" } else { "light_gray" } }
     int: "#5e646f"
     filesize: {|e|
-      if $e == 0b {
-        "#5e646f"
-      } else if $e < 1mb {
-        "#509c93"
-      } else {{ fg: "#6587bf" }}
+        if $e == 0b {
+            "#5e646f"
+        } else if $e < 1mb {
+            "#509c93"
+        } else {{ fg: "#6587bf" }}
     }
     duration: "#5e646f"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#db7070" attr: "b" }
-      } else if $in < 6hr {
-        "#db7070"
-      } else if $in < 1day {
-        "#d69822"
-      } else if $in < 3day {
-        "#7c9f4b"
-      } else if $in < 1wk {
-        { fg: "#7c9f4b" attr: "b" }
-      } else if $in < 6wk {
-        "#509c93"
-      } else if $in < 52wk {
-        "#6587bf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#db7070" attr: "b" }
+        } else if $in < 6hr {
+            "#db7070"
+        } else if $in < 1day {
+            "#d69822"
+        } else if $in < 3day {
+            "#7c9f4b"
+        } else if $in < 1wk {
+            { fg: "#7c9f4b" attr: "b" }
+        } else if $in < 6wk {
+            "#509c93"
+        } else if $in < 52wk {
+            "#6587bf"
+        } else { "dark_gray" }
     }
     range: "#5e646f"
     float: "#5e646f"

--- a/themes/themes/eighties.nu
+++ b/themes/themes/eighties.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#66cccc" } else { "light_gray" } }
     int: "#d3d0c8"
     filesize: {|e|
-      if $e == 0b {
-        "#d3d0c8"
-      } else if $e < 1mb {
-        "#66cccc"
-      } else {{ fg: "#6699cc" }}
+        if $e == 0b {
+            "#d3d0c8"
+        } else if $e < 1mb {
+            "#66cccc"
+        } else {{ fg: "#6699cc" }}
     }
     duration: "#d3d0c8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f2777a" attr: "b" }
-      } else if $in < 6hr {
-        "#f2777a"
-      } else if $in < 1day {
-        "#ffcc66"
-      } else if $in < 3day {
-        "#99cc99"
-      } else if $in < 1wk {
-        { fg: "#99cc99" attr: "b" }
-      } else if $in < 6wk {
-        "#66cccc"
-      } else if $in < 52wk {
-        "#6699cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f2777a" attr: "b" }
+        } else if $in < 6hr {
+            "#f2777a"
+        } else if $in < 1day {
+            "#ffcc66"
+        } else if $in < 3day {
+            "#99cc99"
+        } else if $in < 1wk {
+            { fg: "#99cc99" attr: "b" }
+        } else if $in < 6wk {
+            "#66cccc"
+        } else if $in < 52wk {
+            "#6699cc"
+        } else { "dark_gray" }
     }
     range: "#d3d0c8"
     float: "#d3d0c8"

--- a/themes/themes/elemental.nu
+++ b/themes/themes/elemental.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#59d599" } else { "light_gray" } }
     int: "#807974"
     filesize: {|e|
-      if $e == 0b {
-        "#807974"
-      } else if $e < 1mb {
-        "#387f58"
-      } else {{ fg: "#497f7d" }}
+        if $e == 0b {
+            "#807974"
+        } else if $e < 1mb {
+            "#387f58"
+        } else {{ fg: "#497f7d" }}
     }
     duration: "#807974"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#98290f" attr: "b" }
-      } else if $in < 6hr {
-        "#98290f"
-      } else if $in < 1day {
-        "#7f7111"
-      } else if $in < 3day {
-        "#479a43"
-      } else if $in < 1wk {
-        { fg: "#479a43" attr: "b" }
-      } else if $in < 6wk {
-        "#387f58"
-      } else if $in < 52wk {
-        "#497f7d"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#98290f" attr: "b" }
+        } else if $in < 6hr {
+            "#98290f"
+        } else if $in < 1day {
+            "#7f7111"
+        } else if $in < 3day {
+            "#479a43"
+        } else if $in < 1wk {
+            { fg: "#479a43" attr: "b" }
+        } else if $in < 6wk {
+            "#387f58"
+        } else if $in < 52wk {
+            "#497f7d"
+        } else { "dark_gray" }
     }
     range: "#807974"
     float: "#807974"

--- a/themes/themes/elementary.nu
+++ b/themes/themes/elementary.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4bb8fd" } else { "light_gray" } }
     int: "#f2f2f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f2f2f2"
-      } else if $e < 1mb {
-        "#2aa7e7"
-      } else {{ fg: "#004f9e" }}
+        if $e == 0b {
+            "#f2f2f2"
+        } else if $e < 1mb {
+            "#2aa7e7"
+        } else {{ fg: "#004f9e" }}
     }
     duration: "#f2f2f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e1321a" attr: "b" }
-      } else if $in < 6hr {
-        "#e1321a"
-      } else if $in < 1day {
-        "#ffc005"
-      } else if $in < 3day {
-        "#6ab017"
-      } else if $in < 1wk {
-        { fg: "#6ab017" attr: "b" }
-      } else if $in < 6wk {
-        "#2aa7e7"
-      } else if $in < 52wk {
-        "#004f9e"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e1321a" attr: "b" }
+        } else if $in < 6hr {
+            "#e1321a"
+        } else if $in < 1day {
+            "#ffc005"
+        } else if $in < 3day {
+            "#6ab017"
+        } else if $in < 1wk {
+            { fg: "#6ab017" attr: "b" }
+        } else if $in < 6wk {
+            "#2aa7e7"
+        } else if $in < 52wk {
+            "#004f9e"
+        } else { "dark_gray" }
     }
     range: "#f2f2f2"
     float: "#f2f2f2"

--- a/themes/themes/elic.nu
+++ b/themes/themes/elic.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4bb8fd" } else { "light_gray" } }
     int: "#2aa7e7"
     filesize: {|e|
-      if $e == 0b {
-        "#2aa7e7"
-      } else if $e < 1mb {
-        "#f2f2f2"
-      } else {{ fg: "#729fcf" }}
+        if $e == 0b {
+            "#2aa7e7"
+        } else if $e < 1mb {
+            "#f2f2f2"
+        } else {{ fg: "#729fcf" }}
     }
     duration: "#2aa7e7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e1321a" attr: "b" }
-      } else if $in < 6hr {
-        "#e1321a"
-      } else if $in < 1day {
-        "#ffc005"
-      } else if $in < 3day {
-        "#6ab017"
-      } else if $in < 1wk {
-        { fg: "#6ab017" attr: "b" }
-      } else if $in < 6wk {
-        "#f2f2f2"
-      } else if $in < 52wk {
-        "#729fcf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e1321a" attr: "b" }
+        } else if $in < 6hr {
+            "#e1321a"
+        } else if $in < 1day {
+            "#ffc005"
+        } else if $in < 3day {
+            "#6ab017"
+        } else if $in < 1wk {
+            { fg: "#6ab017" attr: "b" }
+        } else if $in < 6wk {
+            "#f2f2f2"
+        } else if $in < 52wk {
+            "#729fcf"
+        } else { "dark_gray" }
     }
     range: "#2aa7e7"
     float: "#2aa7e7"

--- a/themes/themes/elio.nu
+++ b/themes/themes/elio.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4bb8fd" } else { "light_gray" } }
     int: "#f2f2f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f2f2f2"
-      } else if $e < 1mb {
-        "#2aa7e7"
-      } else {{ fg: "#729fcf" }}
+        if $e == 0b {
+            "#f2f2f2"
+        } else if $e < 1mb {
+            "#2aa7e7"
+        } else {{ fg: "#729fcf" }}
     }
     duration: "#f2f2f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e1321a" attr: "b" }
-      } else if $in < 6hr {
-        "#e1321a"
-      } else if $in < 1day {
-        "#ffc005"
-      } else if $in < 3day {
-        "#6ab017"
-      } else if $in < 1wk {
-        { fg: "#6ab017" attr: "b" }
-      } else if $in < 6wk {
-        "#2aa7e7"
-      } else if $in < 52wk {
-        "#729fcf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e1321a" attr: "b" }
+        } else if $in < 6hr {
+            "#e1321a"
+        } else if $in < 1day {
+            "#ffc005"
+        } else if $in < 3day {
+            "#6ab017"
+        } else if $in < 1wk {
+            { fg: "#6ab017" attr: "b" }
+        } else if $in < 6wk {
+            "#2aa7e7"
+        } else if $in < 52wk {
+            "#729fcf"
+        } else { "dark_gray" }
     }
     range: "#f2f2f2"
     float: "#f2f2f2"

--- a/themes/themes/embark.nu
+++ b/themes/themes/embark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#63f2f1" } else { "light_gray" } }
     int: "#cbe3e7"
     filesize: {|e|
-      if $e == 0b {
-        "#cbe3e7"
-      } else if $e < 1mb {
-        "#87dfeb"
-      } else {{ fg: "#91ddff" }}
+        if $e == 0b {
+            "#cbe3e7"
+        } else if $e < 1mb {
+            "#87dfeb"
+        } else {{ fg: "#91ddff" }}
     }
     duration: "#cbe3e7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f48fb1" attr: "b" }
-      } else if $in < 6hr {
-        "#f48fb1"
-      } else if $in < 1day {
-        "#ffe6b3"
-      } else if $in < 3day {
-        "#a1efd3"
-      } else if $in < 1wk {
-        { fg: "#a1efd3" attr: "b" }
-      } else if $in < 6wk {
-        "#87dfeb"
-      } else if $in < 52wk {
-        "#91ddff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f48fb1" attr: "b" }
+        } else if $in < 6hr {
+            "#f48fb1"
+        } else if $in < 1day {
+            "#ffe6b3"
+        } else if $in < 3day {
+            "#a1efd3"
+        } else if $in < 1wk {
+            { fg: "#a1efd3" attr: "b" }
+        } else if $in < 6wk {
+            "#87dfeb"
+        } else if $in < 52wk {
+            "#91ddff"
+        } else { "dark_gray" }
     }
     range: "#cbe3e7"
     float: "#cbe3e7"

--- a/themes/themes/embers.nu
+++ b/themes/themes/embers.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#576d82" } else { "light_gray" } }
     int: "#a39a90"
     filesize: {|e|
-      if $e == 0b {
-        "#a39a90"
-      } else if $e < 1mb {
-        "#576d82"
-      } else {{ fg: "#6d5782" }}
+        if $e == 0b {
+            "#a39a90"
+        } else if $e < 1mb {
+            "#576d82"
+        } else {{ fg: "#6d5782" }}
     }
     duration: "#a39a90"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#826d57" attr: "b" }
-      } else if $in < 6hr {
-        "#826d57"
-      } else if $in < 1day {
-        "#6d8257"
-      } else if $in < 3day {
-        "#57826d"
-      } else if $in < 1wk {
-        { fg: "#57826d" attr: "b" }
-      } else if $in < 6wk {
-        "#576d82"
-      } else if $in < 52wk {
-        "#6d5782"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#826d57" attr: "b" }
+        } else if $in < 6hr {
+            "#826d57"
+        } else if $in < 1day {
+            "#6d8257"
+        } else if $in < 3day {
+            "#57826d"
+        } else if $in < 1wk {
+            { fg: "#57826d" attr: "b" }
+        } else if $in < 6wk {
+            "#576d82"
+        } else if $in < 52wk {
+            "#6d5782"
+        } else { "dark_gray" }
     }
     range: "#a39a90"
     float: "#a39a90"

--- a/themes/themes/equilibrium-dark.nu
+++ b/themes/themes/equilibrium-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00948b" } else { "light_gray" } }
     int: "#afaba2"
     filesize: {|e|
-      if $e == 0b {
-        "#afaba2"
-      } else if $e < 1mb {
-        "#00948b"
-      } else {{ fg: "#008dd1" }}
+        if $e == 0b {
+            "#afaba2"
+        } else if $e < 1mb {
+            "#00948b"
+        } else {{ fg: "#008dd1" }}
     }
     duration: "#afaba2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f04339" attr: "b" }
-      } else if $in < 6hr {
-        "#f04339"
-      } else if $in < 1day {
-        "#bb8801"
-      } else if $in < 3day {
-        "#7f8b00"
-      } else if $in < 1wk {
-        { fg: "#7f8b00" attr: "b" }
-      } else if $in < 6wk {
-        "#00948b"
-      } else if $in < 52wk {
-        "#008dd1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f04339" attr: "b" }
+        } else if $in < 6hr {
+            "#f04339"
+        } else if $in < 1day {
+            "#bb8801"
+        } else if $in < 3day {
+            "#7f8b00"
+        } else if $in < 1wk {
+            { fg: "#7f8b00" attr: "b" }
+        } else if $in < 6wk {
+            "#00948b"
+        } else if $in < 52wk {
+            "#008dd1"
+        } else { "dark_gray" }
     }
     range: "#afaba2"
     float: "#afaba2"

--- a/themes/themes/equilibrium-gray-dark.nu
+++ b/themes/themes/equilibrium-gray-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00948b" } else { "light_gray" } }
     int: "#ababab"
     filesize: {|e|
-      if $e == 0b {
-        "#ababab"
-      } else if $e < 1mb {
-        "#00948b"
-      } else {{ fg: "#008dd1" }}
+        if $e == 0b {
+            "#ababab"
+        } else if $e < 1mb {
+            "#00948b"
+        } else {{ fg: "#008dd1" }}
     }
     duration: "#ababab"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f04339" attr: "b" }
-      } else if $in < 6hr {
-        "#f04339"
-      } else if $in < 1day {
-        "#bb8801"
-      } else if $in < 3day {
-        "#7f8b00"
-      } else if $in < 1wk {
-        { fg: "#7f8b00" attr: "b" }
-      } else if $in < 6wk {
-        "#00948b"
-      } else if $in < 52wk {
-        "#008dd1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f04339" attr: "b" }
+        } else if $in < 6hr {
+            "#f04339"
+        } else if $in < 1day {
+            "#bb8801"
+        } else if $in < 3day {
+            "#7f8b00"
+        } else if $in < 1wk {
+            { fg: "#7f8b00" attr: "b" }
+        } else if $in < 6wk {
+            "#00948b"
+        } else if $in < 52wk {
+            "#008dd1"
+        } else { "dark_gray" }
     }
     range: "#ababab"
     float: "#ababab"

--- a/themes/themes/equilibrium-gray-light.nu
+++ b/themes/themes/equilibrium-gray-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#007a72" } else { "light_gray" } }
     int: "#474747"
     filesize: {|e|
-      if $e == 0b {
-        "#474747"
-      } else if $e < 1mb {
-        "#007a72"
-      } else {{ fg: "#0073b5" }}
+        if $e == 0b {
+            "#474747"
+        } else if $e < 1mb {
+            "#007a72"
+        } else {{ fg: "#0073b5" }}
     }
     duration: "#474747"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d02023" attr: "b" }
-      } else if $in < 6hr {
-        "#d02023"
-      } else if $in < 1day {
-        "#9d6f00"
-      } else if $in < 3day {
-        "#637200"
-      } else if $in < 1wk {
-        { fg: "#637200" attr: "b" }
-      } else if $in < 6wk {
-        "#007a72"
-      } else if $in < 52wk {
-        "#0073b5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d02023" attr: "b" }
+        } else if $in < 6hr {
+            "#d02023"
+        } else if $in < 1day {
+            "#9d6f00"
+        } else if $in < 3day {
+            "#637200"
+        } else if $in < 1wk {
+            { fg: "#637200" attr: "b" }
+        } else if $in < 6wk {
+            "#007a72"
+        } else if $in < 52wk {
+            "#0073b5"
+        } else { "dark_gray" }
     }
     range: "#474747"
     float: "#474747"

--- a/themes/themes/equilibrium-light.nu
+++ b/themes/themes/equilibrium-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#007a72" } else { "light_gray" } }
     int: "#43474e"
     filesize: {|e|
-      if $e == 0b {
-        "#43474e"
-      } else if $e < 1mb {
-        "#007a72"
-      } else {{ fg: "#0073b5" }}
+        if $e == 0b {
+            "#43474e"
+        } else if $e < 1mb {
+            "#007a72"
+        } else {{ fg: "#0073b5" }}
     }
     duration: "#43474e"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d02023" attr: "b" }
-      } else if $in < 6hr {
-        "#d02023"
-      } else if $in < 1day {
-        "#9d6f00"
-      } else if $in < 3day {
-        "#637200"
-      } else if $in < 1wk {
-        { fg: "#637200" attr: "b" }
-      } else if $in < 6wk {
-        "#007a72"
-      } else if $in < 52wk {
-        "#0073b5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d02023" attr: "b" }
+        } else if $in < 6hr {
+            "#d02023"
+        } else if $in < 1day {
+            "#9d6f00"
+        } else if $in < 3day {
+            "#637200"
+        } else if $in < 1wk {
+            { fg: "#637200" attr: "b" }
+        } else if $in < 6wk {
+            "#007a72"
+        } else if $in < 52wk {
+            "#0073b5"
+        } else { "dark_gray" }
     }
     range: "#43474e"
     float: "#43474e"

--- a/themes/themes/espresso-libre.nu
+++ b/themes/themes/espresso-libre.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#34e2e2" } else { "light_gray" } }
     int: "#d3d7cf"
     filesize: {|e|
-      if $e == 0b {
-        "#d3d7cf"
-      } else if $e < 1mb {
-        "#06989a"
-      } else {{ fg: "#0066ff" }}
+        if $e == 0b {
+            "#d3d7cf"
+        } else if $e < 1mb {
+            "#06989a"
+        } else {{ fg: "#0066ff" }}
     }
     duration: "#d3d7cf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc0000" attr: "b" }
-      } else if $in < 6hr {
-        "#cc0000"
-      } else if $in < 1day {
-        "#f0e53a"
-      } else if $in < 3day {
-        "#1a921c"
-      } else if $in < 1wk {
-        { fg: "#1a921c" attr: "b" }
-      } else if $in < 6wk {
-        "#06989a"
-      } else if $in < 52wk {
-        "#0066ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc0000" attr: "b" }
+        } else if $in < 6hr {
+            "#cc0000"
+        } else if $in < 1day {
+            "#f0e53a"
+        } else if $in < 3day {
+            "#1a921c"
+        } else if $in < 1wk {
+            { fg: "#1a921c" attr: "b" }
+        } else if $in < 6wk {
+            "#06989a"
+        } else if $in < 52wk {
+            "#0066ff"
+        } else { "dark_gray" }
     }
     range: "#d3d7cf"
     float: "#d3d7cf"

--- a/themes/themes/espresso.nu
+++ b/themes/themes/espresso.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#bed6ff" } else { "light_gray" } }
     int: "#cccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#cccccc"
-      } else if $e < 1mb {
-        "#bed6ff"
-      } else {{ fg: "#6c99bb" }}
+        if $e == 0b {
+            "#cccccc"
+        } else if $e < 1mb {
+            "#bed6ff"
+        } else {{ fg: "#6c99bb" }}
     }
     duration: "#cccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d25252" attr: "b" }
-      } else if $in < 6hr {
-        "#d25252"
-      } else if $in < 1day {
-        "#ffc66d"
-      } else if $in < 3day {
-        "#a5c261"
-      } else if $in < 1wk {
-        { fg: "#a5c261" attr: "b" }
-      } else if $in < 6wk {
-        "#bed6ff"
-      } else if $in < 52wk {
-        "#6c99bb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d25252" attr: "b" }
+        } else if $in < 6hr {
+            "#d25252"
+        } else if $in < 1day {
+            "#ffc66d"
+        } else if $in < 3day {
+            "#a5c261"
+        } else if $in < 1wk {
+            { fg: "#a5c261" attr: "b" }
+        } else if $in < 6wk {
+            "#bed6ff"
+        } else if $in < 52wk {
+            "#6c99bb"
+        } else { "dark_gray" }
     }
     range: "#cccccc"
     float: "#cccccc"

--- a/themes/themes/eva-dim.nu
+++ b/themes/themes/eva-dim.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4b8f77" } else { "light_gray" } }
     int: "#9fa2a6"
     filesize: {|e|
-      if $e == 0b {
-        "#9fa2a6"
-      } else if $e < 1mb {
-        "#4b8f77"
-      } else {{ fg: "#1ae1dc" }}
+        if $e == 0b {
+            "#9fa2a6"
+        } else if $e < 1mb {
+            "#4b8f77"
+        } else {{ fg: "#1ae1dc" }}
     }
     duration: "#9fa2a6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c4676c" attr: "b" }
-      } else if $in < 6hr {
-        "#c4676c"
-      } else if $in < 1day {
-        "#cfd05d"
-      } else if $in < 3day {
-        "#5de561"
-      } else if $in < 1wk {
-        { fg: "#5de561" attr: "b" }
-      } else if $in < 6wk {
-        "#4b8f77"
-      } else if $in < 52wk {
-        "#1ae1dc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c4676c" attr: "b" }
+        } else if $in < 6hr {
+            "#c4676c"
+        } else if $in < 1day {
+            "#cfd05d"
+        } else if $in < 3day {
+            "#5de561"
+        } else if $in < 1wk {
+            { fg: "#5de561" attr: "b" }
+        } else if $in < 6wk {
+            "#4b8f77"
+        } else if $in < 52wk {
+            "#1ae1dc"
+        } else { "dark_gray" }
     }
     range: "#9fa2a6"
     float: "#9fa2a6"

--- a/themes/themes/eva.nu
+++ b/themes/themes/eva.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4b8f77" } else { "light_gray" } }
     int: "#9fa2a6"
     filesize: {|e|
-      if $e == 0b {
-        "#9fa2a6"
-      } else if $e < 1mb {
-        "#4b8f77"
-      } else {{ fg: "#15f4ee" }}
+        if $e == 0b {
+            "#9fa2a6"
+        } else if $e < 1mb {
+            "#4b8f77"
+        } else {{ fg: "#15f4ee" }}
     }
     duration: "#9fa2a6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c4676c" attr: "b" }
-      } else if $in < 6hr {
-        "#c4676c"
-      } else if $in < 1day {
-        "#ffff66"
-      } else if $in < 3day {
-        "#66ff66"
-      } else if $in < 1wk {
-        { fg: "#66ff66" attr: "b" }
-      } else if $in < 6wk {
-        "#4b8f77"
-      } else if $in < 52wk {
-        "#15f4ee"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c4676c" attr: "b" }
+        } else if $in < 6hr {
+            "#c4676c"
+        } else if $in < 1day {
+            "#ffff66"
+        } else if $in < 3day {
+            "#66ff66"
+        } else if $in < 1wk {
+            { fg: "#66ff66" attr: "b" }
+        } else if $in < 6wk {
+            "#4b8f77"
+        } else if $in < 52wk {
+            "#15f4ee"
+        } else { "dark_gray" }
     }
     range: "#9fa2a6"
     float: "#9fa2a6"

--- a/themes/themes/everforest-light.nu
+++ b/themes/themes/everforest-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#35a77c" } else { "light_gray" } }
     int: "#dfddc8"
     filesize: {|e|
-      if $e == 0b {
-        "#dfddc8"
-      } else if $e < 1mb {
-        "#35a77c"
-      } else {{ fg: "#3a94c5" }}
+        if $e == 0b {
+            "#dfddc8"
+        } else if $e < 1mb {
+            "#35a77c"
+        } else {{ fg: "#3a94c5" }}
     }
     duration: "#dfddc8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f85552" attr: "b" }
-      } else if $in < 6hr {
-        "#f85552"
-      } else if $in < 1day {
-        "#dfa000"
-      } else if $in < 3day {
-        "#8da101"
-      } else if $in < 1wk {
-        { fg: "#8da101" attr: "b" }
-      } else if $in < 6wk {
-        "#35a77c"
-      } else if $in < 52wk {
-        "#3a94c5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f85552" attr: "b" }
+        } else if $in < 6hr {
+            "#f85552"
+        } else if $in < 1day {
+            "#dfa000"
+        } else if $in < 3day {
+            "#8da101"
+        } else if $in < 1wk {
+            { fg: "#8da101" attr: "b" }
+        } else if $in < 6wk {
+            "#35a77c"
+        } else if $in < 52wk {
+            "#3a94c5"
+        } else { "dark_gray" }
     }
     range: "#dfddc8"
     float: "#dfddc8"

--- a/themes/themes/everforest.nu
+++ b/themes/themes/everforest.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#83c092" } else { "light_gray" } }
     int: "#d3c6aa"
     filesize: {|e|
-      if $e == 0b {
-        "#d3c6aa"
-      } else if $e < 1mb {
-        "#83c092"
-      } else {{ fg: "#7fbbb3" }}
+        if $e == 0b {
+            "#d3c6aa"
+        } else if $e < 1mb {
+            "#83c092"
+        } else {{ fg: "#7fbbb3" }}
     }
     duration: "#d3c6aa"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e67e80" attr: "b" }
-      } else if $in < 6hr {
-        "#e67e80"
-      } else if $in < 1day {
-        "#dbbc7f"
-      } else if $in < 3day {
-        "#a7c080"
-      } else if $in < 1wk {
-        { fg: "#a7c080" attr: "b" }
-      } else if $in < 6wk {
-        "#83c092"
-      } else if $in < 52wk {
-        "#7fbbb3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e67e80" attr: "b" }
+        } else if $in < 6hr {
+            "#e67e80"
+        } else if $in < 1day {
+            "#dbbc7f"
+        } else if $in < 3day {
+            "#a7c080"
+        } else if $in < 1wk {
+            { fg: "#a7c080" attr: "b" }
+        } else if $in < 6wk {
+            "#83c092"
+        } else if $in < 52wk {
+            "#7fbbb3"
+        } else { "dark_gray" }
     }
     range: "#d3c6aa"
     float: "#d3c6aa"

--- a/themes/themes/falcon.nu
+++ b/themes/themes/falcon.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8bccbf" } else { "light_gray" } }
     int: "#b4b4b9"
     filesize: {|e|
-      if $e == 0b {
-        "#b4b4b9"
-      } else if $e < 1mb {
-        "#34bfa4"
-      } else {{ fg: "#635196" }}
+        if $e == 0b {
+            "#b4b4b9"
+        } else if $e < 1mb {
+            "#34bfa4"
+        } else {{ fg: "#635196" }}
     }
     duration: "#b4b4b9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff3600" attr: "b" }
-      } else if $in < 6hr {
-        "#ff3600"
-      } else if $in < 1day {
-        "#ffc552"
-      } else if $in < 3day {
-        "#718e3f"
-      } else if $in < 1wk {
-        { fg: "#718e3f" attr: "b" }
-      } else if $in < 6wk {
-        "#34bfa4"
-      } else if $in < 52wk {
-        "#635196"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff3600" attr: "b" }
+        } else if $in < 6hr {
+            "#ff3600"
+        } else if $in < 1day {
+            "#ffc552"
+        } else if $in < 3day {
+            "#718e3f"
+        } else if $in < 1wk {
+            { fg: "#718e3f" attr: "b" }
+        } else if $in < 6wk {
+            "#34bfa4"
+        } else if $in < 52wk {
+            "#635196"
+        } else { "dark_gray" }
     }
     range: "#b4b4b9"
     float: "#b4b4b9"

--- a/themes/themes/farin.nu
+++ b/themes/themes/farin.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#66ffdd" } else { "light_gray" } }
     int: "#cccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#cccccc"
-      } else if $e < 1mb {
-        "#00ffbb"
-      } else {{ fg: "#1155ff" }}
+        if $e == 0b {
+            "#cccccc"
+        } else if $e < 1mb {
+            "#00ffbb"
+        } else {{ fg: "#1155ff" }}
     }
     duration: "#cccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff1155" attr: "b" }
-      } else if $in < 6hr {
-        "#ff1155"
-      } else if $in < 1day {
-        "#ffbb33"
-      } else if $in < 3day {
-        "#11ff55"
-      } else if $in < 1wk {
-        { fg: "#11ff55" attr: "b" }
-      } else if $in < 6wk {
-        "#00ffbb"
-      } else if $in < 52wk {
-        "#1155ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff1155" attr: "b" }
+        } else if $in < 6hr {
+            "#ff1155"
+        } else if $in < 1day {
+            "#ffbb33"
+        } else if $in < 3day {
+            "#11ff55"
+        } else if $in < 1wk {
+            { fg: "#11ff55" attr: "b" }
+        } else if $in < 6wk {
+            "#00ffbb"
+        } else if $in < 52wk {
+            "#1155ff"
+        } else { "dark_gray" }
     }
     range: "#cccccc"
     float: "#cccccc"

--- a/themes/themes/ffive.nu
+++ b/themes/themes/ffive.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#6dd8d8" } else { "light_gray" } }
     int: "#dadadb"
     filesize: {|e|
-      if $e == 0b {
-        "#dadadb"
-      } else if $e < 1mb {
-        "#54cece"
-      } else {{ fg: "#356abf" }}
+        if $e == 0b {
+            "#dadadb"
+        } else if $e < 1mb {
+            "#54cece"
+        } else {{ fg: "#356abf" }}
     }
     duration: "#dadadb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ea2639" attr: "b" }
-      } else if $in < 6hr {
-        "#ea2639"
-      } else if $in < 1day {
-        "#f8f800"
-      } else if $in < 3day {
-        "#32bf46"
-      } else if $in < 1wk {
-        { fg: "#32bf46" attr: "b" }
-      } else if $in < 6wk {
-        "#54cece"
-      } else if $in < 52wk {
-        "#356abf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ea2639" attr: "b" }
+        } else if $in < 6hr {
+            "#ea2639"
+        } else if $in < 1day {
+            "#f8f800"
+        } else if $in < 3day {
+            "#32bf46"
+        } else if $in < 1wk {
+            { fg: "#32bf46" attr: "b" }
+        } else if $in < 6wk {
+            "#54cece"
+        } else if $in < 52wk {
+            "#356abf"
+        } else { "dark_gray" }
     }
     range: "#dadadb"
     float: "#dadadb"

--- a/themes/themes/fideloper.nu
+++ b/themes/themes/fideloper.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#81908f" } else { "light_gray" } }
     int: "#e9e2cd"
     filesize: {|e|
-      if $e == 0b {
-        "#e9e2cd"
-      } else if $e < 1mb {
-        "#309185"
-      } else {{ fg: "#2e78c1" }}
+        if $e == 0b {
+            "#e9e2cd"
+        } else if $e < 1mb {
+            "#309185"
+        } else {{ fg: "#2e78c1" }}
     }
     duration: "#e9e2cd"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ca1d2c" attr: "b" }
-      } else if $in < 6hr {
-        "#ca1d2c"
-      } else if $in < 1day {
-        "#b7aa9a"
-      } else if $in < 3day {
-        "#edb7ab"
-      } else if $in < 1wk {
-        { fg: "#edb7ab" attr: "b" }
-      } else if $in < 6wk {
-        "#309185"
-      } else if $in < 52wk {
-        "#2e78c1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ca1d2c" attr: "b" }
+        } else if $in < 6hr {
+            "#ca1d2c"
+        } else if $in < 1day {
+            "#b7aa9a"
+        } else if $in < 3day {
+            "#edb7ab"
+        } else if $in < 1wk {
+            { fg: "#edb7ab" attr: "b" }
+        } else if $in < 6wk {
+            "#309185"
+        } else if $in < 52wk {
+            "#2e78c1"
+        } else { "dark_gray" }
     }
     range: "#e9e2cd"
     float: "#e9e2cd"

--- a/themes/themes/fishtank.nu
+++ b/themes/themes/fishtank.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a5bd86" } else { "light_gray" } }
     int: "#ecf0fc"
     filesize: {|e|
-      if $e == 0b {
-        "#ecf0fc"
-      } else if $e < 1mb {
-        "#968763"
-      } else {{ fg: "#525fb8" }}
+        if $e == 0b {
+            "#ecf0fc"
+        } else if $e < 1mb {
+            "#968763"
+        } else {{ fg: "#525fb8" }}
     }
     duration: "#ecf0fc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c6004a" attr: "b" }
-      } else if $in < 6hr {
-        "#c6004a"
-      } else if $in < 1day {
-        "#fecd5e"
-      } else if $in < 3day {
-        "#acf157"
-      } else if $in < 1wk {
-        { fg: "#acf157" attr: "b" }
-      } else if $in < 6wk {
-        "#968763"
-      } else if $in < 52wk {
-        "#525fb8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c6004a" attr: "b" }
+        } else if $in < 6hr {
+            "#c6004a"
+        } else if $in < 1day {
+            "#fecd5e"
+        } else if $in < 3day {
+            "#acf157"
+        } else if $in < 1wk {
+            { fg: "#acf157" attr: "b" }
+        } else if $in < 6wk {
+            "#968763"
+        } else if $in < 52wk {
+            "#525fb8"
+        } else { "dark_gray" }
     }
     range: "#ecf0fc"
     float: "#ecf0fc"

--- a/themes/themes/flat.nu
+++ b/themes/themes/flat.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1abc9c" } else { "light_gray" } }
     int: "#e0e0e0"
     filesize: {|e|
-      if $e == 0b {
-        "#e0e0e0"
-      } else if $e < 1mb {
-        "#1abc9c"
-      } else {{ fg: "#3498db" }}
+        if $e == 0b {
+            "#e0e0e0"
+        } else if $e < 1mb {
+            "#1abc9c"
+        } else {{ fg: "#3498db" }}
     }
     duration: "#e0e0e0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e74c3c" attr: "b" }
-      } else if $in < 6hr {
-        "#e74c3c"
-      } else if $in < 1day {
-        "#f1c40f"
-      } else if $in < 3day {
-        "#2ecc71"
-      } else if $in < 1wk {
-        { fg: "#2ecc71" attr: "b" }
-      } else if $in < 6wk {
-        "#1abc9c"
-      } else if $in < 52wk {
-        "#3498db"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e74c3c" attr: "b" }
+        } else if $in < 6hr {
+            "#e74c3c"
+        } else if $in < 1day {
+            "#f1c40f"
+        } else if $in < 3day {
+            "#2ecc71"
+        } else if $in < 1wk {
+            { fg: "#2ecc71" attr: "b" }
+        } else if $in < 6wk {
+            "#1abc9c"
+        } else if $in < 52wk {
+            "#3498db"
+        } else { "dark_gray" }
     }
     range: "#e0e0e0"
     float: "#e0e0e0"

--- a/themes/themes/flatland.nu
+++ b/themes/themes/flatland.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#d63865" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#d63865"
-      } else {{ fg: "#5096be" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#d63865"
+        } else {{ fg: "#5096be" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f18339" attr: "b" }
-      } else if $in < 6hr {
-        "#f18339"
-      } else if $in < 1day {
-        "#f4ef6d"
-      } else if $in < 3day {
-        "#9fd364"
-      } else if $in < 1wk {
-        { fg: "#9fd364" attr: "b" }
-      } else if $in < 6wk {
-        "#d63865"
-      } else if $in < 52wk {
-        "#5096be"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f18339" attr: "b" }
+        } else if $in < 6hr {
+            "#f18339"
+        } else if $in < 1day {
+            "#f4ef6d"
+        } else if $in < 3day {
+            "#9fd364"
+        } else if $in < 1wk {
+            { fg: "#9fd364" attr: "b" }
+        } else if $in < 6wk {
+            "#d63865"
+        } else if $in < 52wk {
+            "#5096be"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/floraverse.nu
+++ b/themes/themes/floraverse.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#62caa8" } else { "light_gray" } }
     int: "#f3e0b8"
     filesize: {|e|
-      if $e == 0b {
-        "#f3e0b8"
-      } else if $e < 1mb {
-        "#42a38c"
-      } else {{ fg: "#1d6da1" }}
+        if $e == 0b {
+            "#f3e0b8"
+        } else if $e < 1mb {
+            "#42a38c"
+        } else {{ fg: "#1d6da1" }}
     }
     duration: "#f3e0b8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#64002c" attr: "b" }
-      } else if $in < 6hr {
-        "#64002c"
-      } else if $in < 1day {
-        "#cd751c"
-      } else if $in < 3day {
-        "#5d731a"
-      } else if $in < 1wk {
-        { fg: "#5d731a" attr: "b" }
-      } else if $in < 6wk {
-        "#42a38c"
-      } else if $in < 52wk {
-        "#1d6da1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#64002c" attr: "b" }
+        } else if $in < 6hr {
+            "#64002c"
+        } else if $in < 1day {
+            "#cd751c"
+        } else if $in < 3day {
+            "#5d731a"
+        } else if $in < 1wk {
+            { fg: "#5d731a" attr: "b" }
+        } else if $in < 6wk {
+            "#42a38c"
+        } else if $in < 52wk {
+            "#1d6da1"
+        } else { "dark_gray" }
     }
     range: "#f3e0b8"
     float: "#f3e0b8"

--- a/themes/themes/forest-night.nu
+++ b/themes/themes/forest-night.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a9dd9d" } else { "light_gray" } }
     int: "#ffebc3"
     filesize: {|e|
-      if $e == 0b {
-        "#ffebc3"
-      } else if $e < 1mb {
-        "#a9dd9d"
-      } else {{ fg: "#bdd0e5" }}
+        if $e == 0b {
+            "#ffebc3"
+        } else if $e < 1mb {
+            "#a9dd9d"
+        } else {{ fg: "#bdd0e5" }}
     }
     duration: "#ffebc3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fd8489" attr: "b" }
-      } else if $in < 6hr {
-        "#fd8489"
-      } else if $in < 1day {
-        "#f0aa8a"
-      } else if $in < 3day {
-        "#a9dd9d"
-      } else if $in < 1wk {
-        { fg: "#a9dd9d" attr: "b" }
-      } else if $in < 6wk {
-        "#a9dd9d"
-      } else if $in < 52wk {
-        "#bdd0e5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fd8489" attr: "b" }
+        } else if $in < 6hr {
+            "#fd8489"
+        } else if $in < 1day {
+            "#f0aa8a"
+        } else if $in < 3day {
+            "#a9dd9d"
+        } else if $in < 1wk {
+            { fg: "#a9dd9d" attr: "b" }
+        } else if $in < 6wk {
+            "#a9dd9d"
+        } else if $in < 52wk {
+            "#bdd0e5"
+        } else { "dark_gray" }
     }
     range: "#ffebc3"
     float: "#ffebc3"

--- a/themes/themes/foxnightly.nu
+++ b/themes/themes/foxnightly.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c4a000" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#acacae"
-      } else {{ fg: "#66a05b" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#acacae"
+        } else {{ fg: "#66a05b" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b98eff" attr: "b" }
-      } else if $in < 6hr {
-        "#b98eff"
-      } else if $in < 1day {
-        "#729fcf"
-      } else if $in < 3day {
-        "#ff7de9"
-      } else if $in < 1wk {
-        { fg: "#ff7de9" attr: "b" }
-      } else if $in < 6wk {
-        "#acacae"
-      } else if $in < 52wk {
-        "#66a05b"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b98eff" attr: "b" }
+        } else if $in < 6hr {
+            "#b98eff"
+        } else if $in < 1day {
+            "#729fcf"
+        } else if $in < 3day {
+            "#ff7de9"
+        } else if $in < 1wk {
+            { fg: "#ff7de9" attr: "b" }
+        } else if $in < 6wk {
+            "#acacae"
+        } else if $in < 52wk {
+            "#66a05b"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/framer.nu
+++ b/themes/themes/framer.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#acddfd" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#acddfd"
-      } else {{ fg: "#20bcfc" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#acddfd"
+        } else {{ fg: "#20bcfc" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fd886b" attr: "b" }
-      } else if $in < 6hr {
-        "#fd886b"
-      } else if $in < 1day {
-        "#fecb6e"
-      } else if $in < 3day {
-        "#32ccdc"
-      } else if $in < 1wk {
-        { fg: "#32ccdc" attr: "b" }
-      } else if $in < 6wk {
-        "#acddfd"
-      } else if $in < 52wk {
-        "#20bcfc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fd886b" attr: "b" }
+        } else if $in < 6hr {
+            "#fd886b"
+        } else if $in < 1day {
+            "#fecb6e"
+        } else if $in < 3day {
+            "#32ccdc"
+        } else if $in < 1wk {
+            { fg: "#32ccdc" attr: "b" }
+        } else if $in < 6wk {
+            "#acddfd"
+        } else if $in < 52wk {
+            "#20bcfc"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/freya.nu
+++ b/themes/themes/freya.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2aa198" } else { "light_gray" } }
     int: "#94a3a5"
     filesize: {|e|
-      if $e == 0b {
-        "#94a3a5"
-      } else if $e < 1mb {
-        "#2aa198"
-      } else {{ fg: "#268bd2" }}
+        if $e == 0b {
+            "#94a3a5"
+        } else if $e < 1mb {
+            "#2aa198"
+        } else {{ fg: "#268bd2" }}
     }
     duration: "#94a3a5"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dc322f" attr: "b" }
-      } else if $in < 6hr {
-        "#dc322f"
-      } else if $in < 1day {
-        "#b58900"
-      } else if $in < 3day {
-        "#859900"
-      } else if $in < 1wk {
-        { fg: "#859900" attr: "b" }
-      } else if $in < 6wk {
-        "#2aa198"
-      } else if $in < 52wk {
-        "#268bd2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dc322f" attr: "b" }
+        } else if $in < 6hr {
+            "#dc322f"
+        } else if $in < 1day {
+            "#b58900"
+        } else if $in < 3day {
+            "#859900"
+        } else if $in < 1wk {
+            { fg: "#859900" attr: "b" }
+        } else if $in < 6wk {
+            "#2aa198"
+        } else if $in < 52wk {
+            "#268bd2"
+        } else { "dark_gray" }
     }
     range: "#94a3a5"
     float: "#94a3a5"

--- a/themes/themes/frontend-delight.nu
+++ b/themes/themes/frontend-delight.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4fbce6" } else { "light_gray" } }
     int: "#adadad"
     filesize: {|e|
-      if $e == 0b {
-        "#adadad"
-      } else if $e < 1mb {
-        "#3ca1a6"
-      } else {{ fg: "#2c70b7" }}
+        if $e == 0b {
+            "#adadad"
+        } else if $e < 1mb {
+            "#3ca1a6"
+        } else {{ fg: "#2c70b7" }}
     }
     duration: "#adadad"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f8511b" attr: "b" }
-      } else if $in < 6hr {
-        "#f8511b"
-      } else if $in < 1day {
-        "#fa771d"
-      } else if $in < 3day {
-        "#565747"
-      } else if $in < 1wk {
-        { fg: "#565747" attr: "b" }
-      } else if $in < 6wk {
-        "#3ca1a6"
-      } else if $in < 52wk {
-        "#2c70b7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f8511b" attr: "b" }
+        } else if $in < 6hr {
+            "#f8511b"
+        } else if $in < 1day {
+            "#fa771d"
+        } else if $in < 3day {
+            "#565747"
+        } else if $in < 1wk {
+            { fg: "#565747" attr: "b" }
+        } else if $in < 6wk {
+            "#3ca1a6"
+        } else if $in < 52wk {
+            "#2c70b7"
+        } else { "dark_gray" }
     }
     range: "#adadad"
     float: "#adadad"

--- a/themes/themes/frontend-fun-forrest.nu
+++ b/themes/themes/frontend-fun-forrest.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#e6a96b" } else { "light_gray" } }
     int: "#ddc265"
     filesize: {|e|
-      if $e == 0b {
-        "#ddc265"
-      } else if $e < 1mb {
-        "#da8213"
-      } else {{ fg: "#4699a3" }}
+        if $e == 0b {
+            "#ddc265"
+        } else if $e < 1mb {
+            "#da8213"
+        } else {{ fg: "#4699a3" }}
     }
     duration: "#ddc265"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d6262b" attr: "b" }
-      } else if $in < 6hr {
-        "#d6262b"
-      } else if $in < 1day {
-        "#be8a13"
-      } else if $in < 3day {
-        "#919c00"
-      } else if $in < 1wk {
-        { fg: "#919c00" attr: "b" }
-      } else if $in < 6wk {
-        "#da8213"
-      } else if $in < 52wk {
-        "#4699a3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d6262b" attr: "b" }
+        } else if $in < 6hr {
+            "#d6262b"
+        } else if $in < 1day {
+            "#be8a13"
+        } else if $in < 3day {
+            "#919c00"
+        } else if $in < 1wk {
+            { fg: "#919c00" attr: "b" }
+        } else if $in < 6wk {
+            "#da8213"
+        } else if $in < 52wk {
+            "#4699a3"
+        } else { "dark_gray" }
     }
     range: "#ddc265"
     float: "#ddc265"

--- a/themes/themes/frontend-galaxy.nu
+++ b/themes/themes/frontend-galaxy.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3979bc" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#1f9ee7"
-      } else {{ fg: "#589df6" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#1f9ee7"
+        } else {{ fg: "#589df6" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f9555f" attr: "b" }
-      } else if $in < 6hr {
-        "#f9555f"
-      } else if $in < 1day {
-        "#fef02a"
-      } else if $in < 3day {
-        "#21b089"
-      } else if $in < 1wk {
-        { fg: "#21b089" attr: "b" }
-      } else if $in < 6wk {
-        "#1f9ee7"
-      } else if $in < 52wk {
-        "#589df6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f9555f" attr: "b" }
+        } else if $in < 6hr {
+            "#f9555f"
+        } else if $in < 1day {
+            "#fef02a"
+        } else if $in < 3day {
+            "#21b089"
+        } else if $in < 1wk {
+            { fg: "#21b089" attr: "b" }
+        } else if $in < 6wk {
+            "#1f9ee7"
+        } else if $in < 52wk {
+            "#589df6"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/fruit-soda.nu
+++ b/themes/themes/fruit-soda.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#0f9cfd" } else { "light_gray" } }
     int: "#515151"
     filesize: {|e|
-      if $e == 0b {
-        "#515151"
-      } else if $e < 1mb {
-        "#0f9cfd"
-      } else {{ fg: "#2931df" }}
+        if $e == 0b {
+            "#515151"
+        } else if $e < 1mb {
+            "#0f9cfd"
+        } else {{ fg: "#2931df" }}
     }
     duration: "#515151"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fe3e31" attr: "b" }
-      } else if $in < 6hr {
-        "#fe3e31"
-      } else if $in < 1day {
-        "#f7e203"
-      } else if $in < 3day {
-        "#47f74c"
-      } else if $in < 1wk {
-        { fg: "#47f74c" attr: "b" }
-      } else if $in < 6wk {
-        "#0f9cfd"
-      } else if $in < 52wk {
-        "#2931df"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fe3e31" attr: "b" }
+        } else if $in < 6hr {
+            "#fe3e31"
+        } else if $in < 1day {
+            "#f7e203"
+        } else if $in < 3day {
+            "#47f74c"
+        } else if $in < 1wk {
+            { fg: "#47f74c" attr: "b" }
+        } else if $in < 6wk {
+            "#0f9cfd"
+        } else if $in < 52wk {
+            "#2931df"
+        } else { "dark_gray" }
     }
     range: "#515151"
     float: "#515151"

--- a/themes/themes/gigavolt.nu
+++ b/themes/themes/gigavolt.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#fb6acb" } else { "light_gray" } }
     int: "#e9e7e1"
     filesize: {|e|
-      if $e == 0b {
-        "#e9e7e1"
-      } else if $e < 1mb {
-        "#fb6acb"
-      } else {{ fg: "#40bfff" }}
+        if $e == 0b {
+            "#e9e7e1"
+        } else if $e < 1mb {
+            "#fb6acb"
+        } else {{ fg: "#40bfff" }}
     }
     duration: "#e9e7e1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff661a" attr: "b" }
-      } else if $in < 6hr {
-        "#ff661a"
-      } else if $in < 1day {
-        "#ffdc2d"
-      } else if $in < 3day {
-        "#f2e6a9"
-      } else if $in < 1wk {
-        { fg: "#f2e6a9" attr: "b" }
-      } else if $in < 6wk {
-        "#fb6acb"
-      } else if $in < 52wk {
-        "#40bfff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff661a" attr: "b" }
+        } else if $in < 6hr {
+            "#ff661a"
+        } else if $in < 1day {
+            "#ffdc2d"
+        } else if $in < 3day {
+            "#f2e6a9"
+        } else if $in < 1wk {
+            { fg: "#f2e6a9" attr: "b" }
+        } else if $in < 6wk {
+            "#fb6acb"
+        } else if $in < 52wk {
+            "#40bfff"
+        } else { "dark_gray" }
     }
     range: "#e9e7e1"
     float: "#e9e7e1"

--- a/themes/themes/github-dark-colorblind.nu
+++ b/themes/themes/github-dark-colorblind.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#56d4dd" } else { "light_gray" } }
     int: "#b1bac4"
     filesize: {|e|
-      if $e == 0b {
-        "#b1bac4"
-      } else if $e < 1mb {
-        "#39c5cf"
-      } else {{ fg: "#58a6ff" }}
+        if $e == 0b {
+            "#b1bac4"
+        } else if $e < 1mb {
+            "#39c5cf"
+        } else {{ fg: "#58a6ff" }}
     }
     duration: "#b1bac4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff7b72" attr: "b" }
-      } else if $in < 6hr {
-        "#ff7b72"
-      } else if $in < 1day {
-        "#d29922"
-      } else if $in < 3day {
-        "#3fb950"
-      } else if $in < 1wk {
-        { fg: "#3fb950" attr: "b" }
-      } else if $in < 6wk {
-        "#39c5cf"
-      } else if $in < 52wk {
-        "#58a6ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff7b72" attr: "b" }
+        } else if $in < 6hr {
+            "#ff7b72"
+        } else if $in < 1day {
+            "#d29922"
+        } else if $in < 3day {
+            "#3fb950"
+        } else if $in < 1wk {
+            { fg: "#3fb950" attr: "b" }
+        } else if $in < 6wk {
+            "#39c5cf"
+        } else if $in < 52wk {
+            "#58a6ff"
+        } else { "dark_gray" }
     }
     range: "#b1bac4"
     float: "#b1bac4"

--- a/themes/themes/github-dark-default.nu
+++ b/themes/themes/github-dark-default.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#56d4dd" } else { "light_gray" } }
     int: "#b1bac4"
     filesize: {|e|
-      if $e == 0b {
-        "#b1bac4"
-      } else if $e < 1mb {
-        "#39c5cf"
-      } else {{ fg: "#58a6ff" }}
+        if $e == 0b {
+            "#b1bac4"
+        } else if $e < 1mb {
+            "#39c5cf"
+        } else {{ fg: "#58a6ff" }}
     }
     duration: "#b1bac4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff7b72" attr: "b" }
-      } else if $in < 6hr {
-        "#ff7b72"
-      } else if $in < 1day {
-        "#d29922"
-      } else if $in < 3day {
-        "#3fb950"
-      } else if $in < 1wk {
-        { fg: "#3fb950" attr: "b" }
-      } else if $in < 6wk {
-        "#39c5cf"
-      } else if $in < 52wk {
-        "#58a6ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff7b72" attr: "b" }
+        } else if $in < 6hr {
+            "#ff7b72"
+        } else if $in < 1day {
+            "#d29922"
+        } else if $in < 3day {
+            "#3fb950"
+        } else if $in < 1wk {
+            { fg: "#3fb950" attr: "b" }
+        } else if $in < 6wk {
+            "#39c5cf"
+        } else if $in < 52wk {
+            "#58a6ff"
+        } else { "dark_gray" }
     }
     range: "#b1bac4"
     float: "#b1bac4"

--- a/themes/themes/github-dark.nu
+++ b/themes/themes/github-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#56d4dd" } else { "light_gray" } }
     int: "#d1d5da"
     filesize: {|e|
-      if $e == 0b {
-        "#d1d5da"
-      } else if $e < 1mb {
-        "#39c5cf"
-      } else {{ fg: "#2188ff" }}
+        if $e == 0b {
+            "#d1d5da"
+        } else if $e < 1mb {
+            "#39c5cf"
+        } else {{ fg: "#2188ff" }}
     }
     duration: "#d1d5da"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ea4a5a" attr: "b" }
-      } else if $in < 6hr {
-        "#ea4a5a"
-      } else if $in < 1day {
-        "#ffea7f"
-      } else if $in < 3day {
-        "#34d058"
-      } else if $in < 1wk {
-        { fg: "#34d058" attr: "b" }
-      } else if $in < 6wk {
-        "#39c5cf"
-      } else if $in < 52wk {
-        "#2188ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ea4a5a" attr: "b" }
+        } else if $in < 6hr {
+            "#ea4a5a"
+        } else if $in < 1day {
+            "#ffea7f"
+        } else if $in < 3day {
+            "#34d058"
+        } else if $in < 1wk {
+            { fg: "#34d058" attr: "b" }
+        } else if $in < 6wk {
+            "#39c5cf"
+        } else if $in < 52wk {
+            "#2188ff"
+        } else { "dark_gray" }
     }
     range: "#d1d5da"
     float: "#d1d5da"

--- a/themes/themes/github-dimmed.nu
+++ b/themes/themes/github-dimmed.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#56d4dd" } else { "light_gray" } }
     int: "#909dab"
     filesize: {|e|
-      if $e == 0b {
-        "#909dab"
-      } else if $e < 1mb {
-        "#39c5cf"
-      } else {{ fg: "#539bf5" }}
+        if $e == 0b {
+            "#909dab"
+        } else if $e < 1mb {
+            "#39c5cf"
+        } else {{ fg: "#539bf5" }}
     }
     duration: "#909dab"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f47067" attr: "b" }
-      } else if $in < 6hr {
-        "#f47067"
-      } else if $in < 1day {
-        "#c69026"
-      } else if $in < 3day {
-        "#57ab5a"
-      } else if $in < 1wk {
-        { fg: "#57ab5a" attr: "b" }
-      } else if $in < 6wk {
-        "#39c5cf"
-      } else if $in < 52wk {
-        "#539bf5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f47067" attr: "b" }
+        } else if $in < 6hr {
+            "#f47067"
+        } else if $in < 1day {
+            "#c69026"
+        } else if $in < 3day {
+            "#57ab5a"
+        } else if $in < 1wk {
+            { fg: "#57ab5a" attr: "b" }
+        } else if $in < 6wk {
+            "#39c5cf"
+        } else if $in < 52wk {
+            "#539bf5"
+        } else { "dark_gray" }
     }
     range: "#909dab"
     float: "#909dab"

--- a/themes/themes/github-light-colorblind.nu
+++ b/themes/themes/github-light-colorblind.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3192aa" } else { "light_gray" } }
     int: "#6e7781"
     filesize: {|e|
-      if $e == 0b {
-        "#6e7781"
-      } else if $e < 1mb {
-        "#1b7c83"
-      } else {{ fg: "#0969da" }}
+        if $e == 0b {
+            "#6e7781"
+        } else if $e < 1mb {
+            "#1b7c83"
+        } else {{ fg: "#0969da" }}
     }
     duration: "#6e7781"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cf222e" attr: "b" }
-      } else if $in < 6hr {
-        "#cf222e"
-      } else if $in < 1day {
-        "#4d2d00"
-      } else if $in < 3day {
-        "#116329"
-      } else if $in < 1wk {
-        { fg: "#116329" attr: "b" }
-      } else if $in < 6wk {
-        "#1b7c83"
-      } else if $in < 52wk {
-        "#0969da"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cf222e" attr: "b" }
+        } else if $in < 6hr {
+            "#cf222e"
+        } else if $in < 1day {
+            "#4d2d00"
+        } else if $in < 3day {
+            "#116329"
+        } else if $in < 1wk {
+            { fg: "#116329" attr: "b" }
+        } else if $in < 6wk {
+            "#1b7c83"
+        } else if $in < 52wk {
+            "#0969da"
+        } else { "dark_gray" }
     }
     range: "#6e7781"
     float: "#6e7781"

--- a/themes/themes/github-light-default.nu
+++ b/themes/themes/github-light-default.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3192aa" } else { "light_gray" } }
     int: "#6e7781"
     filesize: {|e|
-      if $e == 0b {
-        "#6e7781"
-      } else if $e < 1mb {
-        "#1b7c83"
-      } else {{ fg: "#0969da" }}
+        if $e == 0b {
+            "#6e7781"
+        } else if $e < 1mb {
+            "#1b7c83"
+        } else {{ fg: "#0969da" }}
     }
     duration: "#6e7781"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cf222e" attr: "b" }
-      } else if $in < 6hr {
-        "#cf222e"
-      } else if $in < 1day {
-        "#4d2d00"
-      } else if $in < 3day {
-        "#116329"
-      } else if $in < 1wk {
-        { fg: "#116329" attr: "b" }
-      } else if $in < 6wk {
-        "#1b7c83"
-      } else if $in < 52wk {
-        "#0969da"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cf222e" attr: "b" }
+        } else if $in < 6hr {
+            "#cf222e"
+        } else if $in < 1day {
+            "#4d2d00"
+        } else if $in < 3day {
+            "#116329"
+        } else if $in < 1wk {
+            { fg: "#116329" attr: "b" }
+        } else if $in < 6wk {
+            "#1b7c83"
+        } else if $in < 52wk {
+            "#0969da"
+        } else { "dark_gray" }
     }
     range: "#6e7781"
     float: "#6e7781"

--- a/themes/themes/github-light.nu
+++ b/themes/themes/github-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3192aa" } else { "light_gray" } }
     int: "#6a737d"
     filesize: {|e|
-      if $e == 0b {
-        "#6a737d"
-      } else if $e < 1mb {
-        "#0598bc"
-      } else {{ fg: "#0366d6" }}
+        if $e == 0b {
+            "#6a737d"
+        } else if $e < 1mb {
+            "#0598bc"
+        } else {{ fg: "#0366d6" }}
     }
     duration: "#6a737d"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d73a49" attr: "b" }
-      } else if $in < 6hr {
-        "#d73a49"
-      } else if $in < 1day {
-        "#dbab09"
-      } else if $in < 3day {
-        "#28a745"
-      } else if $in < 1wk {
-        { fg: "#28a745" attr: "b" }
-      } else if $in < 6wk {
-        "#0598bc"
-      } else if $in < 52wk {
-        "#0366d6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d73a49" attr: "b" }
+        } else if $in < 6hr {
+            "#d73a49"
+        } else if $in < 1day {
+            "#dbab09"
+        } else if $in < 3day {
+            "#28a745"
+        } else if $in < 1wk {
+            { fg: "#28a745" attr: "b" }
+        } else if $in < 6wk {
+            "#0598bc"
+        } else if $in < 52wk {
+            "#0366d6"
+        } else { "dark_gray" }
     }
     range: "#6a737d"
     float: "#6a737d"

--- a/themes/themes/github.nu
+++ b/themes/themes/github.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#183691" } else { "light_gray" } }
     int: "#333333"
     filesize: {|e|
-      if $e == 0b {
-        "#333333"
-      } else if $e < 1mb {
-        "#183691"
-      } else {{ fg: "#795da3" }}
+        if $e == 0b {
+            "#333333"
+        } else if $e < 1mb {
+            "#183691"
+        } else {{ fg: "#795da3" }}
     }
     duration: "#333333"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ed6a43" attr: "b" }
-      } else if $in < 6hr {
-        "#ed6a43"
-      } else if $in < 1day {
-        "#795da3"
-      } else if $in < 3day {
-        "#183691"
-      } else if $in < 1wk {
-        { fg: "#183691" attr: "b" }
-      } else if $in < 6wk {
-        "#183691"
-      } else if $in < 52wk {
-        "#795da3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ed6a43" attr: "b" }
+        } else if $in < 6hr {
+            "#ed6a43"
+        } else if $in < 1day {
+            "#795da3"
+        } else if $in < 3day {
+            "#183691"
+        } else if $in < 1wk {
+            { fg: "#183691" attr: "b" }
+        } else if $in < 6wk {
+            "#183691"
+        } else if $in < 52wk {
+            "#795da3"
+        } else { "dark_gray" }
     }
     range: "#333333"
     float: "#333333"

--- a/themes/themes/glacier.nu
+++ b/themes/themes/glacier.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a0b6d3" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#778397"
-      } else {{ fg: "#1f5872" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#778397"
+        } else {{ fg: "#1f5872" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bd0f2f" attr: "b" }
-      } else if $in < 6hr {
-        "#bd0f2f"
-      } else if $in < 1day {
-        "#fb9435"
-      } else if $in < 3day {
-        "#35a770"
-      } else if $in < 1wk {
-        { fg: "#35a770" attr: "b" }
-      } else if $in < 6wk {
-        "#778397"
-      } else if $in < 52wk {
-        "#1f5872"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bd0f2f" attr: "b" }
+        } else if $in < 6hr {
+            "#bd0f2f"
+        } else if $in < 1day {
+            "#fb9435"
+        } else if $in < 3day {
+            "#35a770"
+        } else if $in < 1wk {
+            { fg: "#35a770" attr: "b" }
+        } else if $in < 6wk {
+            "#778397"
+        } else if $in < 52wk {
+            "#1f5872"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/goa-base.nu
+++ b/themes/themes/goa-base.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c8f9f3" } else { "light_gray" } }
     int: "#000000"
     filesize: {|e|
-      if $e == 0b {
-        "#000000"
-      } else if $e < 1mb {
-        "#3affff"
-      } else {{ fg: "#000482" }}
+        if $e == 0b {
+            "#000000"
+        } else if $e < 1mb {
+            "#3affff"
+        } else {{ fg: "#000482" }}
     }
     duration: "#000000"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f78000" attr: "b" }
-      } else if $in < 6hr {
-        "#f78000"
-      } else if $in < 1day {
-        "#f40000"
-      } else if $in < 3day {
-        "#249000"
-      } else if $in < 1wk {
-        { fg: "#249000" attr: "b" }
-      } else if $in < 6wk {
-        "#3affff"
-      } else if $in < 52wk {
-        "#000482"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f78000" attr: "b" }
+        } else if $in < 6hr {
+            "#f78000"
+        } else if $in < 1day {
+            "#f40000"
+        } else if $in < 3day {
+            "#249000"
+        } else if $in < 1wk {
+            { fg: "#249000" attr: "b" }
+        } else if $in < 6wk {
+            "#3affff"
+        } else if $in < 52wk {
+            "#000482"
+        } else { "dark_gray" }
     }
     range: "#000000"
     float: "#000000"

--- a/themes/themes/gooey.nu
+++ b/themes/themes/gooey.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c0b7f9" } else { "light_gray" } }
     int: "#858893"
     filesize: {|e|
-      if $e == 0b {
-        "#858893"
-      } else if $e < 1mb {
-        "#8d84c6"
-      } else {{ fg: "#58b6ca" }}
+        if $e == 0b {
+            "#858893"
+        } else if $e < 1mb {
+            "#8d84c6"
+        } else {{ fg: "#58b6ca" }}
     }
     duration: "#858893"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bb4f6c" attr: "b" }
-      } else if $in < 6hr {
-        "#bb4f6c"
-      } else if $in < 1day {
-        "#c65e3d"
-      } else if $in < 3day {
-        "#72ccae"
-      } else if $in < 1wk {
-        { fg: "#72ccae" attr: "b" }
-      } else if $in < 6wk {
-        "#8d84c6"
-      } else if $in < 52wk {
-        "#58b6ca"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bb4f6c" attr: "b" }
+        } else if $in < 6hr {
+            "#bb4f6c"
+        } else if $in < 1day {
+            "#c65e3d"
+        } else if $in < 3day {
+            "#72ccae"
+        } else if $in < 1wk {
+            { fg: "#72ccae" attr: "b" }
+        } else if $in < 6wk {
+            "#8d84c6"
+        } else if $in < 52wk {
+            "#58b6ca"
+        } else { "dark_gray" }
     }
     range: "#858893"
     float: "#858893"

--- a/themes/themes/google-dark.nu
+++ b/themes/themes/google-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3971ed" } else { "light_gray" } }
     int: "#c5c8c6"
     filesize: {|e|
-      if $e == 0b {
-        "#c5c8c6"
-      } else if $e < 1mb {
-        "#3971ed"
-      } else {{ fg: "#3971ed" }}
+        if $e == 0b {
+            "#c5c8c6"
+        } else if $e < 1mb {
+            "#3971ed"
+        } else {{ fg: "#3971ed" }}
     }
     duration: "#c5c8c6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc342b" attr: "b" }
-      } else if $in < 6hr {
-        "#cc342b"
-      } else if $in < 1day {
-        "#fba922"
-      } else if $in < 3day {
-        "#198844"
-      } else if $in < 1wk {
-        { fg: "#198844" attr: "b" }
-      } else if $in < 6wk {
-        "#3971ed"
-      } else if $in < 52wk {
-        "#3971ed"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc342b" attr: "b" }
+        } else if $in < 6hr {
+            "#cc342b"
+        } else if $in < 1day {
+            "#fba922"
+        } else if $in < 3day {
+            "#198844"
+        } else if $in < 1wk {
+            { fg: "#198844" attr: "b" }
+        } else if $in < 6wk {
+            "#3971ed"
+        } else if $in < 52wk {
+            "#3971ed"
+        } else { "dark_gray" }
     }
     range: "#c5c8c6"
     float: "#c5c8c6"

--- a/themes/themes/google-light.nu
+++ b/themes/themes/google-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3971ed" } else { "light_gray" } }
     int: "#373b41"
     filesize: {|e|
-      if $e == 0b {
-        "#373b41"
-      } else if $e < 1mb {
-        "#3971ed"
-      } else {{ fg: "#3971ed" }}
+        if $e == 0b {
+            "#373b41"
+        } else if $e < 1mb {
+            "#3971ed"
+        } else {{ fg: "#3971ed" }}
     }
     duration: "#373b41"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc342b" attr: "b" }
-      } else if $in < 6hr {
-        "#cc342b"
-      } else if $in < 1day {
-        "#fba922"
-      } else if $in < 3day {
-        "#198844"
-      } else if $in < 1wk {
-        { fg: "#198844" attr: "b" }
-      } else if $in < 6wk {
-        "#3971ed"
-      } else if $in < 52wk {
-        "#3971ed"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc342b" attr: "b" }
+        } else if $in < 6hr {
+            "#cc342b"
+        } else if $in < 1day {
+            "#fba922"
+        } else if $in < 3day {
+            "#198844"
+        } else if $in < 1wk {
+            { fg: "#198844" attr: "b" }
+        } else if $in < 6wk {
+            "#3971ed"
+        } else if $in < 52wk {
+            "#3971ed"
+        } else { "dark_gray" }
     }
     range: "#373b41"
     float: "#373b41"

--- a/themes/themes/grape.nu
+++ b/themes/themes/grape.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#9de3eb" } else { "light_gray" } }
     int: "#9e9ea0"
     filesize: {|e|
-      if $e == 0b {
-        "#9e9ea0"
-      } else if $e < 1mb {
-        "#3bdeed"
-      } else {{ fg: "#487df4" }}
+        if $e == 0b {
+            "#9e9ea0"
+        } else if $e < 1mb {
+            "#3bdeed"
+        } else {{ fg: "#487df4" }}
     }
     duration: "#9e9ea0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ed2261" attr: "b" }
-      } else if $in < 6hr {
-        "#ed2261"
-      } else if $in < 1day {
-        "#8ddc20"
-      } else if $in < 3day {
-        "#1fa91b"
-      } else if $in < 1wk {
-        { fg: "#1fa91b" attr: "b" }
-      } else if $in < 6wk {
-        "#3bdeed"
-      } else if $in < 52wk {
-        "#487df4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ed2261" attr: "b" }
+        } else if $in < 6hr {
+            "#ed2261"
+        } else if $in < 1day {
+            "#8ddc20"
+        } else if $in < 3day {
+            "#1fa91b"
+        } else if $in < 1wk {
+            { fg: "#1fa91b" attr: "b" }
+        } else if $in < 6wk {
+            "#3bdeed"
+        } else if $in < 52wk {
+            "#487df4"
+        } else { "dark_gray" }
     }
     range: "#9e9ea0"
     float: "#9e9ea0"

--- a/themes/themes/grass.nu
+++ b/themes/themes/grass.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#55ffff" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#00bbbb"
-      } else {{ fg: "#0000a3" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#00bbbb"
+        } else {{ fg: "#0000a3" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bb0000" attr: "b" }
-      } else if $in < 6hr {
-        "#bb0000"
-      } else if $in < 1day {
-        "#e7b000"
-      } else if $in < 3day {
-        "#00bb00"
-      } else if $in < 1wk {
-        { fg: "#00bb00" attr: "b" }
-      } else if $in < 6wk {
-        "#00bbbb"
-      } else if $in < 52wk {
-        "#0000a3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bb0000" attr: "b" }
+        } else if $in < 6hr {
+            "#bb0000"
+        } else if $in < 1day {
+            "#e7b000"
+        } else if $in < 3day {
+            "#00bb00"
+        } else if $in < 1wk {
+            { fg: "#00bb00" attr: "b" }
+        } else if $in < 6wk {
+            "#00bbbb"
+        } else if $in < 52wk {
+            "#0000a3"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/grayscale-dark.nu
+++ b/themes/themes/grayscale-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#868686" } else { "light_gray" } }
     int: "#b9b9b9"
     filesize: {|e|
-      if $e == 0b {
-        "#b9b9b9"
-      } else if $e < 1mb {
-        "#868686"
-      } else {{ fg: "#686868" }}
+        if $e == 0b {
+            "#b9b9b9"
+        } else if $e < 1mb {
+            "#868686"
+        } else {{ fg: "#686868" }}
     }
     duration: "#b9b9b9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#7c7c7c" attr: "b" }
-      } else if $in < 6hr {
-        "#7c7c7c"
-      } else if $in < 1day {
-        "#a0a0a0"
-      } else if $in < 3day {
-        "#8e8e8e"
-      } else if $in < 1wk {
-        { fg: "#8e8e8e" attr: "b" }
-      } else if $in < 6wk {
-        "#868686"
-      } else if $in < 52wk {
-        "#686868"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#7c7c7c" attr: "b" }
+        } else if $in < 6hr {
+            "#7c7c7c"
+        } else if $in < 1day {
+            "#a0a0a0"
+        } else if $in < 3day {
+            "#8e8e8e"
+        } else if $in < 1wk {
+            { fg: "#8e8e8e" attr: "b" }
+        } else if $in < 6wk {
+            "#868686"
+        } else if $in < 52wk {
+            "#686868"
+        } else { "dark_gray" }
     }
     range: "#b9b9b9"
     float: "#b9b9b9"

--- a/themes/themes/grayscale-light.nu
+++ b/themes/themes/grayscale-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#868686" } else { "light_gray" } }
     int: "#464646"
     filesize: {|e|
-      if $e == 0b {
-        "#464646"
-      } else if $e < 1mb {
-        "#868686"
-      } else {{ fg: "#686868" }}
+        if $e == 0b {
+            "#464646"
+        } else if $e < 1mb {
+            "#868686"
+        } else {{ fg: "#686868" }}
     }
     duration: "#464646"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#7c7c7c" attr: "b" }
-      } else if $in < 6hr {
-        "#7c7c7c"
-      } else if $in < 1day {
-        "#a0a0a0"
-      } else if $in < 3day {
-        "#8e8e8e"
-      } else if $in < 1wk {
-        { fg: "#8e8e8e" attr: "b" }
-      } else if $in < 6wk {
-        "#868686"
-      } else if $in < 52wk {
-        "#686868"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#7c7c7c" attr: "b" }
+        } else if $in < 6hr {
+            "#7c7c7c"
+        } else if $in < 1day {
+            "#a0a0a0"
+        } else if $in < 3day {
+            "#8e8e8e"
+        } else if $in < 1wk {
+            { fg: "#8e8e8e" attr: "b" }
+        } else if $in < 6wk {
+            "#868686"
+        } else if $in < 52wk {
+            "#686868"
+        } else { "dark_gray" }
     }
     range: "#464646"
     float: "#464646"

--- a/themes/themes/green-screen.nu
+++ b/themes/themes/green-screen.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#005500" } else { "light_gray" } }
     int: "#00bb00"
     filesize: {|e|
-      if $e == 0b {
-        "#00bb00"
-      } else if $e < 1mb {
-        "#005500"
-      } else {{ fg: "#009900" }}
+        if $e == 0b {
+            "#00bb00"
+        } else if $e < 1mb {
+            "#005500"
+        } else {{ fg: "#009900" }}
     }
     duration: "#00bb00"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#007700" attr: "b" }
-      } else if $in < 6hr {
-        "#007700"
-      } else if $in < 1day {
-        "#007700"
-      } else if $in < 3day {
-        "#00bb00"
-      } else if $in < 1wk {
-        { fg: "#00bb00" attr: "b" }
-      } else if $in < 6wk {
-        "#005500"
-      } else if $in < 52wk {
-        "#009900"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#007700" attr: "b" }
+        } else if $in < 6hr {
+            "#007700"
+        } else if $in < 1day {
+            "#007700"
+        } else if $in < 3day {
+            "#00bb00"
+        } else if $in < 1wk {
+            { fg: "#00bb00" attr: "b" }
+        } else if $in < 6wk {
+            "#005500"
+        } else if $in < 52wk {
+            "#009900"
+        } else { "dark_gray" }
     }
     range: "#00bb00"
     float: "#00bb00"

--- a/themes/themes/greenscreen.nu
+++ b/themes/themes/greenscreen.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#005500" } else { "light_gray" } }
     int: "#00bb00"
     filesize: {|e|
-      if $e == 0b {
-        "#00bb00"
-      } else if $e < 1mb {
-        "#005500"
-      } else {{ fg: "#009900" }}
+        if $e == 0b {
+            "#00bb00"
+        } else if $e < 1mb {
+            "#005500"
+        } else {{ fg: "#009900" }}
     }
     duration: "#00bb00"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#007700" attr: "b" }
-      } else if $in < 6hr {
-        "#007700"
-      } else if $in < 1day {
-        "#007700"
-      } else if $in < 3day {
-        "#00bb00"
-      } else if $in < 1wk {
-        { fg: "#00bb00" attr: "b" }
-      } else if $in < 6wk {
-        "#005500"
-      } else if $in < 52wk {
-        "#009900"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#007700" attr: "b" }
+        } else if $in < 6hr {
+            "#007700"
+        } else if $in < 1day {
+            "#007700"
+        } else if $in < 3day {
+            "#00bb00"
+        } else if $in < 1wk {
+            { fg: "#00bb00" attr: "b" }
+        } else if $in < 6wk {
+            "#005500"
+        } else if $in < 52wk {
+            "#009900"
+        } else { "dark_gray" }
     }
     range: "#00bb00"
     float: "#00bb00"

--- a/themes/themes/gruvbit.nu
+++ b/themes/themes/gruvbit.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#e9593d" } else { "light_gray" } }
     int: "#504945"
     filesize: {|e|
-      if $e == 0b {
-        "#504945"
-      } else if $e < 1mb {
-        "#e9593d"
-      } else {{ fg: "#83a598" }}
+        if $e == 0b {
+            "#504945"
+        } else if $e < 1mb {
+            "#e9593d"
+        } else {{ fg: "#83a598" }}
     }
     duration: "#504945"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fabd2f" attr: "b" }
-      } else if $in < 6hr {
-        "#fabd2f"
-      } else if $in < 1day {
-        "#dc9656"
-      } else if $in < 3day {
-        "#8ec07c"
-      } else if $in < 1wk {
-        { fg: "#8ec07c" attr: "b" }
-      } else if $in < 6wk {
-        "#e9593d"
-      } else if $in < 52wk {
-        "#83a598"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fabd2f" attr: "b" }
+        } else if $in < 6hr {
+            "#fabd2f"
+        } else if $in < 1day {
+            "#dc9656"
+        } else if $in < 3day {
+            "#8ec07c"
+        } else if $in < 1wk {
+            { fg: "#8ec07c" attr: "b" }
+        } else if $in < 6wk {
+            "#e9593d"
+        } else if $in < 52wk {
+            "#83a598"
+        } else { "dark_gray" }
     }
     range: "#504945"
     float: "#504945"

--- a/themes/themes/gruvbox-dark-hard.nu
+++ b/themes/themes/gruvbox-dark-hard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ec07c" } else { "light_gray" } }
     int: "#d5c4a1"
     filesize: {|e|
-      if $e == 0b {
-        "#d5c4a1"
-      } else if $e < 1mb {
-        "#8ec07c"
-      } else {{ fg: "#83a598" }}
+        if $e == 0b {
+            "#d5c4a1"
+        } else if $e < 1mb {
+            "#8ec07c"
+        } else {{ fg: "#83a598" }}
     }
     duration: "#d5c4a1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb4934" attr: "b" }
-      } else if $in < 6hr {
-        "#fb4934"
-      } else if $in < 1day {
-        "#fabd2f"
-      } else if $in < 3day {
-        "#b8bb26"
-      } else if $in < 1wk {
-        { fg: "#b8bb26" attr: "b" }
-      } else if $in < 6wk {
-        "#8ec07c"
-      } else if $in < 52wk {
-        "#83a598"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb4934" attr: "b" }
+        } else if $in < 6hr {
+            "#fb4934"
+        } else if $in < 1day {
+            "#fabd2f"
+        } else if $in < 3day {
+            "#b8bb26"
+        } else if $in < 1wk {
+            { fg: "#b8bb26" attr: "b" }
+        } else if $in < 6wk {
+            "#8ec07c"
+        } else if $in < 52wk {
+            "#83a598"
+        } else { "dark_gray" }
     }
     range: "#d5c4a1"
     float: "#d5c4a1"

--- a/themes/themes/gruvbox-dark-medium.nu
+++ b/themes/themes/gruvbox-dark-medium.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ec07c" } else { "light_gray" } }
     int: "#d5c4a1"
     filesize: {|e|
-      if $e == 0b {
-        "#d5c4a1"
-      } else if $e < 1mb {
-        "#8ec07c"
-      } else {{ fg: "#83a598" }}
+        if $e == 0b {
+            "#d5c4a1"
+        } else if $e < 1mb {
+            "#8ec07c"
+        } else {{ fg: "#83a598" }}
     }
     duration: "#d5c4a1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb4934" attr: "b" }
-      } else if $in < 6hr {
-        "#fb4934"
-      } else if $in < 1day {
-        "#fabd2f"
-      } else if $in < 3day {
-        "#b8bb26"
-      } else if $in < 1wk {
-        { fg: "#b8bb26" attr: "b" }
-      } else if $in < 6wk {
-        "#8ec07c"
-      } else if $in < 52wk {
-        "#83a598"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb4934" attr: "b" }
+        } else if $in < 6hr {
+            "#fb4934"
+        } else if $in < 1day {
+            "#fabd2f"
+        } else if $in < 3day {
+            "#b8bb26"
+        } else if $in < 1wk {
+            { fg: "#b8bb26" attr: "b" }
+        } else if $in < 6wk {
+            "#8ec07c"
+        } else if $in < 52wk {
+            "#83a598"
+        } else { "dark_gray" }
     }
     range: "#d5c4a1"
     float: "#d5c4a1"

--- a/themes/themes/gruvbox-dark-pale.nu
+++ b/themes/themes/gruvbox-dark-pale.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#85ad85" } else { "light_gray" } }
     int: "#dab997"
     filesize: {|e|
-      if $e == 0b {
-        "#dab997"
-      } else if $e < 1mb {
-        "#85ad85"
-      } else {{ fg: "#83adad" }}
+        if $e == 0b {
+            "#dab997"
+        } else if $e < 1mb {
+            "#85ad85"
+        } else {{ fg: "#83adad" }}
     }
     duration: "#dab997"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d75f5f" attr: "b" }
-      } else if $in < 6hr {
-        "#d75f5f"
-      } else if $in < 1day {
-        "#ffaf00"
-      } else if $in < 3day {
-        "#afaf00"
-      } else if $in < 1wk {
-        { fg: "#afaf00" attr: "b" }
-      } else if $in < 6wk {
-        "#85ad85"
-      } else if $in < 52wk {
-        "#83adad"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d75f5f" attr: "b" }
+        } else if $in < 6hr {
+            "#d75f5f"
+        } else if $in < 1day {
+            "#ffaf00"
+        } else if $in < 3day {
+            "#afaf00"
+        } else if $in < 1wk {
+            { fg: "#afaf00" attr: "b" }
+        } else if $in < 6wk {
+            "#85ad85"
+        } else if $in < 52wk {
+            "#83adad"
+        } else { "dark_gray" }
     }
     range: "#dab997"
     float: "#dab997"

--- a/themes/themes/gruvbox-dark-soft.nu
+++ b/themes/themes/gruvbox-dark-soft.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ec07c" } else { "light_gray" } }
     int: "#d5c4a1"
     filesize: {|e|
-      if $e == 0b {
-        "#d5c4a1"
-      } else if $e < 1mb {
-        "#8ec07c"
-      } else {{ fg: "#83a598" }}
+        if $e == 0b {
+            "#d5c4a1"
+        } else if $e < 1mb {
+            "#8ec07c"
+        } else {{ fg: "#83a598" }}
     }
     duration: "#d5c4a1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb4934" attr: "b" }
-      } else if $in < 6hr {
-        "#fb4934"
-      } else if $in < 1day {
-        "#fabd2f"
-      } else if $in < 3day {
-        "#b8bb26"
-      } else if $in < 1wk {
-        { fg: "#b8bb26" attr: "b" }
-      } else if $in < 6wk {
-        "#8ec07c"
-      } else if $in < 52wk {
-        "#83a598"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb4934" attr: "b" }
+        } else if $in < 6hr {
+            "#fb4934"
+        } else if $in < 1day {
+            "#fabd2f"
+        } else if $in < 3day {
+            "#b8bb26"
+        } else if $in < 1wk {
+            { fg: "#b8bb26" attr: "b" }
+        } else if $in < 6wk {
+            "#8ec07c"
+        } else if $in < 52wk {
+            "#83a598"
+        } else { "dark_gray" }
     }
     range: "#d5c4a1"
     float: "#d5c4a1"

--- a/themes/themes/gruvbox-dark.nu
+++ b/themes/themes/gruvbox-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ec07c" } else { "light_gray" } }
     int: "#a89984"
     filesize: {|e|
-      if $e == 0b {
-        "#a89984"
-      } else if $e < 1mb {
-        "#689d6a"
-      } else {{ fg: "#458588" }}
+        if $e == 0b {
+            "#a89984"
+        } else if $e < 1mb {
+            "#689d6a"
+        } else {{ fg: "#458588" }}
     }
     duration: "#a89984"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc241d" attr: "b" }
-      } else if $in < 6hr {
-        "#cc241d"
-      } else if $in < 1day {
-        "#d79921"
-      } else if $in < 3day {
-        "#98971a"
-      } else if $in < 1wk {
-        { fg: "#98971a" attr: "b" }
-      } else if $in < 6wk {
-        "#689d6a"
-      } else if $in < 52wk {
-        "#458588"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc241d" attr: "b" }
+        } else if $in < 6hr {
+            "#cc241d"
+        } else if $in < 1day {
+            "#d79921"
+        } else if $in < 3day {
+            "#98971a"
+        } else if $in < 1wk {
+            { fg: "#98971a" attr: "b" }
+        } else if $in < 6wk {
+            "#689d6a"
+        } else if $in < 52wk {
+            "#458588"
+        } else { "dark_gray" }
     }
     range: "#a89984"
     float: "#a89984"

--- a/themes/themes/gruvbox-light-hard.nu
+++ b/themes/themes/gruvbox-light-hard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#427b58" } else { "light_gray" } }
     int: "#504945"
     filesize: {|e|
-      if $e == 0b {
-        "#504945"
-      } else if $e < 1mb {
-        "#427b58"
-      } else {{ fg: "#076678" }}
+        if $e == 0b {
+            "#504945"
+        } else if $e < 1mb {
+            "#427b58"
+        } else {{ fg: "#076678" }}
     }
     duration: "#504945"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9d0006" attr: "b" }
-      } else if $in < 6hr {
-        "#9d0006"
-      } else if $in < 1day {
-        "#b57614"
-      } else if $in < 3day {
-        "#79740e"
-      } else if $in < 1wk {
-        { fg: "#79740e" attr: "b" }
-      } else if $in < 6wk {
-        "#427b58"
-      } else if $in < 52wk {
-        "#076678"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9d0006" attr: "b" }
+        } else if $in < 6hr {
+            "#9d0006"
+        } else if $in < 1day {
+            "#b57614"
+        } else if $in < 3day {
+            "#79740e"
+        } else if $in < 1wk {
+            { fg: "#79740e" attr: "b" }
+        } else if $in < 6wk {
+            "#427b58"
+        } else if $in < 52wk {
+            "#076678"
+        } else { "dark_gray" }
     }
     range: "#504945"
     float: "#504945"

--- a/themes/themes/gruvbox-light-medium.nu
+++ b/themes/themes/gruvbox-light-medium.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#427b58" } else { "light_gray" } }
     int: "#504945"
     filesize: {|e|
-      if $e == 0b {
-        "#504945"
-      } else if $e < 1mb {
-        "#427b58"
-      } else {{ fg: "#076678" }}
+        if $e == 0b {
+            "#504945"
+        } else if $e < 1mb {
+            "#427b58"
+        } else {{ fg: "#076678" }}
     }
     duration: "#504945"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9d0006" attr: "b" }
-      } else if $in < 6hr {
-        "#9d0006"
-      } else if $in < 1day {
-        "#b57614"
-      } else if $in < 3day {
-        "#79740e"
-      } else if $in < 1wk {
-        { fg: "#79740e" attr: "b" }
-      } else if $in < 6wk {
-        "#427b58"
-      } else if $in < 52wk {
-        "#076678"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9d0006" attr: "b" }
+        } else if $in < 6hr {
+            "#9d0006"
+        } else if $in < 1day {
+            "#b57614"
+        } else if $in < 3day {
+            "#79740e"
+        } else if $in < 1wk {
+            { fg: "#79740e" attr: "b" }
+        } else if $in < 6wk {
+            "#427b58"
+        } else if $in < 52wk {
+            "#076678"
+        } else { "dark_gray" }
     }
     range: "#504945"
     float: "#504945"

--- a/themes/themes/gruvbox-light-soft.nu
+++ b/themes/themes/gruvbox-light-soft.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#427b58" } else { "light_gray" } }
     int: "#504945"
     filesize: {|e|
-      if $e == 0b {
-        "#504945"
-      } else if $e < 1mb {
-        "#427b58"
-      } else {{ fg: "#076678" }}
+        if $e == 0b {
+            "#504945"
+        } else if $e < 1mb {
+            "#427b58"
+        } else {{ fg: "#076678" }}
     }
     duration: "#504945"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9d0006" attr: "b" }
-      } else if $in < 6hr {
-        "#9d0006"
-      } else if $in < 1day {
-        "#b57614"
-      } else if $in < 3day {
-        "#79740e"
-      } else if $in < 1wk {
-        { fg: "#79740e" attr: "b" }
-      } else if $in < 6wk {
-        "#427b58"
-      } else if $in < 52wk {
-        "#076678"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9d0006" attr: "b" }
+        } else if $in < 6hr {
+            "#9d0006"
+        } else if $in < 1day {
+            "#b57614"
+        } else if $in < 3day {
+            "#79740e"
+        } else if $in < 1wk {
+            { fg: "#79740e" attr: "b" }
+        } else if $in < 6wk {
+            "#427b58"
+        } else if $in < 52wk {
+            "#076678"
+        } else { "dark_gray" }
     }
     range: "#504945"
     float: "#504945"

--- a/themes/themes/gruvbox-material-dark-hard.nu
+++ b/themes/themes/gruvbox-material-dark-hard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#89b482" } else { "light_gray" } }
     int: "#d4be98"
     filesize: {|e|
-      if $e == 0b {
-        "#d4be98"
-      } else if $e < 1mb {
-        "#89b482"
-      } else {{ fg: "#7daea3" }}
+        if $e == 0b {
+            "#d4be98"
+        } else if $e < 1mb {
+            "#89b482"
+        } else {{ fg: "#7daea3" }}
     }
     duration: "#d4be98"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ea6962" attr: "b" }
-      } else if $in < 6hr {
-        "#ea6962"
-      } else if $in < 1day {
-        "#d8a657"
-      } else if $in < 3day {
-        "#a9b665"
-      } else if $in < 1wk {
-        { fg: "#a9b665" attr: "b" }
-      } else if $in < 6wk {
-        "#89b482"
-      } else if $in < 52wk {
-        "#7daea3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ea6962" attr: "b" }
+        } else if $in < 6hr {
+            "#ea6962"
+        } else if $in < 1day {
+            "#d8a657"
+        } else if $in < 3day {
+            "#a9b665"
+        } else if $in < 1wk {
+            { fg: "#a9b665" attr: "b" }
+        } else if $in < 6wk {
+            "#89b482"
+        } else if $in < 52wk {
+            "#7daea3"
+        } else { "dark_gray" }
     }
     range: "#d4be98"
     float: "#d4be98"

--- a/themes/themes/gruvbox-material-dark-medium.nu
+++ b/themes/themes/gruvbox-material-dark-medium.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#89b482" } else { "light_gray" } }
     int: "#d4be98"
     filesize: {|e|
-      if $e == 0b {
-        "#d4be98"
-      } else if $e < 1mb {
-        "#89b482"
-      } else {{ fg: "#7daea3" }}
+        if $e == 0b {
+            "#d4be98"
+        } else if $e < 1mb {
+            "#89b482"
+        } else {{ fg: "#7daea3" }}
     }
     duration: "#d4be98"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ea6962" attr: "b" }
-      } else if $in < 6hr {
-        "#ea6962"
-      } else if $in < 1day {
-        "#d8a657"
-      } else if $in < 3day {
-        "#a9b665"
-      } else if $in < 1wk {
-        { fg: "#a9b665" attr: "b" }
-      } else if $in < 6wk {
-        "#89b482"
-      } else if $in < 52wk {
-        "#7daea3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ea6962" attr: "b" }
+        } else if $in < 6hr {
+            "#ea6962"
+        } else if $in < 1day {
+            "#d8a657"
+        } else if $in < 3day {
+            "#a9b665"
+        } else if $in < 1wk {
+            { fg: "#a9b665" attr: "b" }
+        } else if $in < 6wk {
+            "#89b482"
+        } else if $in < 52wk {
+            "#7daea3"
+        } else { "dark_gray" }
     }
     range: "#d4be98"
     float: "#d4be98"

--- a/themes/themes/gruvbox-material-dark-soft.nu
+++ b/themes/themes/gruvbox-material-dark-soft.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#89b482" } else { "light_gray" } }
     int: "#d4be98"
     filesize: {|e|
-      if $e == 0b {
-        "#d4be98"
-      } else if $e < 1mb {
-        "#89b482"
-      } else {{ fg: "#7daea3" }}
+        if $e == 0b {
+            "#d4be98"
+        } else if $e < 1mb {
+            "#89b482"
+        } else {{ fg: "#7daea3" }}
     }
     duration: "#d4be98"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ea6962" attr: "b" }
-      } else if $in < 6hr {
-        "#ea6962"
-      } else if $in < 1day {
-        "#d8a657"
-      } else if $in < 3day {
-        "#a9b665"
-      } else if $in < 1wk {
-        { fg: "#a9b665" attr: "b" }
-      } else if $in < 6wk {
-        "#89b482"
-      } else if $in < 52wk {
-        "#7daea3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ea6962" attr: "b" }
+        } else if $in < 6hr {
+            "#ea6962"
+        } else if $in < 1day {
+            "#d8a657"
+        } else if $in < 3day {
+            "#a9b665"
+        } else if $in < 1wk {
+            { fg: "#a9b665" attr: "b" }
+        } else if $in < 6wk {
+            "#89b482"
+        } else if $in < 52wk {
+            "#7daea3"
+        } else { "dark_gray" }
     }
     range: "#d4be98"
     float: "#d4be98"

--- a/themes/themes/gruvbox-material-light-hard.nu
+++ b/themes/themes/gruvbox-material-light-hard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4c7a5d" } else { "light_gray" } }
     int: "#654735"
     filesize: {|e|
-      if $e == 0b {
-        "#654735"
-      } else if $e < 1mb {
-        "#4c7a5d"
-      } else {{ fg: "#45707a" }}
+        if $e == 0b {
+            "#654735"
+        } else if $e < 1mb {
+            "#4c7a5d"
+        } else {{ fg: "#45707a" }}
     }
     duration: "#654735"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c14a4a" attr: "b" }
-      } else if $in < 6hr {
-        "#c14a4a"
-      } else if $in < 1day {
-        "#b47109"
-      } else if $in < 3day {
-        "#6c782e"
-      } else if $in < 1wk {
-        { fg: "#6c782e" attr: "b" }
-      } else if $in < 6wk {
-        "#4c7a5d"
-      } else if $in < 52wk {
-        "#45707a"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c14a4a" attr: "b" }
+        } else if $in < 6hr {
+            "#c14a4a"
+        } else if $in < 1day {
+            "#b47109"
+        } else if $in < 3day {
+            "#6c782e"
+        } else if $in < 1wk {
+            { fg: "#6c782e" attr: "b" }
+        } else if $in < 6wk {
+            "#4c7a5d"
+        } else if $in < 52wk {
+            "#45707a"
+        } else { "dark_gray" }
     }
     range: "#654735"
     float: "#654735"

--- a/themes/themes/gruvbox-material-light-medium.nu
+++ b/themes/themes/gruvbox-material-light-medium.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4c7a5d" } else { "light_gray" } }
     int: "#654735"
     filesize: {|e|
-      if $e == 0b {
-        "#654735"
-      } else if $e < 1mb {
-        "#4c7a5d"
-      } else {{ fg: "#45707a" }}
+        if $e == 0b {
+            "#654735"
+        } else if $e < 1mb {
+            "#4c7a5d"
+        } else {{ fg: "#45707a" }}
     }
     duration: "#654735"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c14a4a" attr: "b" }
-      } else if $in < 6hr {
-        "#c14a4a"
-      } else if $in < 1day {
-        "#b47109"
-      } else if $in < 3day {
-        "#6c782e"
-      } else if $in < 1wk {
-        { fg: "#6c782e" attr: "b" }
-      } else if $in < 6wk {
-        "#4c7a5d"
-      } else if $in < 52wk {
-        "#45707a"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c14a4a" attr: "b" }
+        } else if $in < 6hr {
+            "#c14a4a"
+        } else if $in < 1day {
+            "#b47109"
+        } else if $in < 3day {
+            "#6c782e"
+        } else if $in < 1wk {
+            { fg: "#6c782e" attr: "b" }
+        } else if $in < 6wk {
+            "#4c7a5d"
+        } else if $in < 52wk {
+            "#45707a"
+        } else { "dark_gray" }
     }
     range: "#654735"
     float: "#654735"

--- a/themes/themes/gruvbox-material-light-soft.nu
+++ b/themes/themes/gruvbox-material-light-soft.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4c7a5d" } else { "light_gray" } }
     int: "#654735"
     filesize: {|e|
-      if $e == 0b {
-        "#654735"
-      } else if $e < 1mb {
-        "#4c7a5d"
-      } else {{ fg: "#45707a" }}
+        if $e == 0b {
+            "#654735"
+        } else if $e < 1mb {
+            "#4c7a5d"
+        } else {{ fg: "#45707a" }}
     }
     duration: "#654735"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c14a4a" attr: "b" }
-      } else if $in < 6hr {
-        "#c14a4a"
-      } else if $in < 1day {
-        "#b47109"
-      } else if $in < 3day {
-        "#6c782e"
-      } else if $in < 1wk {
-        { fg: "#6c782e" attr: "b" }
-      } else if $in < 6wk {
-        "#4c7a5d"
-      } else if $in < 52wk {
-        "#45707a"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c14a4a" attr: "b" }
+        } else if $in < 6hr {
+            "#c14a4a"
+        } else if $in < 1day {
+            "#b47109"
+        } else if $in < 3day {
+            "#6c782e"
+        } else if $in < 1wk {
+            { fg: "#6c782e" attr: "b" }
+        } else if $in < 6wk {
+            "#4c7a5d"
+        } else if $in < 52wk {
+            "#45707a"
+        } else { "dark_gray" }
     }
     range: "#654735"
     float: "#654735"

--- a/themes/themes/gruvbox-mix-dark-hard.nu
+++ b/themes/themes/gruvbox-mix-dark-hard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8bba7f" } else { "light_gray" } }
     int: "#e2cca9"
     filesize: {|e|
-      if $e == 0b {
-        "#e2cca9"
-      } else if $e < 1mb {
-        "#8bba7f"
-      } else {{ fg: "#80aa9e" }}
+        if $e == 0b {
+            "#e2cca9"
+        } else if $e < 1mb {
+            "#8bba7f"
+        } else {{ fg: "#80aa9e" }}
     }
     duration: "#e2cca9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f2594b" attr: "b" }
-      } else if $in < 6hr {
-        "#f2594b"
-      } else if $in < 1day {
-        "#e9b143"
-      } else if $in < 3day {
-        "#b0b846"
-      } else if $in < 1wk {
-        { fg: "#b0b846" attr: "b" }
-      } else if $in < 6wk {
-        "#8bba7f"
-      } else if $in < 52wk {
-        "#80aa9e"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f2594b" attr: "b" }
+        } else if $in < 6hr {
+            "#f2594b"
+        } else if $in < 1day {
+            "#e9b143"
+        } else if $in < 3day {
+            "#b0b846"
+        } else if $in < 1wk {
+            { fg: "#b0b846" attr: "b" }
+        } else if $in < 6wk {
+            "#8bba7f"
+        } else if $in < 52wk {
+            "#80aa9e"
+        } else { "dark_gray" }
     }
     range: "#e2cca9"
     float: "#e2cca9"

--- a/themes/themes/gruvbox-mix-dark-medium.nu
+++ b/themes/themes/gruvbox-mix-dark-medium.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8bba7f" } else { "light_gray" } }
     int: "#e2cca9"
     filesize: {|e|
-      if $e == 0b {
-        "#e2cca9"
-      } else if $e < 1mb {
-        "#8bba7f"
-      } else {{ fg: "#80aa9e" }}
+        if $e == 0b {
+            "#e2cca9"
+        } else if $e < 1mb {
+            "#8bba7f"
+        } else {{ fg: "#80aa9e" }}
     }
     duration: "#e2cca9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f2594b" attr: "b" }
-      } else if $in < 6hr {
-        "#f2594b"
-      } else if $in < 1day {
-        "#e9b143"
-      } else if $in < 3day {
-        "#b0b846"
-      } else if $in < 1wk {
-        { fg: "#b0b846" attr: "b" }
-      } else if $in < 6wk {
-        "#8bba7f"
-      } else if $in < 52wk {
-        "#80aa9e"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f2594b" attr: "b" }
+        } else if $in < 6hr {
+            "#f2594b"
+        } else if $in < 1day {
+            "#e9b143"
+        } else if $in < 3day {
+            "#b0b846"
+        } else if $in < 1wk {
+            { fg: "#b0b846" attr: "b" }
+        } else if $in < 6wk {
+            "#8bba7f"
+        } else if $in < 52wk {
+            "#80aa9e"
+        } else { "dark_gray" }
     }
     range: "#e2cca9"
     float: "#e2cca9"

--- a/themes/themes/gruvbox-mix-dark-soft.nu
+++ b/themes/themes/gruvbox-mix-dark-soft.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8bba7f" } else { "light_gray" } }
     int: "#e2cca9"
     filesize: {|e|
-      if $e == 0b {
-        "#e2cca9"
-      } else if $e < 1mb {
-        "#8bba7f"
-      } else {{ fg: "#80aa9e" }}
+        if $e == 0b {
+            "#e2cca9"
+        } else if $e < 1mb {
+            "#8bba7f"
+        } else {{ fg: "#80aa9e" }}
     }
     duration: "#e2cca9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f2594b" attr: "b" }
-      } else if $in < 6hr {
-        "#f2594b"
-      } else if $in < 1day {
-        "#e9b143"
-      } else if $in < 3day {
-        "#b0b846"
-      } else if $in < 1wk {
-        { fg: "#b0b846" attr: "b" }
-      } else if $in < 6wk {
-        "#8bba7f"
-      } else if $in < 52wk {
-        "#80aa9e"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f2594b" attr: "b" }
+        } else if $in < 6hr {
+            "#f2594b"
+        } else if $in < 1day {
+            "#e9b143"
+        } else if $in < 3day {
+            "#b0b846"
+        } else if $in < 1wk {
+            { fg: "#b0b846" attr: "b" }
+        } else if $in < 6wk {
+            "#8bba7f"
+        } else if $in < 52wk {
+            "#80aa9e"
+        } else { "dark_gray" }
     }
     range: "#e2cca9"
     float: "#e2cca9"

--- a/themes/themes/gruvbox-mix-light-hard.nu
+++ b/themes/themes/gruvbox-mix-light-hard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#477a5b" } else { "light_gray" } }
     int: "#514036"
     filesize: {|e|
-      if $e == 0b {
-        "#514036"
-      } else if $e < 1mb {
-        "#477a5b"
-      } else {{ fg: "#266b79" }}
+        if $e == 0b {
+            "#514036"
+        } else if $e < 1mb {
+            "#477a5b"
+        } else {{ fg: "#266b79" }}
     }
     duration: "#514036"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#af2528" attr: "b" }
-      } else if $in < 6hr {
-        "#af2528"
-      } else if $in < 1day {
-        "#b4730e"
-      } else if $in < 3day {
-        "#72761e"
-      } else if $in < 1wk {
-        { fg: "#72761e" attr: "b" }
-      } else if $in < 6wk {
-        "#477a5b"
-      } else if $in < 52wk {
-        "#266b79"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#af2528" attr: "b" }
+        } else if $in < 6hr {
+            "#af2528"
+        } else if $in < 1day {
+            "#b4730e"
+        } else if $in < 3day {
+            "#72761e"
+        } else if $in < 1wk {
+            { fg: "#72761e" attr: "b" }
+        } else if $in < 6wk {
+            "#477a5b"
+        } else if $in < 52wk {
+            "#266b79"
+        } else { "dark_gray" }
     }
     range: "#514036"
     float: "#514036"

--- a/themes/themes/gruvbox-mix-light-medium.nu
+++ b/themes/themes/gruvbox-mix-light-medium.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#477a5b" } else { "light_gray" } }
     int: "#514036"
     filesize: {|e|
-      if $e == 0b {
-        "#514036"
-      } else if $e < 1mb {
-        "#477a5b"
-      } else {{ fg: "#266b79" }}
+        if $e == 0b {
+            "#514036"
+        } else if $e < 1mb {
+            "#477a5b"
+        } else {{ fg: "#266b79" }}
     }
     duration: "#514036"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#af2528" attr: "b" }
-      } else if $in < 6hr {
-        "#af2528"
-      } else if $in < 1day {
-        "#b4730e"
-      } else if $in < 3day {
-        "#72761e"
-      } else if $in < 1wk {
-        { fg: "#72761e" attr: "b" }
-      } else if $in < 6wk {
-        "#477a5b"
-      } else if $in < 52wk {
-        "#266b79"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#af2528" attr: "b" }
+        } else if $in < 6hr {
+            "#af2528"
+        } else if $in < 1day {
+            "#b4730e"
+        } else if $in < 3day {
+            "#72761e"
+        } else if $in < 1wk {
+            { fg: "#72761e" attr: "b" }
+        } else if $in < 6wk {
+            "#477a5b"
+        } else if $in < 52wk {
+            "#266b79"
+        } else { "dark_gray" }
     }
     range: "#514036"
     float: "#514036"

--- a/themes/themes/gruvbox-mix-light-soft.nu
+++ b/themes/themes/gruvbox-mix-light-soft.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#477a5b" } else { "light_gray" } }
     int: "#514036"
     filesize: {|e|
-      if $e == 0b {
-        "#514036"
-      } else if $e < 1mb {
-        "#477a5b"
-      } else {{ fg: "#266b79" }}
+        if $e == 0b {
+            "#514036"
+        } else if $e < 1mb {
+            "#477a5b"
+        } else {{ fg: "#266b79" }}
     }
     duration: "#514036"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#af2528" attr: "b" }
-      } else if $in < 6hr {
-        "#af2528"
-      } else if $in < 1day {
-        "#b4730e"
-      } else if $in < 3day {
-        "#72761e"
-      } else if $in < 1wk {
-        { fg: "#72761e" attr: "b" }
-      } else if $in < 6wk {
-        "#477a5b"
-      } else if $in < 52wk {
-        "#266b79"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#af2528" attr: "b" }
+        } else if $in < 6hr {
+            "#af2528"
+        } else if $in < 1day {
+            "#b4730e"
+        } else if $in < 3day {
+            "#72761e"
+        } else if $in < 1wk {
+            { fg: "#72761e" attr: "b" }
+        } else if $in < 6wk {
+            "#477a5b"
+        } else if $in < 52wk {
+            "#266b79"
+        } else { "dark_gray" }
     }
     range: "#514036"
     float: "#514036"

--- a/themes/themes/gruvbox-original-dark-hard.nu
+++ b/themes/themes/gruvbox-original-dark-hard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ec07c" } else { "light_gray" } }
     int: "#ebdbb2"
     filesize: {|e|
-      if $e == 0b {
-        "#ebdbb2"
-      } else if $e < 1mb {
-        "#8ec07c"
-      } else {{ fg: "#83a598" }}
+        if $e == 0b {
+            "#ebdbb2"
+        } else if $e < 1mb {
+            "#8ec07c"
+        } else {{ fg: "#83a598" }}
     }
     duration: "#ebdbb2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb4934" attr: "b" }
-      } else if $in < 6hr {
-        "#fb4934"
-      } else if $in < 1day {
-        "#fabd2f"
-      } else if $in < 3day {
-        "#b8bb26"
-      } else if $in < 1wk {
-        { fg: "#b8bb26" attr: "b" }
-      } else if $in < 6wk {
-        "#8ec07c"
-      } else if $in < 52wk {
-        "#83a598"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb4934" attr: "b" }
+        } else if $in < 6hr {
+            "#fb4934"
+        } else if $in < 1day {
+            "#fabd2f"
+        } else if $in < 3day {
+            "#b8bb26"
+        } else if $in < 1wk {
+            { fg: "#b8bb26" attr: "b" }
+        } else if $in < 6wk {
+            "#8ec07c"
+        } else if $in < 52wk {
+            "#83a598"
+        } else { "dark_gray" }
     }
     range: "#ebdbb2"
     float: "#ebdbb2"

--- a/themes/themes/gruvbox-original-dark-medium.nu
+++ b/themes/themes/gruvbox-original-dark-medium.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ec07c" } else { "light_gray" } }
     int: "#ebdbb2"
     filesize: {|e|
-      if $e == 0b {
-        "#ebdbb2"
-      } else if $e < 1mb {
-        "#8ec07c"
-      } else {{ fg: "#83a598" }}
+        if $e == 0b {
+            "#ebdbb2"
+        } else if $e < 1mb {
+            "#8ec07c"
+        } else {{ fg: "#83a598" }}
     }
     duration: "#ebdbb2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb4934" attr: "b" }
-      } else if $in < 6hr {
-        "#fb4934"
-      } else if $in < 1day {
-        "#fabd2f"
-      } else if $in < 3day {
-        "#b8bb26"
-      } else if $in < 1wk {
-        { fg: "#b8bb26" attr: "b" }
-      } else if $in < 6wk {
-        "#8ec07c"
-      } else if $in < 52wk {
-        "#83a598"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb4934" attr: "b" }
+        } else if $in < 6hr {
+            "#fb4934"
+        } else if $in < 1day {
+            "#fabd2f"
+        } else if $in < 3day {
+            "#b8bb26"
+        } else if $in < 1wk {
+            { fg: "#b8bb26" attr: "b" }
+        } else if $in < 6wk {
+            "#8ec07c"
+        } else if $in < 52wk {
+            "#83a598"
+        } else { "dark_gray" }
     }
     range: "#ebdbb2"
     float: "#ebdbb2"

--- a/themes/themes/gruvbox-original-dark-soft.nu
+++ b/themes/themes/gruvbox-original-dark-soft.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ec07c" } else { "light_gray" } }
     int: "#ebdbb2"
     filesize: {|e|
-      if $e == 0b {
-        "#ebdbb2"
-      } else if $e < 1mb {
-        "#8ec07c"
-      } else {{ fg: "#83a598" }}
+        if $e == 0b {
+            "#ebdbb2"
+        } else if $e < 1mb {
+            "#8ec07c"
+        } else {{ fg: "#83a598" }}
     }
     duration: "#ebdbb2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb4934" attr: "b" }
-      } else if $in < 6hr {
-        "#fb4934"
-      } else if $in < 1day {
-        "#fabd2f"
-      } else if $in < 3day {
-        "#b8bb26"
-      } else if $in < 1wk {
-        { fg: "#b8bb26" attr: "b" }
-      } else if $in < 6wk {
-        "#8ec07c"
-      } else if $in < 52wk {
-        "#83a598"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb4934" attr: "b" }
+        } else if $in < 6hr {
+            "#fb4934"
+        } else if $in < 1day {
+            "#fabd2f"
+        } else if $in < 3day {
+            "#b8bb26"
+        } else if $in < 1wk {
+            { fg: "#b8bb26" attr: "b" }
+        } else if $in < 6wk {
+            "#8ec07c"
+        } else if $in < 52wk {
+            "#83a598"
+        } else { "dark_gray" }
     }
     range: "#ebdbb2"
     float: "#ebdbb2"

--- a/themes/themes/gruvbox-original-light-hard.nu
+++ b/themes/themes/gruvbox-original-light-hard.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#427b58" } else { "light_gray" } }
     int: "#3c3836"
     filesize: {|e|
-      if $e == 0b {
-        "#3c3836"
-      } else if $e < 1mb {
-        "#427b58"
-      } else {{ fg: "#076678" }}
+        if $e == 0b {
+            "#3c3836"
+        } else if $e < 1mb {
+            "#427b58"
+        } else {{ fg: "#076678" }}
     }
     duration: "#3c3836"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9d0006" attr: "b" }
-      } else if $in < 6hr {
-        "#9d0006"
-      } else if $in < 1day {
-        "#b57614"
-      } else if $in < 3day {
-        "#79740e"
-      } else if $in < 1wk {
-        { fg: "#79740e" attr: "b" }
-      } else if $in < 6wk {
-        "#427b58"
-      } else if $in < 52wk {
-        "#076678"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9d0006" attr: "b" }
+        } else if $in < 6hr {
+            "#9d0006"
+        } else if $in < 1day {
+            "#b57614"
+        } else if $in < 3day {
+            "#79740e"
+        } else if $in < 1wk {
+            { fg: "#79740e" attr: "b" }
+        } else if $in < 6wk {
+            "#427b58"
+        } else if $in < 52wk {
+            "#076678"
+        } else { "dark_gray" }
     }
     range: "#3c3836"
     float: "#3c3836"

--- a/themes/themes/gruvbox-original-light-medium.nu
+++ b/themes/themes/gruvbox-original-light-medium.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#427b58" } else { "light_gray" } }
     int: "#3c3836"
     filesize: {|e|
-      if $e == 0b {
-        "#3c3836"
-      } else if $e < 1mb {
-        "#427b58"
-      } else {{ fg: "#076678" }}
+        if $e == 0b {
+            "#3c3836"
+        } else if $e < 1mb {
+            "#427b58"
+        } else {{ fg: "#076678" }}
     }
     duration: "#3c3836"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9d0006" attr: "b" }
-      } else if $in < 6hr {
-        "#9d0006"
-      } else if $in < 1day {
-        "#b57614"
-      } else if $in < 3day {
-        "#79740e"
-      } else if $in < 1wk {
-        { fg: "#79740e" attr: "b" }
-      } else if $in < 6wk {
-        "#427b58"
-      } else if $in < 52wk {
-        "#076678"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9d0006" attr: "b" }
+        } else if $in < 6hr {
+            "#9d0006"
+        } else if $in < 1day {
+            "#b57614"
+        } else if $in < 3day {
+            "#79740e"
+        } else if $in < 1wk {
+            { fg: "#79740e" attr: "b" }
+        } else if $in < 6wk {
+            "#427b58"
+        } else if $in < 52wk {
+            "#076678"
+        } else { "dark_gray" }
     }
     range: "#3c3836"
     float: "#3c3836"

--- a/themes/themes/gruvbox-original-light-soft.nu
+++ b/themes/themes/gruvbox-original-light-soft.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#427b58" } else { "light_gray" } }
     int: "#3c3836"
     filesize: {|e|
-      if $e == 0b {
-        "#3c3836"
-      } else if $e < 1mb {
-        "#427b58"
-      } else {{ fg: "#076678" }}
+        if $e == 0b {
+            "#3c3836"
+        } else if $e < 1mb {
+            "#427b58"
+        } else {{ fg: "#076678" }}
     }
     duration: "#3c3836"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9d0006" attr: "b" }
-      } else if $in < 6hr {
-        "#9d0006"
-      } else if $in < 1day {
-        "#b57614"
-      } else if $in < 3day {
-        "#79740e"
-      } else if $in < 1wk {
-        { fg: "#79740e" attr: "b" }
-      } else if $in < 6wk {
-        "#427b58"
-      } else if $in < 52wk {
-        "#076678"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9d0006" attr: "b" }
+        } else if $in < 6hr {
+            "#9d0006"
+        } else if $in < 1day {
+            "#b57614"
+        } else if $in < 3day {
+            "#79740e"
+        } else if $in < 1wk {
+            { fg: "#79740e" attr: "b" }
+        } else if $in < 6wk {
+            "#427b58"
+        } else if $in < 52wk {
+            "#076678"
+        } else { "dark_gray" }
     }
     range: "#3c3836"
     float: "#3c3836"

--- a/themes/themes/gruvbox.nu
+++ b/themes/themes/gruvbox.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#427b58" } else { "light_gray" } }
     int: "#7c6f64"
     filesize: {|e|
-      if $e == 0b {
-        "#7c6f64"
-      } else if $e < 1mb {
-        "#689d6a"
-      } else {{ fg: "#458588" }}
+        if $e == 0b {
+            "#7c6f64"
+        } else if $e < 1mb {
+            "#689d6a"
+        } else {{ fg: "#458588" }}
     }
     duration: "#7c6f64"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc241d" attr: "b" }
-      } else if $in < 6hr {
-        "#cc241d"
-      } else if $in < 1day {
-        "#d79921"
-      } else if $in < 3day {
-        "#98971a"
-      } else if $in < 1wk {
-        { fg: "#98971a" attr: "b" }
-      } else if $in < 6wk {
-        "#689d6a"
-      } else if $in < 52wk {
-        "#458588"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc241d" attr: "b" }
+        } else if $in < 6hr {
+            "#cc241d"
+        } else if $in < 1day {
+            "#d79921"
+        } else if $in < 3day {
+            "#98971a"
+        } else if $in < 1wk {
+            { fg: "#98971a" attr: "b" }
+        } else if $in < 6wk {
+            "#689d6a"
+        } else if $in < 52wk {
+            "#458588"
+        } else { "dark_gray" }
     }
     range: "#7c6f64"
     float: "#7c6f64"

--- a/themes/themes/hardcore.nu
+++ b/themes/themes/hardcore.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#708387" } else { "light_gray" } }
     int: "#cdcdcd"
     filesize: {|e|
-      if $e == 0b {
-        "#cdcdcd"
-      } else if $e < 1mb {
-        "#708387"
-      } else {{ fg: "#66d9ef" }}
+        if $e == 0b {
+            "#cdcdcd"
+        } else if $e < 1mb {
+            "#708387"
+        } else {{ fg: "#66d9ef" }}
     }
     duration: "#cdcdcd"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f92672" attr: "b" }
-      } else if $in < 6hr {
-        "#f92672"
-      } else if $in < 1day {
-        "#e6db74"
-      } else if $in < 3day {
-        "#a6e22e"
-      } else if $in < 1wk {
-        { fg: "#a6e22e" attr: "b" }
-      } else if $in < 6wk {
-        "#708387"
-      } else if $in < 52wk {
-        "#66d9ef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f92672" attr: "b" }
+        } else if $in < 6hr {
+            "#f92672"
+        } else if $in < 1day {
+            "#e6db74"
+        } else if $in < 3day {
+            "#a6e22e"
+        } else if $in < 1wk {
+            { fg: "#a6e22e" attr: "b" }
+        } else if $in < 6wk {
+            "#708387"
+        } else if $in < 52wk {
+            "#66d9ef"
+        } else { "dark_gray" }
     }
     range: "#cdcdcd"
     float: "#cdcdcd"

--- a/themes/themes/harmonic-dark.nu
+++ b/themes/themes/harmonic-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#568bbf" } else { "light_gray" } }
     int: "#cbd6e2"
     filesize: {|e|
-      if $e == 0b {
-        "#cbd6e2"
-      } else if $e < 1mb {
-        "#568bbf"
-      } else {{ fg: "#8b56bf" }}
+        if $e == 0b {
+            "#cbd6e2"
+        } else if $e < 1mb {
+            "#568bbf"
+        } else {{ fg: "#8b56bf" }}
     }
     duration: "#cbd6e2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bf8b56" attr: "b" }
-      } else if $in < 6hr {
-        "#bf8b56"
-      } else if $in < 1day {
-        "#8bbf56"
-      } else if $in < 3day {
-        "#56bf8b"
-      } else if $in < 1wk {
-        { fg: "#56bf8b" attr: "b" }
-      } else if $in < 6wk {
-        "#568bbf"
-      } else if $in < 52wk {
-        "#8b56bf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bf8b56" attr: "b" }
+        } else if $in < 6hr {
+            "#bf8b56"
+        } else if $in < 1day {
+            "#8bbf56"
+        } else if $in < 3day {
+            "#56bf8b"
+        } else if $in < 1wk {
+            { fg: "#56bf8b" attr: "b" }
+        } else if $in < 6wk {
+            "#568bbf"
+        } else if $in < 52wk {
+            "#8b56bf"
+        } else { "dark_gray" }
     }
     range: "#cbd6e2"
     float: "#cbd6e2"

--- a/themes/themes/harmonic-light.nu
+++ b/themes/themes/harmonic-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#568bbf" } else { "light_gray" } }
     int: "#405c79"
     filesize: {|e|
-      if $e == 0b {
-        "#405c79"
-      } else if $e < 1mb {
-        "#568bbf"
-      } else {{ fg: "#8b56bf" }}
+        if $e == 0b {
+            "#405c79"
+        } else if $e < 1mb {
+            "#568bbf"
+        } else {{ fg: "#8b56bf" }}
     }
     duration: "#405c79"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bf8b56" attr: "b" }
-      } else if $in < 6hr {
-        "#bf8b56"
-      } else if $in < 1day {
-        "#8bbf56"
-      } else if $in < 3day {
-        "#56bf8b"
-      } else if $in < 1wk {
-        { fg: "#56bf8b" attr: "b" }
-      } else if $in < 6wk {
-        "#568bbf"
-      } else if $in < 52wk {
-        "#8b56bf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bf8b56" attr: "b" }
+        } else if $in < 6hr {
+            "#bf8b56"
+        } else if $in < 1day {
+            "#8bbf56"
+        } else if $in < 3day {
+            "#56bf8b"
+        } else if $in < 1wk {
+            { fg: "#56bf8b" attr: "b" }
+        } else if $in < 6wk {
+            "#568bbf"
+        } else if $in < 52wk {
+            "#8b56bf"
+        } else { "dark_gray" }
     }
     range: "#405c79"
     float: "#405c79"

--- a/themes/themes/harmonic16-dark.nu
+++ b/themes/themes/harmonic16-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#568bbf" } else { "light_gray" } }
     int: "#cbd6e2"
     filesize: {|e|
-      if $e == 0b {
-        "#cbd6e2"
-      } else if $e < 1mb {
-        "#568bbf"
-      } else {{ fg: "#8b56bf" }}
+        if $e == 0b {
+            "#cbd6e2"
+        } else if $e < 1mb {
+            "#568bbf"
+        } else {{ fg: "#8b56bf" }}
     }
     duration: "#cbd6e2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bf8b56" attr: "b" }
-      } else if $in < 6hr {
-        "#bf8b56"
-      } else if $in < 1day {
-        "#8bbf56"
-      } else if $in < 3day {
-        "#56bf8b"
-      } else if $in < 1wk {
-        { fg: "#56bf8b" attr: "b" }
-      } else if $in < 6wk {
-        "#568bbf"
-      } else if $in < 52wk {
-        "#8b56bf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bf8b56" attr: "b" }
+        } else if $in < 6hr {
+            "#bf8b56"
+        } else if $in < 1day {
+            "#8bbf56"
+        } else if $in < 3day {
+            "#56bf8b"
+        } else if $in < 1wk {
+            { fg: "#56bf8b" attr: "b" }
+        } else if $in < 6wk {
+            "#568bbf"
+        } else if $in < 52wk {
+            "#8b56bf"
+        } else { "dark_gray" }
     }
     range: "#cbd6e2"
     float: "#cbd6e2"

--- a/themes/themes/harmonic16-light.nu
+++ b/themes/themes/harmonic16-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#568bbf" } else { "light_gray" } }
     int: "#405c79"
     filesize: {|e|
-      if $e == 0b {
-        "#405c79"
-      } else if $e < 1mb {
-        "#568bbf"
-      } else {{ fg: "#8b56bf" }}
+        if $e == 0b {
+            "#405c79"
+        } else if $e < 1mb {
+            "#568bbf"
+        } else {{ fg: "#8b56bf" }}
     }
     duration: "#405c79"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bf8b56" attr: "b" }
-      } else if $in < 6hr {
-        "#bf8b56"
-      } else if $in < 1day {
-        "#8bbf56"
-      } else if $in < 3day {
-        "#56bf8b"
-      } else if $in < 1wk {
-        { fg: "#56bf8b" attr: "b" }
-      } else if $in < 6wk {
-        "#568bbf"
-      } else if $in < 52wk {
-        "#8b56bf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bf8b56" attr: "b" }
+        } else if $in < 6hr {
+            "#bf8b56"
+        } else if $in < 1day {
+            "#8bbf56"
+        } else if $in < 3day {
+            "#56bf8b"
+        } else if $in < 1wk {
+            { fg: "#56bf8b" attr: "b" }
+        } else if $in < 6wk {
+            "#568bbf"
+        } else if $in < 52wk {
+            "#8b56bf"
+        } else { "dark_gray" }
     }
     range: "#405c79"
     float: "#405c79"

--- a/themes/themes/harper.nu
+++ b/themes/themes/harper.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#f5bfd7" } else { "light_gray" } }
     int: "#a8a49d"
     filesize: {|e|
-      if $e == 0b {
-        "#a8a49d"
-      } else if $e < 1mb {
-        "#f5bfd7"
-      } else {{ fg: "#489e48" }}
+        if $e == 0b {
+            "#a8a49d"
+        } else if $e < 1mb {
+            "#f5bfd7"
+        } else {{ fg: "#489e48" }}
     }
     duration: "#a8a49d"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f8b63f" attr: "b" }
-      } else if $in < 6hr {
-        "#f8b63f"
-      } else if $in < 1day {
-        "#d6da25"
-      } else if $in < 3day {
-        "#7fb5e1"
-      } else if $in < 1wk {
-        { fg: "#7fb5e1" attr: "b" }
-      } else if $in < 6wk {
-        "#f5bfd7"
-      } else if $in < 52wk {
-        "#489e48"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f8b63f" attr: "b" }
+        } else if $in < 6hr {
+            "#f8b63f"
+        } else if $in < 1day {
+            "#d6da25"
+        } else if $in < 3day {
+            "#7fb5e1"
+        } else if $in < 1wk {
+            { fg: "#7fb5e1" attr: "b" }
+        } else if $in < 6wk {
+            "#f5bfd7"
+        } else if $in < 52wk {
+            "#489e48"
+        } else { "dark_gray" }
     }
     range: "#a8a49d"
     float: "#a8a49d"

--- a/themes/themes/heetch-light.nu
+++ b/themes/themes/heetch-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c33678" } else { "light_gray" } }
     int: "#5a496e"
     filesize: {|e|
-      if $e == 0b {
-        "#5a496e"
-      } else if $e < 1mb {
-        "#c33678"
-      } else {{ fg: "#47f9f5" }}
+        if $e == 0b {
+            "#5a496e"
+        } else if $e < 1mb {
+            "#c33678"
+        } else {{ fg: "#47f9f5" }}
     }
     duration: "#5a496e"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#27d9d5" attr: "b" }
-      } else if $in < 6hr {
-        "#27d9d5"
-      } else if $in < 1day {
-        "#5ba2b6"
-      } else if $in < 3day {
-        "#f80059"
-      } else if $in < 1wk {
-        { fg: "#f80059" attr: "b" }
-      } else if $in < 6wk {
-        "#c33678"
-      } else if $in < 52wk {
-        "#47f9f5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#27d9d5" attr: "b" }
+        } else if $in < 6hr {
+            "#27d9d5"
+        } else if $in < 1day {
+            "#5ba2b6"
+        } else if $in < 3day {
+            "#f80059"
+        } else if $in < 1wk {
+            { fg: "#f80059" attr: "b" }
+        } else if $in < 6wk {
+            "#c33678"
+        } else if $in < 52wk {
+            "#47f9f5"
+        } else { "dark_gray" }
     }
     range: "#5a496e"
     float: "#5a496e"

--- a/themes/themes/heetch.nu
+++ b/themes/themes/heetch.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#f80059" } else { "light_gray" } }
     int: "#bdb6c5"
     filesize: {|e|
-      if $e == 0b {
-        "#bdb6c5"
-      } else if $e < 1mb {
-        "#f80059"
-      } else {{ fg: "#bd0152" }}
+        if $e == 0b {
+            "#bdb6c5"
+        } else if $e < 1mb {
+            "#f80059"
+        } else {{ fg: "#bd0152" }}
     }
     duration: "#bdb6c5"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#27d9d5" attr: "b" }
-      } else if $in < 6hr {
-        "#27d9d5"
-      } else if $in < 1day {
-        "#8f6c97"
-      } else if $in < 3day {
-        "#c33678"
-      } else if $in < 1wk {
-        { fg: "#c33678" attr: "b" }
-      } else if $in < 6wk {
-        "#f80059"
-      } else if $in < 52wk {
-        "#bd0152"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#27d9d5" attr: "b" }
+        } else if $in < 6hr {
+            "#27d9d5"
+        } else if $in < 1day {
+            "#8f6c97"
+        } else if $in < 3day {
+            "#c33678"
+        } else if $in < 1wk {
+            { fg: "#c33678" attr: "b" }
+        } else if $in < 6wk {
+            "#f80059"
+        } else if $in < 52wk {
+            "#bd0152"
+        } else { "dark_gray" }
     }
     range: "#bdb6c5"
     float: "#bdb6c5"

--- a/themes/themes/helios.nu
+++ b/themes/themes/helios.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1ba595" } else { "light_gray" } }
     int: "#d5d5d5"
     filesize: {|e|
-      if $e == 0b {
-        "#d5d5d5"
-      } else if $e < 1mb {
-        "#1ba595"
-      } else {{ fg: "#1e8bac" }}
+        if $e == 0b {
+            "#d5d5d5"
+        } else if $e < 1mb {
+            "#1ba595"
+        } else {{ fg: "#1e8bac" }}
     }
     duration: "#d5d5d5"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d72638" attr: "b" }
-      } else if $in < 6hr {
-        "#d72638"
-      } else if $in < 1day {
-        "#f19d1a"
-      } else if $in < 3day {
-        "#88b92d"
-      } else if $in < 1wk {
-        { fg: "#88b92d" attr: "b" }
-      } else if $in < 6wk {
-        "#1ba595"
-      } else if $in < 52wk {
-        "#1e8bac"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d72638" attr: "b" }
+        } else if $in < 6hr {
+            "#d72638"
+        } else if $in < 1day {
+            "#f19d1a"
+        } else if $in < 3day {
+            "#88b92d"
+        } else if $in < 1wk {
+            { fg: "#88b92d" attr: "b" }
+        } else if $in < 6wk {
+            "#1ba595"
+        } else if $in < 52wk {
+            "#1e8bac"
+        } else { "dark_gray" }
     }
     range: "#d5d5d5"
     float: "#d5d5d5"

--- a/themes/themes/hemisu-dark.nu
+++ b/themes/themes/hemisu-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b6e0e5" } else { "light_gray" } }
     int: "#ededed"
     filesize: {|e|
-      if $e == 0b {
-        "#ededed"
-      } else if $e < 1mb {
-        "#569a9f"
-      } else {{ fg: "#67bee3" }}
+        if $e == 0b {
+            "#ededed"
+        } else if $e < 1mb {
+            "#569a9f"
+        } else {{ fg: "#67bee3" }}
     }
     duration: "#ededed"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0054" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0054"
-      } else if $in < 1day {
-        "#9d895e"
-      } else if $in < 3day {
-        "#b1d630"
-      } else if $in < 1wk {
-        { fg: "#b1d630" attr: "b" }
-      } else if $in < 6wk {
-        "#569a9f"
-      } else if $in < 52wk {
-        "#67bee3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0054" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0054"
+        } else if $in < 1day {
+            "#9d895e"
+        } else if $in < 3day {
+            "#b1d630"
+        } else if $in < 1wk {
+            { fg: "#b1d630" attr: "b" }
+        } else if $in < 6wk {
+            "#569a9f"
+        } else if $in < 52wk {
+            "#67bee3"
+        } else { "dark_gray" }
     }
     range: "#ededed"
     float: "#ededed"

--- a/themes/themes/hemisu-light.nu
+++ b/themes/themes/hemisu-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#85b2aa" } else { "light_gray" } }
     int: "#999999"
     filesize: {|e|
-      if $e == 0b {
-        "#999999"
-      } else if $e < 1mb {
-        "#538091"
-      } else {{ fg: "#538091" }}
+        if $e == 0b {
+            "#999999"
+        } else if $e < 1mb {
+            "#538091"
+        } else {{ fg: "#538091" }}
     }
     duration: "#999999"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0055" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0055"
-      } else if $in < 1day {
-        "#503d15"
-      } else if $in < 3day {
-        "#739100"
-      } else if $in < 1wk {
-        { fg: "#739100" attr: "b" }
-      } else if $in < 6wk {
-        "#538091"
-      } else if $in < 52wk {
-        "#538091"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0055" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0055"
+        } else if $in < 1day {
+            "#503d15"
+        } else if $in < 3day {
+            "#739100"
+        } else if $in < 1wk {
+            { fg: "#739100" attr: "b" }
+        } else if $in < 6wk {
+            "#538091"
+        } else if $in < 52wk {
+            "#538091"
+        } else { "dark_gray" }
     }
     range: "#999999"
     float: "#999999"

--- a/themes/themes/highway.nu
+++ b/themes/themes/highway.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5d504a" } else { "light_gray" } }
     int: "#ededed"
     filesize: {|e|
-      if $e == 0b {
-        "#ededed"
-      } else if $e < 1mb {
-        "#384564"
-      } else {{ fg: "#006bb3" }}
+        if $e == 0b {
+            "#ededed"
+        } else if $e < 1mb {
+            "#384564"
+        } else {{ fg: "#006bb3" }}
     }
     duration: "#ededed"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d00e18" attr: "b" }
-      } else if $in < 6hr {
-        "#d00e18"
-      } else if $in < 1day {
-        "#ffcb3e"
-      } else if $in < 3day {
-        "#138034"
-      } else if $in < 1wk {
-        { fg: "#138034" attr: "b" }
-      } else if $in < 6wk {
-        "#384564"
-      } else if $in < 52wk {
-        "#006bb3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d00e18" attr: "b" }
+        } else if $in < 6hr {
+            "#d00e18"
+        } else if $in < 1day {
+            "#ffcb3e"
+        } else if $in < 3day {
+            "#138034"
+        } else if $in < 1wk {
+            { fg: "#138034" attr: "b" }
+        } else if $in < 6wk {
+            "#384564"
+        } else if $in < 52wk {
+            "#006bb3"
+        } else { "dark_gray" }
     }
     range: "#ededed"
     float: "#ededed"

--- a/themes/themes/hipster-green.nu
+++ b/themes/themes/hipster-green.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00e5e5" } else { "light_gray" } }
     int: "#bfbfbf"
     filesize: {|e|
-      if $e == 0b {
-        "#bfbfbf"
-      } else if $e < 1mb {
-        "#00a6b2"
-      } else {{ fg: "#246eb2" }}
+        if $e == 0b {
+            "#bfbfbf"
+        } else if $e < 1mb {
+            "#00a6b2"
+        } else {{ fg: "#246eb2" }}
     }
     duration: "#bfbfbf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b6214a" attr: "b" }
-      } else if $in < 6hr {
-        "#b6214a"
-      } else if $in < 1day {
-        "#bfbf00"
-      } else if $in < 3day {
-        "#00a600"
-      } else if $in < 1wk {
-        { fg: "#00a600" attr: "b" }
-      } else if $in < 6wk {
-        "#00a6b2"
-      } else if $in < 52wk {
-        "#246eb2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b6214a" attr: "b" }
+        } else if $in < 6hr {
+            "#b6214a"
+        } else if $in < 1day {
+            "#bfbf00"
+        } else if $in < 3day {
+            "#00a600"
+        } else if $in < 1wk {
+            { fg: "#00a600" attr: "b" }
+        } else if $in < 6wk {
+            "#00a6b2"
+        } else if $in < 52wk {
+            "#246eb2"
+        } else { "dark_gray" }
     }
     range: "#bfbfbf"
     float: "#bfbfbf"

--- a/themes/themes/homebrew.nu
+++ b/themes/themes/homebrew.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00e5e5" } else { "light_gray" } }
     int: "#bfbfbf"
     filesize: {|e|
-      if $e == 0b {
-        "#bfbfbf"
-      } else if $e < 1mb {
-        "#00a6b2"
-      } else {{ fg: "#0000b2" }}
+        if $e == 0b {
+            "#bfbfbf"
+        } else if $e < 1mb {
+            "#00a6b2"
+        } else {{ fg: "#0000b2" }}
     }
     duration: "#bfbfbf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#990000" attr: "b" }
-      } else if $in < 6hr {
-        "#990000"
-      } else if $in < 1day {
-        "#999900"
-      } else if $in < 3day {
-        "#00a600"
-      } else if $in < 1wk {
-        { fg: "#00a600" attr: "b" }
-      } else if $in < 6wk {
-        "#00a6b2"
-      } else if $in < 52wk {
-        "#0000b2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#990000" attr: "b" }
+        } else if $in < 6hr {
+            "#990000"
+        } else if $in < 1day {
+            "#999900"
+        } else if $in < 3day {
+            "#00a600"
+        } else if $in < 1wk {
+            { fg: "#00a600" attr: "b" }
+        } else if $in < 6wk {
+            "#00a6b2"
+        } else if $in < 52wk {
+            "#0000b2"
+        } else { "dark_gray" }
     }
     range: "#bfbfbf"
     float: "#bfbfbf"

--- a/themes/themes/hopscotch.nu
+++ b/themes/themes/hopscotch.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#149b93" } else { "light_gray" } }
     int: "#b9b5b8"
     filesize: {|e|
-      if $e == 0b {
-        "#b9b5b8"
-      } else if $e < 1mb {
-        "#149b93"
-      } else {{ fg: "#1290bf" }}
+        if $e == 0b {
+            "#b9b5b8"
+        } else if $e < 1mb {
+            "#149b93"
+        } else {{ fg: "#1290bf" }}
     }
     duration: "#b9b5b8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dd464c" attr: "b" }
-      } else if $in < 6hr {
-        "#dd464c"
-      } else if $in < 1day {
-        "#fdcc59"
-      } else if $in < 3day {
-        "#8fc13e"
-      } else if $in < 1wk {
-        { fg: "#8fc13e" attr: "b" }
-      } else if $in < 6wk {
-        "#149b93"
-      } else if $in < 52wk {
-        "#1290bf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dd464c" attr: "b" }
+        } else if $in < 6hr {
+            "#dd464c"
+        } else if $in < 1day {
+            "#fdcc59"
+        } else if $in < 3day {
+            "#8fc13e"
+        } else if $in < 1wk {
+            { fg: "#8fc13e" attr: "b" }
+        } else if $in < 6wk {
+            "#149b93"
+        } else if $in < 52wk {
+            "#1290bf"
+        } else { "dark_gray" }
     }
     range: "#b9b5b8"
     float: "#b9b5b8"

--- a/themes/themes/horizon-dark.nu
+++ b/themes/themes/horizon-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#24a8b4" } else { "light_gray" } }
     int: "#cbced0"
     filesize: {|e|
-      if $e == 0b {
-        "#cbced0"
-      } else if $e < 1mb {
-        "#24a8b4"
-      } else {{ fg: "#df5273" }}
+        if $e == 0b {
+            "#cbced0"
+        } else if $e < 1mb {
+            "#24a8b4"
+        } else {{ fg: "#df5273" }}
     }
     duration: "#cbced0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e93c58" attr: "b" }
-      } else if $in < 6hr {
-        "#e93c58"
-      } else if $in < 1day {
-        "#efb993"
-      } else if $in < 3day {
-        "#efaf8e"
-      } else if $in < 1wk {
-        { fg: "#efaf8e" attr: "b" }
-      } else if $in < 6wk {
-        "#24a8b4"
-      } else if $in < 52wk {
-        "#df5273"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e93c58" attr: "b" }
+        } else if $in < 6hr {
+            "#e93c58"
+        } else if $in < 1day {
+            "#efb993"
+        } else if $in < 3day {
+            "#efaf8e"
+        } else if $in < 1wk {
+            { fg: "#efaf8e" attr: "b" }
+        } else if $in < 6wk {
+            "#24a8b4"
+        } else if $in < 52wk {
+            "#df5273"
+        } else { "dark_gray" }
     }
     range: "#cbced0"
     float: "#cbced0"

--- a/themes/themes/horizon-light.nu
+++ b/themes/themes/horizon-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#dc3318" } else { "light_gray" } }
     int: "#403c3d"
     filesize: {|e|
-      if $e == 0b {
-        "#403c3d"
-      } else if $e < 1mb {
-        "#dc3318"
-      } else {{ fg: "#da103f" }}
+        if $e == 0b {
+            "#403c3d"
+        } else if $e < 1mb {
+            "#dc3318"
+        } else {{ fg: "#da103f" }}
     }
     duration: "#403c3d"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f7939b" attr: "b" }
-      } else if $in < 6hr {
-        "#f7939b"
-      } else if $in < 1day {
-        "#fbe0d9"
-      } else if $in < 3day {
-        "#94e1b0"
-      } else if $in < 1wk {
-        { fg: "#94e1b0" attr: "b" }
-      } else if $in < 6wk {
-        "#dc3318"
-      } else if $in < 52wk {
-        "#da103f"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f7939b" attr: "b" }
+        } else if $in < 6hr {
+            "#f7939b"
+        } else if $in < 1day {
+            "#fbe0d9"
+        } else if $in < 3day {
+            "#94e1b0"
+        } else if $in < 1wk {
+            { fg: "#94e1b0" attr: "b" }
+        } else if $in < 6wk {
+            "#dc3318"
+        } else if $in < 52wk {
+            "#da103f"
+        } else { "dark_gray" }
     }
     range: "#403c3d"
     float: "#403c3d"

--- a/themes/themes/horizon-terminal-dark.nu
+++ b/themes/themes/horizon-terminal-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#59e1e3" } else { "light_gray" } }
     int: "#cbced0"
     filesize: {|e|
-      if $e == 0b {
-        "#cbced0"
-      } else if $e < 1mb {
-        "#59e1e3"
-      } else {{ fg: "#26bbd9" }}
+        if $e == 0b {
+            "#cbced0"
+        } else if $e < 1mb {
+            "#59e1e3"
+        } else {{ fg: "#26bbd9" }}
     }
     duration: "#cbced0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e95678" attr: "b" }
-      } else if $in < 6hr {
-        "#e95678"
-      } else if $in < 1day {
-        "#fac29a"
-      } else if $in < 3day {
-        "#29d398"
-      } else if $in < 1wk {
-        { fg: "#29d398" attr: "b" }
-      } else if $in < 6wk {
-        "#59e1e3"
-      } else if $in < 52wk {
-        "#26bbd9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e95678" attr: "b" }
+        } else if $in < 6hr {
+            "#e95678"
+        } else if $in < 1day {
+            "#fac29a"
+        } else if $in < 3day {
+            "#29d398"
+        } else if $in < 1wk {
+            { fg: "#29d398" attr: "b" }
+        } else if $in < 6wk {
+            "#59e1e3"
+        } else if $in < 52wk {
+            "#26bbd9"
+        } else { "dark_gray" }
     }
     range: "#cbced0"
     float: "#cbced0"

--- a/themes/themes/horizon-terminal-light.nu
+++ b/themes/themes/horizon-terminal-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#59e1e3" } else { "light_gray" } }
     int: "#403c3d"
     filesize: {|e|
-      if $e == 0b {
-        "#403c3d"
-      } else if $e < 1mb {
-        "#59e1e3"
-      } else {{ fg: "#26bbd9" }}
+        if $e == 0b {
+            "#403c3d"
+        } else if $e < 1mb {
+            "#59e1e3"
+        } else {{ fg: "#26bbd9" }}
     }
     duration: "#403c3d"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e95678" attr: "b" }
-      } else if $in < 6hr {
-        "#e95678"
-      } else if $in < 1day {
-        "#fadad1"
-      } else if $in < 3day {
-        "#29d398"
-      } else if $in < 1wk {
-        { fg: "#29d398" attr: "b" }
-      } else if $in < 6wk {
-        "#59e1e3"
-      } else if $in < 52wk {
-        "#26bbd9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e95678" attr: "b" }
+        } else if $in < 6hr {
+            "#e95678"
+        } else if $in < 1day {
+            "#fadad1"
+        } else if $in < 3day {
+            "#29d398"
+        } else if $in < 1wk {
+            { fg: "#29d398" attr: "b" }
+        } else if $in < 6wk {
+            "#59e1e3"
+        } else if $in < 52wk {
+            "#26bbd9"
+        } else { "dark_gray" }
     }
     range: "#403c3d"
     float: "#403c3d"

--- a/themes/themes/humanoid-dark.nu
+++ b/themes/themes/humanoid-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#0dd9d6" } else { "light_gray" } }
     int: "#f8f8f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f8f8f2"
-      } else if $e < 1mb {
-        "#0dd9d6"
-      } else {{ fg: "#00a6fb" }}
+        if $e == 0b {
+            "#f8f8f2"
+        } else if $e < 1mb {
+            "#0dd9d6"
+        } else {{ fg: "#00a6fb" }}
     }
     duration: "#f8f8f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f11235" attr: "b" }
-      } else if $in < 6hr {
-        "#f11235"
-      } else if $in < 1day {
-        "#ffb627"
-      } else if $in < 3day {
-        "#02d849"
-      } else if $in < 1wk {
-        { fg: "#02d849" attr: "b" }
-      } else if $in < 6wk {
-        "#0dd9d6"
-      } else if $in < 52wk {
-        "#00a6fb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f11235" attr: "b" }
+        } else if $in < 6hr {
+            "#f11235"
+        } else if $in < 1day {
+            "#ffb627"
+        } else if $in < 3day {
+            "#02d849"
+        } else if $in < 1wk {
+            { fg: "#02d849" attr: "b" }
+        } else if $in < 6wk {
+            "#0dd9d6"
+        } else if $in < 52wk {
+            "#00a6fb"
+        } else { "dark_gray" }
     }
     range: "#f8f8f2"
     float: "#f8f8f2"

--- a/themes/themes/humanoid-light.nu
+++ b/themes/themes/humanoid-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#008e8e" } else { "light_gray" } }
     int: "#232629"
     filesize: {|e|
-      if $e == 0b {
-        "#232629"
-      } else if $e < 1mb {
-        "#008e8e"
-      } else {{ fg: "#0082c9" }}
+        if $e == 0b {
+            "#232629"
+        } else if $e < 1mb {
+            "#008e8e"
+        } else {{ fg: "#0082c9" }}
     }
     duration: "#232629"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b0151a" attr: "b" }
-      } else if $in < 6hr {
-        "#b0151a"
-      } else if $in < 1day {
-        "#ffb627"
-      } else if $in < 3day {
-        "#388e3c"
-      } else if $in < 1wk {
-        { fg: "#388e3c" attr: "b" }
-      } else if $in < 6wk {
-        "#008e8e"
-      } else if $in < 52wk {
-        "#0082c9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b0151a" attr: "b" }
+        } else if $in < 6hr {
+            "#b0151a"
+        } else if $in < 1day {
+            "#ffb627"
+        } else if $in < 3day {
+            "#388e3c"
+        } else if $in < 1wk {
+            { fg: "#388e3c" attr: "b" }
+        } else if $in < 6wk {
+            "#008e8e"
+        } else if $in < 52wk {
+            "#0082c9"
+        } else { "dark_gray" }
     }
     range: "#232629"
     float: "#232629"

--- a/themes/themes/hurtado.nu
+++ b/themes/themes/hurtado.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#86eafe" } else { "light_gray" } }
     int: "#cbcccb"
     filesize: {|e|
-      if $e == 0b {
-        "#cbcccb"
-      } else if $e < 1mb {
-        "#86e9fe"
-      } else {{ fg: "#496487" }}
+        if $e == 0b {
+            "#cbcccb"
+        } else if $e < 1mb {
+            "#86e9fe"
+        } else {{ fg: "#496487" }}
     }
     duration: "#cbcccb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff1b00" attr: "b" }
-      } else if $in < 6hr {
-        "#ff1b00"
-      } else if $in < 1day {
-        "#fbe74a"
-      } else if $in < 3day {
-        "#a5e055"
-      } else if $in < 1wk {
-        { fg: "#a5e055" attr: "b" }
-      } else if $in < 6wk {
-        "#86e9fe"
-      } else if $in < 52wk {
-        "#496487"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff1b00" attr: "b" }
+        } else if $in < 6hr {
+            "#ff1b00"
+        } else if $in < 1day {
+            "#fbe74a"
+        } else if $in < 3day {
+            "#a5e055"
+        } else if $in < 1wk {
+            { fg: "#a5e055" attr: "b" }
+        } else if $in < 6wk {
+            "#86e9fe"
+        } else if $in < 52wk {
+            "#496487"
+        } else { "dark_gray" }
     }
     range: "#cbcccb"
     float: "#cbcccb"

--- a/themes/themes/hybrid.nu
+++ b/themes/themes/hybrid.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8abeb7" } else { "light_gray" } }
     int: "#969896"
     filesize: {|e|
-      if $e == 0b {
-        "#969896"
-      } else if $e < 1mb {
-        "#5e8d87"
-      } else {{ fg: "#5f819d" }}
+        if $e == 0b {
+            "#969896"
+        } else if $e < 1mb {
+            "#5e8d87"
+        } else {{ fg: "#5f819d" }}
     }
     duration: "#969896"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a54242" attr: "b" }
-      } else if $in < 6hr {
-        "#a54242"
-      } else if $in < 1day {
-        "#de935f"
-      } else if $in < 3day {
-        "#8c9440"
-      } else if $in < 1wk {
-        { fg: "#8c9440" attr: "b" }
-      } else if $in < 6wk {
-        "#5e8d87"
-      } else if $in < 52wk {
-        "#5f819d"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a54242" attr: "b" }
+        } else if $in < 6hr {
+            "#a54242"
+        } else if $in < 1day {
+            "#de935f"
+        } else if $in < 3day {
+            "#8c9440"
+        } else if $in < 1wk {
+            { fg: "#8c9440" attr: "b" }
+        } else if $in < 6wk {
+            "#5e8d87"
+        } else if $in < 52wk {
+            "#5f819d"
+        } else { "dark_gray" }
     }
     range: "#969896"
     float: "#969896"

--- a/themes/themes/ia-dark.nu
+++ b/themes/themes/ia-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7c9cae" } else { "light_gray" } }
     int: "#cccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#cccccc"
-      } else if $e < 1mb {
-        "#7c9cae"
-      } else {{ fg: "#8eccdd" }}
+        if $e == 0b {
+            "#cccccc"
+        } else if $e < 1mb {
+            "#7c9cae"
+        } else {{ fg: "#8eccdd" }}
     }
     duration: "#cccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d88568" attr: "b" }
-      } else if $in < 6hr {
-        "#d88568"
-      } else if $in < 1day {
-        "#b99353"
-      } else if $in < 3day {
-        "#83a471"
-      } else if $in < 1wk {
-        { fg: "#83a471" attr: "b" }
-      } else if $in < 6wk {
-        "#7c9cae"
-      } else if $in < 52wk {
-        "#8eccdd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d88568" attr: "b" }
+        } else if $in < 6hr {
+            "#d88568"
+        } else if $in < 1day {
+            "#b99353"
+        } else if $in < 3day {
+            "#83a471"
+        } else if $in < 1wk {
+            { fg: "#83a471" attr: "b" }
+        } else if $in < 6wk {
+            "#7c9cae"
+        } else if $in < 52wk {
+            "#8eccdd"
+        } else { "dark_gray" }
     }
     range: "#cccccc"
     float: "#cccccc"

--- a/themes/themes/ia-light.nu
+++ b/themes/themes/ia-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2d6bb1" } else { "light_gray" } }
     int: "#181818"
     filesize: {|e|
-      if $e == 0b {
-        "#181818"
-      } else if $e < 1mb {
-        "#2d6bb1"
-      } else {{ fg: "#48bac2" }}
+        if $e == 0b {
+            "#181818"
+        } else if $e < 1mb {
+            "#2d6bb1"
+        } else {{ fg: "#48bac2" }}
     }
     duration: "#181818"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9c5a02" attr: "b" }
-      } else if $in < 6hr {
-        "#9c5a02"
-      } else if $in < 1day {
-        "#c48218"
-      } else if $in < 3day {
-        "#38781c"
-      } else if $in < 1wk {
-        { fg: "#38781c" attr: "b" }
-      } else if $in < 6wk {
-        "#2d6bb1"
-      } else if $in < 52wk {
-        "#48bac2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9c5a02" attr: "b" }
+        } else if $in < 6hr {
+            "#9c5a02"
+        } else if $in < 1day {
+            "#c48218"
+        } else if $in < 3day {
+            "#38781c"
+        } else if $in < 1wk {
+            { fg: "#38781c" attr: "b" }
+        } else if $in < 6wk {
+            "#2d6bb1"
+        } else if $in < 52wk {
+            "#48bac2"
+        } else { "dark_gray" }
     }
     range: "#181818"
     float: "#181818"

--- a/themes/themes/ibm3270.nu
+++ b/themes/themes/ibm3270.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#9ce2e2" } else { "light_gray" } }
     int: "#a5a5a5"
     filesize: {|e|
-      if $e == 0b {
-        "#a5a5a5"
-      } else if $e < 1mb {
-        "#54e4e4"
-      } else {{ fg: "#7890f0" }}
+        if $e == 0b {
+            "#a5a5a5"
+        } else if $e < 1mb {
+            "#54e4e4"
+        } else {{ fg: "#7890f0" }}
     }
     duration: "#a5a5a5"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f01818" attr: "b" }
-      } else if $in < 6hr {
-        "#f01818"
-      } else if $in < 1day {
-        "#f0d824"
-      } else if $in < 3day {
-        "#24d830"
-      } else if $in < 1wk {
-        { fg: "#24d830" attr: "b" }
-      } else if $in < 6wk {
-        "#54e4e4"
-      } else if $in < 52wk {
-        "#7890f0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f01818" attr: "b" }
+        } else if $in < 6hr {
+            "#f01818"
+        } else if $in < 1day {
+            "#f0d824"
+        } else if $in < 3day {
+            "#24d830"
+        } else if $in < 1wk {
+            { fg: "#24d830" attr: "b" }
+        } else if $in < 6wk {
+            "#54e4e4"
+        } else if $in < 52wk {
+            "#7890f0"
+        } else { "dark_gray" }
     }
     range: "#a5a5a5"
     float: "#a5a5a5"

--- a/themes/themes/ic-green-ppl.nu
+++ b/themes/themes/ic-green-ppl.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#22ff71" } else { "light_gray" } }
     int: "#e0ffef"
     filesize: {|e|
-      if $e == 0b {
-        "#e0ffef"
-      } else if $e < 1mb {
-        "#2cb868"
-      } else {{ fg: "#149b45" }}
+        if $e == 0b {
+            "#e0ffef"
+        } else if $e < 1mb {
+            "#2cb868"
+        } else {{ fg: "#149b45" }}
     }
     duration: "#e0ffef"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb002a" attr: "b" }
-      } else if $in < 6hr {
-        "#fb002a"
-      } else if $in < 1day {
-        "#659b25"
-      } else if $in < 3day {
-        "#339c24"
-      } else if $in < 1wk {
-        { fg: "#339c24" attr: "b" }
-      } else if $in < 6wk {
-        "#2cb868"
-      } else if $in < 52wk {
-        "#149b45"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb002a" attr: "b" }
+        } else if $in < 6hr {
+            "#fb002a"
+        } else if $in < 1day {
+            "#659b25"
+        } else if $in < 3day {
+            "#339c24"
+        } else if $in < 1wk {
+            { fg: "#339c24" attr: "b" }
+        } else if $in < 6wk {
+            "#2cb868"
+        } else if $in < 52wk {
+            "#149b45"
+        } else { "dark_gray" }
     }
     range: "#e0ffef"
     float: "#e0ffef"

--- a/themes/themes/ic-orange-ppl.nu
+++ b/themes/themes/ic-orange-ppl.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c69752" } else { "light_gray" } }
     int: "#ffc88a"
     filesize: {|e|
-      if $e == 0b {
-        "#ffc88a"
-      } else if $e < 1mb {
-        "#f79500"
-      } else {{ fg: "#bd6d00" }}
+        if $e == 0b {
+            "#ffc88a"
+        } else if $e < 1mb {
+            "#f79500"
+        } else {{ fg: "#bd6d00" }}
     }
     duration: "#ffc88a"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c13900" attr: "b" }
-      } else if $in < 6hr {
-        "#c13900"
-      } else if $in < 1day {
-        "#caaf00"
-      } else if $in < 3day {
-        "#a4a900"
-      } else if $in < 1wk {
-        { fg: "#a4a900" attr: "b" }
-      } else if $in < 6wk {
-        "#f79500"
-      } else if $in < 52wk {
-        "#bd6d00"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c13900" attr: "b" }
+        } else if $in < 6hr {
+            "#c13900"
+        } else if $in < 1day {
+            "#caaf00"
+        } else if $in < 3day {
+            "#a4a900"
+        } else if $in < 1wk {
+            { fg: "#a4a900" attr: "b" }
+        } else if $in < 6wk {
+            "#f79500"
+        } else if $in < 52wk {
+            "#bd6d00"
+        } else { "dark_gray" }
     }
     range: "#ffc88a"
     float: "#ffc88a"

--- a/themes/themes/iceberg-light.nu
+++ b/themes/themes/iceberg-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#327698" } else { "light_gray" } }
     int: "#33374c"
     filesize: {|e|
-      if $e == 0b {
-        "#33374c"
-      } else if $e < 1mb {
-        "#3f83a6"
-      } else {{ fg: "#2d539e" }}
+        if $e == 0b {
+            "#33374c"
+        } else if $e < 1mb {
+            "#3f83a6"
+        } else {{ fg: "#2d539e" }}
     }
     duration: "#33374c"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc517a" attr: "b" }
-      } else if $in < 6hr {
-        "#cc517a"
-      } else if $in < 1day {
-        "#c57339"
-      } else if $in < 3day {
-        "#668e3d"
-      } else if $in < 1wk {
-        { fg: "#668e3d" attr: "b" }
-      } else if $in < 6wk {
-        "#3f83a6"
-      } else if $in < 52wk {
-        "#2d539e"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc517a" attr: "b" }
+        } else if $in < 6hr {
+            "#cc517a"
+        } else if $in < 1day {
+            "#c57339"
+        } else if $in < 3day {
+            "#668e3d"
+        } else if $in < 1wk {
+            { fg: "#668e3d" attr: "b" }
+        } else if $in < 6wk {
+            "#3f83a6"
+        } else if $in < 52wk {
+            "#2d539e"
+        } else { "dark_gray" }
     }
     range: "#33374c"
     float: "#33374c"

--- a/themes/themes/icy.nu
+++ b/themes/themes/icy.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#26c6da" } else { "light_gray" } }
     int: "#095b67"
     filesize: {|e|
-      if $e == 0b {
-        "#095b67"
-      } else if $e < 1mb {
-        "#26c6da"
-      } else {{ fg: "#00bcd4" }}
+        if $e == 0b {
+            "#095b67"
+        } else if $e < 1mb {
+            "#26c6da"
+        } else {{ fg: "#00bcd4" }}
     }
     duration: "#095b67"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#16c1d9" attr: "b" }
-      } else if $in < 6hr {
-        "#16c1d9"
-      } else if $in < 1day {
-        "#80deea"
-      } else if $in < 3day {
-        "#4dd0e1"
-      } else if $in < 1wk {
-        { fg: "#4dd0e1" attr: "b" }
-      } else if $in < 6wk {
-        "#26c6da"
-      } else if $in < 52wk {
-        "#00bcd4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#16c1d9" attr: "b" }
+        } else if $in < 6hr {
+            "#16c1d9"
+        } else if $in < 1day {
+            "#80deea"
+        } else if $in < 3day {
+            "#4dd0e1"
+        } else if $in < 1wk {
+            { fg: "#4dd0e1" attr: "b" }
+        } else if $in < 6wk {
+            "#26c6da"
+        } else if $in < 52wk {
+            "#00bcd4"
+        } else { "dark_gray" }
     }
     range: "#095b67"
     float: "#095b67"

--- a/themes/themes/idle-toes.nu
+++ b/themes/themes/idle-toes.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#dcf4ff" } else { "light_gray" } }
     int: "#eeeeec"
     filesize: {|e|
-      if $e == 0b {
-        "#eeeeec"
-      } else if $e < 1mb {
-        "#bed6ff"
-      } else {{ fg: "#4099ff" }}
+        if $e == 0b {
+            "#eeeeec"
+        } else if $e < 1mb {
+            "#bed6ff"
+        } else {{ fg: "#4099ff" }}
     }
     duration: "#eeeeec"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d25252" attr: "b" }
-      } else if $in < 6hr {
-        "#d25252"
-      } else if $in < 1day {
-        "#ffc66d"
-      } else if $in < 3day {
-        "#7fe173"
-      } else if $in < 1wk {
-        { fg: "#7fe173" attr: "b" }
-      } else if $in < 6wk {
-        "#bed6ff"
-      } else if $in < 52wk {
-        "#4099ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d25252" attr: "b" }
+        } else if $in < 6hr {
+            "#d25252"
+        } else if $in < 1day {
+            "#ffc66d"
+        } else if $in < 3day {
+            "#7fe173"
+        } else if $in < 1wk {
+            { fg: "#7fe173" attr: "b" }
+        } else if $in < 6wk {
+            "#bed6ff"
+        } else if $in < 52wk {
+            "#4099ff"
+        } else { "dark_gray" }
     }
     range: "#eeeeec"
     float: "#eeeeec"

--- a/themes/themes/idm_3b.nu
+++ b/themes/themes/idm_3b.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#caa0f0" } else { "light_gray" } }
     int: "#606060"
     filesize: {|e|
-      if $e == 0b {
-        "#606060"
-      } else if $e < 1mb {
-        "#a070e0"
-      } else {{ fg: "#408aca" }}
+        if $e == 0b {
+            "#606060"
+        } else if $e < 1mb {
+            "#a070e0"
+        } else {{ fg: "#408aca" }}
     }
     duration: "#606060"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b04060" attr: "b" }
-      } else if $in < 6hr {
-        "#b04060"
-      } else if $in < 1day {
-        "#ffb060"
-      } else if $in < 3day {
-        "#70d0a0"
-      } else if $in < 1wk {
-        { fg: "#70d0a0" attr: "b" }
-      } else if $in < 6wk {
-        "#a070e0"
-      } else if $in < 52wk {
-        "#408aca"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b04060" attr: "b" }
+        } else if $in < 6hr {
+            "#b04060"
+        } else if $in < 1day {
+            "#ffb060"
+        } else if $in < 3day {
+            "#70d0a0"
+        } else if $in < 1wk {
+            { fg: "#70d0a0" attr: "b" }
+        } else if $in < 6wk {
+            "#a070e0"
+        } else if $in < 52wk {
+            "#408aca"
+        } else { "dark_gray" }
     }
     range: "#606060"
     float: "#606060"

--- a/themes/themes/ir-black.nu
+++ b/themes/themes/ir-black.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c6c5fe" } else { "light_gray" } }
     int: "#b5b3aa"
     filesize: {|e|
-      if $e == 0b {
-        "#b5b3aa"
-      } else if $e < 1mb {
-        "#c6c5fe"
-      } else {{ fg: "#96cbfe" }}
+        if $e == 0b {
+            "#b5b3aa"
+        } else if $e < 1mb {
+            "#c6c5fe"
+        } else {{ fg: "#96cbfe" }}
     }
     duration: "#b5b3aa"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff6c60" attr: "b" }
-      } else if $in < 6hr {
-        "#ff6c60"
-      } else if $in < 1day {
-        "#ffffb6"
-      } else if $in < 3day {
-        "#a8ff60"
-      } else if $in < 1wk {
-        { fg: "#a8ff60" attr: "b" }
-      } else if $in < 6wk {
-        "#c6c5fe"
-      } else if $in < 52wk {
-        "#96cbfe"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff6c60" attr: "b" }
+        } else if $in < 6hr {
+            "#ff6c60"
+        } else if $in < 1day {
+            "#ffffb6"
+        } else if $in < 3day {
+            "#a8ff60"
+        } else if $in < 1wk {
+            { fg: "#a8ff60" attr: "b" }
+        } else if $in < 6wk {
+            "#c6c5fe"
+        } else if $in < 52wk {
+            "#96cbfe"
+        } else { "dark_gray" }
     }
     range: "#b5b3aa"
     float: "#b5b3aa"

--- a/themes/themes/irblack.nu
+++ b/themes/themes/irblack.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#c6c5fe" } else { "light_gray" } }
     int: "#b5b3aa"
     filesize: {|e|
-      if $e == 0b {
-        "#b5b3aa"
-      } else if $e < 1mb {
-        "#c6c5fe"
-      } else {{ fg: "#96cbfe" }}
+        if $e == 0b {
+            "#b5b3aa"
+        } else if $e < 1mb {
+            "#c6c5fe"
+        } else {{ fg: "#96cbfe" }}
     }
     duration: "#b5b3aa"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff6c60" attr: "b" }
-      } else if $in < 6hr {
-        "#ff6c60"
-      } else if $in < 1day {
-        "#ffffb6"
-      } else if $in < 3day {
-        "#a8ff60"
-      } else if $in < 1wk {
-        { fg: "#a8ff60" attr: "b" }
-      } else if $in < 6wk {
-        "#c6c5fe"
-      } else if $in < 52wk {
-        "#96cbfe"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff6c60" attr: "b" }
+        } else if $in < 6hr {
+            "#ff6c60"
+        } else if $in < 1day {
+            "#ffffb6"
+        } else if $in < 3day {
+            "#a8ff60"
+        } else if $in < 1wk {
+            { fg: "#a8ff60" attr: "b" }
+        } else if $in < 6wk {
+            "#c6c5fe"
+        } else if $in < 52wk {
+            "#96cbfe"
+        } else { "dark_gray" }
     }
     range: "#b5b3aa"
     float: "#b5b3aa"

--- a/themes/themes/isotope.nu
+++ b/themes/themes/isotope.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00ffff" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#00ffff"
-      } else {{ fg: "#0066ff" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#00ffff"
+        } else {{ fg: "#0066ff" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0000" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0000"
-      } else if $in < 1day {
-        "#ff0099"
-      } else if $in < 3day {
-        "#33ff00"
-      } else if $in < 1wk {
-        { fg: "#33ff00" attr: "b" }
-      } else if $in < 6wk {
-        "#00ffff"
-      } else if $in < 52wk {
-        "#0066ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0000" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0000"
+        } else if $in < 1day {
+            "#ff0099"
+        } else if $in < 3day {
+            "#33ff00"
+        } else if $in < 1wk {
+            { fg: "#33ff00" attr: "b" }
+        } else if $in < 6wk {
+            "#00ffff"
+        } else if $in < 52wk {
+            "#0066ff"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/jackie-brown.nu
+++ b/themes/themes/jackie-brown.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00e5e5" } else { "light_gray" } }
     int: "#bfbfbf"
     filesize: {|e|
-      if $e == 0b {
-        "#bfbfbf"
-      } else if $e < 1mb {
-        "#00acee"
-      } else {{ fg: "#246eb2" }}
+        if $e == 0b {
+            "#bfbfbf"
+        } else if $e < 1mb {
+            "#00acee"
+        } else {{ fg: "#246eb2" }}
     }
     duration: "#bfbfbf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ef5734" attr: "b" }
-      } else if $in < 6hr {
-        "#ef5734"
-      } else if $in < 1day {
-        "#bebf00"
-      } else if $in < 3day {
-        "#2baf2b"
-      } else if $in < 1wk {
-        { fg: "#2baf2b" attr: "b" }
-      } else if $in < 6wk {
-        "#00acee"
-      } else if $in < 52wk {
-        "#246eb2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ef5734" attr: "b" }
+        } else if $in < 6hr {
+            "#ef5734"
+        } else if $in < 1day {
+            "#bebf00"
+        } else if $in < 3day {
+            "#2baf2b"
+        } else if $in < 1wk {
+            { fg: "#2baf2b" attr: "b" }
+        } else if $in < 6wk {
+            "#00acee"
+        } else if $in < 52wk {
+            "#246eb2"
+        } else { "dark_gray" }
     }
     range: "#bfbfbf"
     float: "#bfbfbf"

--- a/themes/themes/japanesque.nu
+++ b/themes/themes/japanesque.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#76bbca" } else { "light_gray" } }
     int: "#fafaf6"
     filesize: {|e|
-      if $e == 0b {
-        "#fafaf6"
-      } else if $e < 1mb {
-        "#389aad"
-      } else {{ fg: "#4c9ad4" }}
+        if $e == 0b {
+            "#fafaf6"
+        } else if $e < 1mb {
+            "#389aad"
+        } else {{ fg: "#4c9ad4" }}
     }
     duration: "#fafaf6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cf3f61" attr: "b" }
-      } else if $in < 6hr {
-        "#cf3f61"
-      } else if $in < 1day {
-        "#e9b32a"
-      } else if $in < 3day {
-        "#7bb75b"
-      } else if $in < 1wk {
-        { fg: "#7bb75b" attr: "b" }
-      } else if $in < 6wk {
-        "#389aad"
-      } else if $in < 52wk {
-        "#4c9ad4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cf3f61" attr: "b" }
+        } else if $in < 6hr {
+            "#cf3f61"
+        } else if $in < 1day {
+            "#e9b32a"
+        } else if $in < 3day {
+            "#7bb75b"
+        } else if $in < 1wk {
+            { fg: "#7bb75b" attr: "b" }
+        } else if $in < 6wk {
+            "#389aad"
+        } else if $in < 52wk {
+            "#4c9ad4"
+        } else { "dark_gray" }
     }
     range: "#fafaf6"
     float: "#fafaf6"

--- a/themes/themes/jellybeans.nu
+++ b/themes/themes/jellybeans.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1ab2a8" } else { "light_gray" } }
     int: "#dedede"
     filesize: {|e|
-      if $e == 0b {
-        "#dedede"
-      } else if $e < 1mb {
-        "#00988e"
-      } else {{ fg: "#97bedc" }}
+        if $e == 0b {
+            "#dedede"
+        } else if $e < 1mb {
+            "#00988e"
+        } else {{ fg: "#97bedc" }}
     }
     duration: "#dedede"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e27373" attr: "b" }
-      } else if $in < 6hr {
-        "#e27373"
-      } else if $in < 1day {
-        "#ffba7b"
-      } else if $in < 3day {
-        "#94b979"
-      } else if $in < 1wk {
-        { fg: "#94b979" attr: "b" }
-      } else if $in < 6wk {
-        "#00988e"
-      } else if $in < 52wk {
-        "#97bedc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e27373" attr: "b" }
+        } else if $in < 6hr {
+            "#e27373"
+        } else if $in < 1day {
+            "#ffba7b"
+        } else if $in < 3day {
+            "#94b979"
+        } else if $in < 1wk {
+            { fg: "#94b979" attr: "b" }
+        } else if $in < 6wk {
+            "#00988e"
+        } else if $in < 52wk {
+            "#97bedc"
+        } else { "dark_gray" }
     }
     range: "#dedede"
     float: "#dedede"

--- a/themes/themes/jet-brains-darcula.nu
+++ b/themes/themes/jet-brains-darcula.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#60d3d1" } else { "light_gray" } }
     int: "#adadad"
     filesize: {|e|
-      if $e == 0b {
-        "#adadad"
-      } else if $e < 1mb {
-        "#33c2c1"
-      } else {{ fg: "#4581eb" }}
+        if $e == 0b {
+            "#adadad"
+        } else if $e < 1mb {
+            "#33c2c1"
+        } else {{ fg: "#4581eb" }}
     }
     duration: "#adadad"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fa5355" attr: "b" }
-      } else if $in < 6hr {
-        "#fa5355"
-      } else if $in < 1day {
-        "#c2c300"
-      } else if $in < 3day {
-        "#126e00"
-      } else if $in < 1wk {
-        { fg: "#126e00" attr: "b" }
-      } else if $in < 6wk {
-        "#33c2c1"
-      } else if $in < 52wk {
-        "#4581eb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fa5355" attr: "b" }
+        } else if $in < 6hr {
+            "#fa5355"
+        } else if $in < 1day {
+            "#c2c300"
+        } else if $in < 3day {
+            "#126e00"
+        } else if $in < 1wk {
+            { fg: "#126e00" attr: "b" }
+        } else if $in < 6wk {
+            "#33c2c1"
+        } else if $in < 52wk {
+            "#4581eb"
+        } else { "dark_gray" }
     }
     range: "#adadad"
     float: "#adadad"

--- a/themes/themes/jup.nu
+++ b/themes/themes/jup.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#74ffb9" } else { "light_gray" } }
     int: "#f2f2f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f2f2f2"
-      } else if $e < 1mb {
-        "#00dd6f"
-      } else {{ fg: "#006fdd" }}
+        if $e == 0b {
+            "#f2f2f2"
+        } else if $e < 1mb {
+            "#00dd6f"
+        } else {{ fg: "#006fdd" }}
     }
     duration: "#f2f2f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dd006f" attr: "b" }
-      } else if $in < 6hr {
-        "#dd006f"
-      } else if $in < 1day {
-        "#dd6f00"
-      } else if $in < 3day {
-        "#6fdd00"
-      } else if $in < 1wk {
-        { fg: "#6fdd00" attr: "b" }
-      } else if $in < 6wk {
-        "#00dd6f"
-      } else if $in < 52wk {
-        "#006fdd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dd006f" attr: "b" }
+        } else if $in < 6hr {
+            "#dd006f"
+        } else if $in < 1day {
+            "#dd6f00"
+        } else if $in < 3day {
+            "#6fdd00"
+        } else if $in < 1wk {
+            { fg: "#6fdd00" attr: "b" }
+        } else if $in < 6wk {
+            "#00dd6f"
+        } else if $in < 52wk {
+            "#006fdd"
+        } else { "dark_gray" }
     }
     range: "#f2f2f2"
     float: "#f2f2f2"

--- a/themes/themes/kibble.nu
+++ b/themes/themes/kibble.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#68f2e0" } else { "light_gray" } }
     int: "#e2d1e3"
     filesize: {|e|
-      if $e == 0b {
-        "#e2d1e3"
-      } else if $e < 1mb {
-        "#0798ab"
-      } else {{ fg: "#3449d1" }}
+        if $e == 0b {
+            "#e2d1e3"
+        } else if $e < 1mb {
+            "#0798ab"
+        } else {{ fg: "#3449d1" }}
     }
     duration: "#e2d1e3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c70031" attr: "b" }
-      } else if $in < 6hr {
-        "#c70031"
-      } else if $in < 1day {
-        "#d8e30e"
-      } else if $in < 3day {
-        "#29cf13"
-      } else if $in < 1wk {
-        { fg: "#29cf13" attr: "b" }
-      } else if $in < 6wk {
-        "#0798ab"
-      } else if $in < 52wk {
-        "#3449d1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c70031" attr: "b" }
+        } else if $in < 6hr {
+            "#c70031"
+        } else if $in < 1day {
+            "#d8e30e"
+        } else if $in < 3day {
+            "#29cf13"
+        } else if $in < 1wk {
+            { fg: "#29cf13" attr: "b" }
+        } else if $in < 6wk {
+            "#0798ab"
+        } else if $in < 52wk {
+            "#3449d1"
+        } else { "dark_gray" }
     }
     range: "#e2d1e3"
     float: "#e2d1e3"

--- a/themes/themes/kimber.nu
+++ b/themes/themes/kimber.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#78b4b4" } else { "light_gray" } }
     int: "#dedee7"
     filesize: {|e|
-      if $e == 0b {
-        "#dedee7"
-      } else if $e < 1mb {
-        "#78b4b4"
-      } else {{ fg: "#537c9c" }}
+        if $e == 0b {
+            "#dedee7"
+        } else if $e < 1mb {
+            "#78b4b4"
+        } else {{ fg: "#537c9c" }}
     }
     duration: "#dedee7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c88c8c" attr: "b" }
-      } else if $in < 6hr {
-        "#c88c8c"
-      } else if $in < 1day {
-        "#d8b56d"
-      } else if $in < 3day {
-        "#99c899"
-      } else if $in < 1wk {
-        { fg: "#99c899" attr: "b" }
-      } else if $in < 6wk {
-        "#78b4b4"
-      } else if $in < 52wk {
-        "#537c9c"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c88c8c" attr: "b" }
+        } else if $in < 6hr {
+            "#c88c8c"
+        } else if $in < 1day {
+            "#d8b56d"
+        } else if $in < 3day {
+            "#99c899"
+        } else if $in < 1wk {
+            { fg: "#99c899" attr: "b" }
+        } else if $in < 6wk {
+            "#78b4b4"
+        } else if $in < 52wk {
+            "#537c9c"
+        } else { "dark_gray" }
     }
     range: "#dedee7"
     float: "#dedee7"

--- a/themes/themes/later-this-evening.nu
+++ b/themes/themes/later-this-evening.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5fc0ae" } else { "light_gray" } }
     int: "#3c3d3d"
     filesize: {|e|
-      if $e == 0b {
-        "#3c3d3d"
-      } else if $e < 1mb {
-        "#91bfb7"
-      } else {{ fg: "#a0bad6" }}
+        if $e == 0b {
+            "#3c3d3d"
+        } else if $e < 1mb {
+            "#91bfb7"
+        } else {{ fg: "#a0bad6" }}
     }
     duration: "#3c3d3d"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d45a60" attr: "b" }
-      } else if $in < 6hr {
-        "#d45a60"
-      } else if $in < 1day {
-        "#e5d289"
-      } else if $in < 3day {
-        "#afba67"
-      } else if $in < 1wk {
-        { fg: "#afba67" attr: "b" }
-      } else if $in < 6wk {
-        "#91bfb7"
-      } else if $in < 52wk {
-        "#a0bad6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d45a60" attr: "b" }
+        } else if $in < 6hr {
+            "#d45a60"
+        } else if $in < 1day {
+            "#e5d289"
+        } else if $in < 3day {
+            "#afba67"
+        } else if $in < 1wk {
+            { fg: "#afba67" attr: "b" }
+        } else if $in < 6wk {
+            "#91bfb7"
+        } else if $in < 52wk {
+            "#a0bad6"
+        } else { "dark_gray" }
     }
     range: "#3c3d3d"
     float: "#3c3d3d"

--- a/themes/themes/lavandula.nu
+++ b/themes/themes/lavandula.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#9ad4e0" } else { "light_gray" } }
     int: "#736e7d"
     filesize: {|e|
-      if $e == 0b {
-        "#736e7d"
-      } else if $e < 1mb {
-        "#58777f"
-      } else {{ fg: "#4f4a7f" }}
+        if $e == 0b {
+            "#736e7d"
+        } else if $e < 1mb {
+            "#58777f"
+        } else {{ fg: "#4f4a7f" }}
     }
     duration: "#736e7d"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#7d1625" attr: "b" }
-      } else if $in < 6hr {
-        "#7d1625"
-      } else if $in < 1day {
-        "#7f6f49"
-      } else if $in < 3day {
-        "#337e6f"
-      } else if $in < 1wk {
-        { fg: "#337e6f" attr: "b" }
-      } else if $in < 6wk {
-        "#58777f"
-      } else if $in < 52wk {
-        "#4f4a7f"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#7d1625" attr: "b" }
+        } else if $in < 6hr {
+            "#7d1625"
+        } else if $in < 1day {
+            "#7f6f49"
+        } else if $in < 3day {
+            "#337e6f"
+        } else if $in < 1wk {
+            { fg: "#337e6f" attr: "b" }
+        } else if $in < 6wk {
+            "#58777f"
+        } else if $in < 52wk {
+            "#4f4a7f"
+        } else { "dark_gray" }
     }
     range: "#736e7d"
     float: "#736e7d"

--- a/themes/themes/liquid-carbon-transparent.nu
+++ b/themes/themes/liquid-carbon-transparent.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7ac4cc" } else { "light_gray" } }
     int: "#bccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#bccccc"
-      } else if $e < 1mb {
-        "#7ac4cc"
-      } else {{ fg: "#0099cc" }}
+        if $e == 0b {
+            "#bccccc"
+        } else if $e < 1mb {
+            "#7ac4cc"
+        } else {{ fg: "#0099cc" }}
     }
     duration: "#bccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff3030" attr: "b" }
-      } else if $in < 6hr {
-        "#ff3030"
-      } else if $in < 1day {
-        "#ccac00"
-      } else if $in < 3day {
-        "#559a70"
-      } else if $in < 1wk {
-        { fg: "#559a70" attr: "b" }
-      } else if $in < 6wk {
-        "#7ac4cc"
-      } else if $in < 52wk {
-        "#0099cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff3030" attr: "b" }
+        } else if $in < 6hr {
+            "#ff3030"
+        } else if $in < 1day {
+            "#ccac00"
+        } else if $in < 3day {
+            "#559a70"
+        } else if $in < 1wk {
+            { fg: "#559a70" attr: "b" }
+        } else if $in < 6wk {
+            "#7ac4cc"
+        } else if $in < 52wk {
+            "#0099cc"
+        } else { "dark_gray" }
     }
     range: "#bccccc"
     float: "#bccccc"

--- a/themes/themes/liquid-carbon.nu
+++ b/themes/themes/liquid-carbon.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7ac4cc" } else { "light_gray" } }
     int: "#bccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#bccccc"
-      } else if $e < 1mb {
-        "#7ac4cc"
-      } else {{ fg: "#0099cc" }}
+        if $e == 0b {
+            "#bccccc"
+        } else if $e < 1mb {
+            "#7ac4cc"
+        } else {{ fg: "#0099cc" }}
     }
     duration: "#bccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff3030" attr: "b" }
-      } else if $in < 6hr {
-        "#ff3030"
-      } else if $in < 1day {
-        "#ccac00"
-      } else if $in < 3day {
-        "#559a70"
-      } else if $in < 1wk {
-        { fg: "#559a70" attr: "b" }
-      } else if $in < 6wk {
-        "#7ac4cc"
-      } else if $in < 52wk {
-        "#0099cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff3030" attr: "b" }
+        } else if $in < 6hr {
+            "#ff3030"
+        } else if $in < 1day {
+            "#ccac00"
+        } else if $in < 3day {
+            "#559a70"
+        } else if $in < 1wk {
+            { fg: "#559a70" attr: "b" }
+        } else if $in < 6wk {
+            "#7ac4cc"
+        } else if $in < 52wk {
+            "#0099cc"
+        } else { "dark_gray" }
     }
     range: "#bccccc"
     float: "#bccccc"

--- a/themes/themes/london-tube.nu
+++ b/themes/themes/london-tube.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#85cebc" } else { "light_gray" } }
     int: "#d9d8d8"
     filesize: {|e|
-      if $e == 0b {
-        "#d9d8d8"
-      } else if $e < 1mb {
-        "#85cebc"
-      } else {{ fg: "#009ddc" }}
+        if $e == 0b {
+            "#d9d8d8"
+        } else if $e < 1mb {
+            "#85cebc"
+        } else {{ fg: "#009ddc" }}
     }
     duration: "#d9d8d8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ee2e24" attr: "b" }
-      } else if $in < 6hr {
-        "#ee2e24"
-      } else if $in < 1day {
-        "#ffd204"
-      } else if $in < 3day {
-        "#00853e"
-      } else if $in < 1wk {
-        { fg: "#00853e" attr: "b" }
-      } else if $in < 6wk {
-        "#85cebc"
-      } else if $in < 52wk {
-        "#009ddc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ee2e24" attr: "b" }
+        } else if $in < 6hr {
+            "#ee2e24"
+        } else if $in < 1day {
+            "#ffd204"
+        } else if $in < 3day {
+            "#00853e"
+        } else if $in < 1wk {
+            { fg: "#00853e" attr: "b" }
+        } else if $in < 6wk {
+            "#85cebc"
+        } else if $in < 52wk {
+            "#009ddc"
+        } else { "dark_gray" }
     }
     range: "#d9d8d8"
     float: "#d9d8d8"

--- a/themes/themes/macintosh.nu
+++ b/themes/themes/macintosh.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#02abea" } else { "light_gray" } }
     int: "#c0c0c0"
     filesize: {|e|
-      if $e == 0b {
-        "#c0c0c0"
-      } else if $e < 1mb {
-        "#02abea"
-      } else {{ fg: "#0000d3" }}
+        if $e == 0b {
+            "#c0c0c0"
+        } else if $e < 1mb {
+            "#02abea"
+        } else {{ fg: "#0000d3" }}
     }
     duration: "#c0c0c0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dd0907" attr: "b" }
-      } else if $in < 6hr {
-        "#dd0907"
-      } else if $in < 1day {
-        "#fbf305"
-      } else if $in < 3day {
-        "#1fb714"
-      } else if $in < 1wk {
-        { fg: "#1fb714" attr: "b" }
-      } else if $in < 6wk {
-        "#02abea"
-      } else if $in < 52wk {
-        "#0000d3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dd0907" attr: "b" }
+        } else if $in < 6hr {
+            "#dd0907"
+        } else if $in < 1day {
+            "#fbf305"
+        } else if $in < 3day {
+            "#1fb714"
+        } else if $in < 1wk {
+            { fg: "#1fb714" attr: "b" }
+        } else if $in < 6wk {
+            "#02abea"
+        } else if $in < 52wk {
+            "#0000d3"
+        } else { "dark_gray" }
     }
     range: "#c0c0c0"
     float: "#c0c0c0"

--- a/themes/themes/maia.nu
+++ b/themes/themes/maia.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00d1d1" } else { "light_gray" } }
     int: "#e0e0e0"
     filesize: {|e|
-      if $e == 0b {
-        "#e0e0e0"
-      } else if $e < 1mb {
-        "#00cccc"
-      } else {{ fg: "#16a085" }}
+        if $e == 0b {
+            "#e0e0e0"
+        } else if $e < 1mb {
+            "#00cccc"
+        } else {{ fg: "#16a085" }}
     }
     duration: "#e0e0e0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ba2922" attr: "b" }
-      } else if $in < 6hr {
-        "#ba2922"
-      } else if $in < 1day {
-        "#4c4f4d"
-      } else if $in < 3day {
-        "#7e807e"
-      } else if $in < 1wk {
-        { fg: "#7e807e" attr: "b" }
-      } else if $in < 6wk {
-        "#00cccc"
-      } else if $in < 52wk {
-        "#16a085"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ba2922" attr: "b" }
+        } else if $in < 6hr {
+            "#ba2922"
+        } else if $in < 1day {
+            "#4c4f4d"
+        } else if $in < 3day {
+            "#7e807e"
+        } else if $in < 1wk {
+            { fg: "#7e807e" attr: "b" }
+        } else if $in < 6wk {
+            "#00cccc"
+        } else if $in < 52wk {
+            "#16a085"
+        } else { "dark_gray" }
     }
     range: "#e0e0e0"
     float: "#e0e0e0"

--- a/themes/themes/man-page.nu
+++ b/themes/themes/man-page.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00e5e5" } else { "light_gray" } }
     int: "#cccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#cccccc"
-      } else if $e < 1mb {
-        "#00a6b2"
-      } else {{ fg: "#0000b2" }}
+        if $e == 0b {
+            "#cccccc"
+        } else if $e < 1mb {
+            "#00a6b2"
+        } else {{ fg: "#0000b2" }}
     }
     duration: "#cccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc0000" attr: "b" }
-      } else if $in < 6hr {
-        "#cc0000"
-      } else if $in < 1day {
-        "#999900"
-      } else if $in < 3day {
-        "#00a600"
-      } else if $in < 1wk {
-        { fg: "#00a600" attr: "b" }
-      } else if $in < 6wk {
-        "#00a6b2"
-      } else if $in < 52wk {
-        "#0000b2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc0000" attr: "b" }
+        } else if $in < 6hr {
+            "#cc0000"
+        } else if $in < 1day {
+            "#999900"
+        } else if $in < 3day {
+            "#00a600"
+        } else if $in < 1wk {
+            { fg: "#00a600" attr: "b" }
+        } else if $in < 6wk {
+            "#00a6b2"
+        } else if $in < 52wk {
+            "#0000b2"
+        } else { "dark_gray" }
     }
     range: "#cccccc"
     float: "#cccccc"

--- a/themes/themes/mar.nu
+++ b/themes/themes/mar.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#73cda0" } else { "light_gray" } }
     int: "#f8f8f8"
     filesize: {|e|
-      if $e == 0b {
-        "#f8f8f8"
-      } else if $e < 1mb {
-        "#40b57b"
-      } else {{ fg: "#407bb5" }}
+        if $e == 0b {
+            "#f8f8f8"
+        } else if $e < 1mb {
+            "#40b57b"
+        } else {{ fg: "#407bb5" }}
     }
     duration: "#f8f8f8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b5407b" attr: "b" }
-      } else if $in < 6hr {
-        "#b5407b"
-      } else if $in < 1day {
-        "#b57b40"
-      } else if $in < 3day {
-        "#7bb540"
-      } else if $in < 1wk {
-        { fg: "#7bb540" attr: "b" }
-      } else if $in < 6wk {
-        "#40b57b"
-      } else if $in < 52wk {
-        "#407bb5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b5407b" attr: "b" }
+        } else if $in < 6hr {
+            "#b5407b"
+        } else if $in < 1day {
+            "#b57b40"
+        } else if $in < 3day {
+            "#7bb540"
+        } else if $in < 1wk {
+            { fg: "#7bb540" attr: "b" }
+        } else if $in < 6wk {
+            "#40b57b"
+        } else if $in < 52wk {
+            "#407bb5"
+        } else { "dark_gray" }
     }
     range: "#f8f8f8"
     float: "#f8f8f8"

--- a/themes/themes/marrakesh.nu
+++ b/themes/themes/marrakesh.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#75a738" } else { "light_gray" } }
     int: "#948e48"
     filesize: {|e|
-      if $e == 0b {
-        "#948e48"
-      } else if $e < 1mb {
-        "#75a738"
-      } else {{ fg: "#477ca1" }}
+        if $e == 0b {
+            "#948e48"
+        } else if $e < 1mb {
+            "#75a738"
+        } else {{ fg: "#477ca1" }}
     }
     duration: "#948e48"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c35359" attr: "b" }
-      } else if $in < 6hr {
-        "#c35359"
-      } else if $in < 1day {
-        "#a88339"
-      } else if $in < 3day {
-        "#18974e"
-      } else if $in < 1wk {
-        { fg: "#18974e" attr: "b" }
-      } else if $in < 6wk {
-        "#75a738"
-      } else if $in < 52wk {
-        "#477ca1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c35359" attr: "b" }
+        } else if $in < 6hr {
+            "#c35359"
+        } else if $in < 1day {
+            "#a88339"
+        } else if $in < 3day {
+            "#18974e"
+        } else if $in < 1wk {
+            { fg: "#18974e" attr: "b" }
+        } else if $in < 6wk {
+            "#75a738"
+        } else if $in < 52wk {
+            "#477ca1"
+        } else { "dark_gray" }
     }
     range: "#948e48"
     float: "#948e48"

--- a/themes/themes/materia.nu
+++ b/themes/themes/materia.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#80cbc4" } else { "light_gray" } }
     int: "#cdd3de"
     filesize: {|e|
-      if $e == 0b {
-        "#cdd3de"
-      } else if $e < 1mb {
-        "#80cbc4"
-      } else {{ fg: "#89ddff" }}
+        if $e == 0b {
+            "#cdd3de"
+        } else if $e < 1mb {
+            "#80cbc4"
+        } else {{ fg: "#89ddff" }}
     }
     duration: "#cdd3de"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ec5f67" attr: "b" }
-      } else if $in < 6hr {
-        "#ec5f67"
-      } else if $in < 1day {
-        "#ffcc00"
-      } else if $in < 3day {
-        "#8bd649"
-      } else if $in < 1wk {
-        { fg: "#8bd649" attr: "b" }
-      } else if $in < 6wk {
-        "#80cbc4"
-      } else if $in < 52wk {
-        "#89ddff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ec5f67" attr: "b" }
+        } else if $in < 6hr {
+            "#ec5f67"
+        } else if $in < 1day {
+            "#ffcc00"
+        } else if $in < 3day {
+            "#8bd649"
+        } else if $in < 1wk {
+            { fg: "#8bd649" attr: "b" }
+        } else if $in < 6wk {
+            "#80cbc4"
+        } else if $in < 52wk {
+            "#89ddff"
+        } else { "dark_gray" }
     }
     range: "#cdd3de"
     float: "#cdd3de"

--- a/themes/themes/material-dark.nu
+++ b/themes/themes/material-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#26bad1" } else { "light_gray" } }
     int: "#eeeeee"
     filesize: {|e|
-      if $e == 0b {
-        "#eeeeee"
-      } else if $e < 1mb {
-        "#0e707c"
-      } else {{ fg: "#134eb2" }}
+        if $e == 0b {
+            "#eeeeee"
+        } else if $e < 1mb {
+            "#0e707c"
+        } else {{ fg: "#134eb2" }}
     }
     duration: "#eeeeee"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b7141e" attr: "b" }
-      } else if $in < 6hr {
-        "#b7141e"
-      } else if $in < 1day {
-        "#f5971d"
-      } else if $in < 3day {
-        "#457b23"
-      } else if $in < 1wk {
-        { fg: "#457b23" attr: "b" }
-      } else if $in < 6wk {
-        "#0e707c"
-      } else if $in < 52wk {
-        "#134eb2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b7141e" attr: "b" }
+        } else if $in < 6hr {
+            "#b7141e"
+        } else if $in < 1day {
+            "#f5971d"
+        } else if $in < 3day {
+            "#457b23"
+        } else if $in < 1wk {
+            { fg: "#457b23" attr: "b" }
+        } else if $in < 6wk {
+            "#0e707c"
+        } else if $in < 52wk {
+            "#134eb2"
+        } else { "dark_gray" }
     }
     range: "#eeeeee"
     float: "#eeeeee"

--- a/themes/themes/material-darker.nu
+++ b/themes/themes/material-darker.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#89ddff" } else { "light_gray" } }
     int: "#eeffff"
     filesize: {|e|
-      if $e == 0b {
-        "#eeffff"
-      } else if $e < 1mb {
-        "#89ddff"
-      } else {{ fg: "#82aaff" }}
+        if $e == 0b {
+            "#eeffff"
+        } else if $e < 1mb {
+            "#89ddff"
+        } else {{ fg: "#82aaff" }}
     }
     duration: "#eeffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f07178" attr: "b" }
-      } else if $in < 6hr {
-        "#f07178"
-      } else if $in < 1day {
-        "#ffcb6b"
-      } else if $in < 3day {
-        "#c3e88d"
-      } else if $in < 1wk {
-        { fg: "#c3e88d" attr: "b" }
-      } else if $in < 6wk {
-        "#89ddff"
-      } else if $in < 52wk {
-        "#82aaff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f07178" attr: "b" }
+        } else if $in < 6hr {
+            "#f07178"
+        } else if $in < 1day {
+            "#ffcb6b"
+        } else if $in < 3day {
+            "#c3e88d"
+        } else if $in < 1wk {
+            { fg: "#c3e88d" attr: "b" }
+        } else if $in < 6wk {
+            "#89ddff"
+        } else if $in < 52wk {
+            "#82aaff"
+        } else { "dark_gray" }
     }
     range: "#eeffff"
     float: "#eeffff"

--- a/themes/themes/material-lighter.nu
+++ b/themes/themes/material-lighter.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#39adb5" } else { "light_gray" } }
     int: "#80cbc4"
     filesize: {|e|
-      if $e == 0b {
-        "#80cbc4"
-      } else if $e < 1mb {
-        "#39adb5"
-      } else {{ fg: "#6182b8" }}
+        if $e == 0b {
+            "#80cbc4"
+        } else if $e < 1mb {
+            "#39adb5"
+        } else {{ fg: "#6182b8" }}
     }
     duration: "#80cbc4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff5370" attr: "b" }
-      } else if $in < 6hr {
-        "#ff5370"
-      } else if $in < 1day {
-        "#ffb62c"
-      } else if $in < 3day {
-        "#91b859"
-      } else if $in < 1wk {
-        { fg: "#91b859" attr: "b" }
-      } else if $in < 6wk {
-        "#39adb5"
-      } else if $in < 52wk {
-        "#6182b8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff5370" attr: "b" }
+        } else if $in < 6hr {
+            "#ff5370"
+        } else if $in < 1day {
+            "#ffb62c"
+        } else if $in < 3day {
+            "#91b859"
+        } else if $in < 1wk {
+            { fg: "#91b859" attr: "b" }
+        } else if $in < 6wk {
+            "#39adb5"
+        } else if $in < 52wk {
+            "#6182b8"
+        } else { "dark_gray" }
     }
     range: "#80cbc4"
     float: "#80cbc4"

--- a/themes/themes/material-palenight.nu
+++ b/themes/themes/material-palenight.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#89ddff" } else { "light_gray" } }
     int: "#959dcb"
     filesize: {|e|
-      if $e == 0b {
-        "#959dcb"
-      } else if $e < 1mb {
-        "#89ddff"
-      } else {{ fg: "#82aaff" }}
+        if $e == 0b {
+            "#959dcb"
+        } else if $e < 1mb {
+            "#89ddff"
+        } else {{ fg: "#82aaff" }}
     }
     duration: "#959dcb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f07178" attr: "b" }
-      } else if $in < 6hr {
-        "#f07178"
-      } else if $in < 1day {
-        "#ffcb6b"
-      } else if $in < 3day {
-        "#c3e88d"
-      } else if $in < 1wk {
-        { fg: "#c3e88d" attr: "b" }
-      } else if $in < 6wk {
-        "#89ddff"
-      } else if $in < 52wk {
-        "#82aaff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f07178" attr: "b" }
+        } else if $in < 6hr {
+            "#f07178"
+        } else if $in < 1day {
+            "#ffcb6b"
+        } else if $in < 3day {
+            "#c3e88d"
+        } else if $in < 1wk {
+            { fg: "#c3e88d" attr: "b" }
+        } else if $in < 6wk {
+            "#89ddff"
+        } else if $in < 52wk {
+            "#82aaff"
+        } else { "dark_gray" }
     }
     range: "#959dcb"
     float: "#959dcb"

--- a/themes/themes/material-vivid.nu
+++ b/themes/themes/material-vivid.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00bcd4" } else { "light_gray" } }
     int: "#80868b"
     filesize: {|e|
-      if $e == 0b {
-        "#80868b"
-      } else if $e < 1mb {
-        "#00bcd4"
-      } else {{ fg: "#2196f3" }}
+        if $e == 0b {
+            "#80868b"
+        } else if $e < 1mb {
+            "#00bcd4"
+        } else {{ fg: "#2196f3" }}
     }
     duration: "#80868b"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f44336" attr: "b" }
-      } else if $in < 6hr {
-        "#f44336"
-      } else if $in < 1day {
-        "#ffeb3b"
-      } else if $in < 3day {
-        "#00e676"
-      } else if $in < 1wk {
-        { fg: "#00e676" attr: "b" }
-      } else if $in < 6wk {
-        "#00bcd4"
-      } else if $in < 52wk {
-        "#2196f3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f44336" attr: "b" }
+        } else if $in < 6hr {
+            "#f44336"
+        } else if $in < 1day {
+            "#ffeb3b"
+        } else if $in < 3day {
+            "#00e676"
+        } else if $in < 1wk {
+            { fg: "#00e676" attr: "b" }
+        } else if $in < 6wk {
+            "#00bcd4"
+        } else if $in < 52wk {
+            "#2196f3"
+        } else { "dark_gray" }
     }
     range: "#80868b"
     float: "#80868b"

--- a/themes/themes/material.nu
+++ b/themes/themes/material.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#89ddff" } else { "light_gray" } }
     int: "#eeffff"
     filesize: {|e|
-      if $e == 0b {
-        "#eeffff"
-      } else if $e < 1mb {
-        "#89ddff"
-      } else {{ fg: "#82aaff" }}
+        if $e == 0b {
+            "#eeffff"
+        } else if $e < 1mb {
+            "#89ddff"
+        } else {{ fg: "#82aaff" }}
     }
     duration: "#eeffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f07178" attr: "b" }
-      } else if $in < 6hr {
-        "#f07178"
-      } else if $in < 1day {
-        "#ffcb6b"
-      } else if $in < 3day {
-        "#c3e88d"
-      } else if $in < 1wk {
-        { fg: "#c3e88d" attr: "b" }
-      } else if $in < 6wk {
-        "#89ddff"
-      } else if $in < 52wk {
-        "#82aaff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f07178" attr: "b" }
+        } else if $in < 6hr {
+            "#f07178"
+        } else if $in < 1day {
+            "#ffcb6b"
+        } else if $in < 3day {
+            "#c3e88d"
+        } else if $in < 1wk {
+            { fg: "#c3e88d" attr: "b" }
+        } else if $in < 6wk {
+            "#89ddff"
+        } else if $in < 52wk {
+            "#82aaff"
+        } else { "dark_gray" }
     }
     range: "#eeffff"
     float: "#eeffff"

--- a/themes/themes/mathias.nu
+++ b/themes/themes/mathias.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#55ffff" } else { "light_gray" } }
     int: "#f2f2f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f2f2f2"
-      } else if $e < 1mb {
-        "#67d9f0"
-      } else {{ fg: "#c48dff" }}
+        if $e == 0b {
+            "#f2f2f2"
+        } else if $e < 1mb {
+            "#67d9f0"
+        } else {{ fg: "#c48dff" }}
     }
     duration: "#f2f2f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e52222" attr: "b" }
-      } else if $in < 6hr {
-        "#e52222"
-      } else if $in < 1day {
-        "#fc951e"
-      } else if $in < 3day {
-        "#a6e32d"
-      } else if $in < 1wk {
-        { fg: "#a6e32d" attr: "b" }
-      } else if $in < 6wk {
-        "#67d9f0"
-      } else if $in < 52wk {
-        "#c48dff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e52222" attr: "b" }
+        } else if $in < 6hr {
+            "#e52222"
+        } else if $in < 1day {
+            "#fc951e"
+        } else if $in < 3day {
+            "#a6e32d"
+        } else if $in < 1wk {
+            { fg: "#a6e32d" attr: "b" }
+        } else if $in < 6wk {
+            "#67d9f0"
+        } else if $in < 52wk {
+            "#c48dff"
+        } else { "dark_gray" }
     }
     range: "#f2f2f2"
     float: "#f2f2f2"

--- a/themes/themes/medallion.nu
+++ b/themes/themes/medallion.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ffbc51" } else { "light_gray" } }
     int: "#cac29a"
     filesize: {|e|
-      if $e == 0b {
-        "#cac29a"
-      } else if $e < 1mb {
-        "#916c25"
-      } else {{ fg: "#616bb0" }}
+        if $e == 0b {
+            "#cac29a"
+        } else if $e < 1mb {
+            "#916c25"
+        } else {{ fg: "#616bb0" }}
     }
     duration: "#cac29a"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b64c00" attr: "b" }
-      } else if $in < 6hr {
-        "#b64c00"
-      } else if $in < 1day {
-        "#d3bd26"
-      } else if $in < 3day {
-        "#7c8b16"
-      } else if $in < 1wk {
-        { fg: "#7c8b16" attr: "b" }
-      } else if $in < 6wk {
-        "#916c25"
-      } else if $in < 52wk {
-        "#616bb0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b64c00" attr: "b" }
+        } else if $in < 6hr {
+            "#b64c00"
+        } else if $in < 1day {
+            "#d3bd26"
+        } else if $in < 3day {
+            "#7c8b16"
+        } else if $in < 1wk {
+            { fg: "#7c8b16" attr: "b" }
+        } else if $in < 6wk {
+            "#916c25"
+        } else if $in < 52wk {
+            "#616bb0"
+        } else { "dark_gray" }
     }
     range: "#cac29a"
     float: "#cac29a"

--- a/themes/themes/mellow-purple.nu
+++ b/themes/themes/mellow-purple.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b900b1" } else { "light_gray" } }
     int: "#ffeeff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffeeff"
-      } else if $e < 1mb {
-        "#b900b1"
-      } else {{ fg: "#550068" }}
+        if $e == 0b {
+            "#ffeeff"
+        } else if $e < 1mb {
+            "#b900b1"
+        } else {{ fg: "#550068" }}
     }
     duration: "#ffeeff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#00d9e9" attr: "b" }
-      } else if $in < 6hr {
-        "#00d9e9"
-      } else if $in < 1day {
-        "#955ae7"
-      } else if $in < 3day {
-        "#05cb0d"
-      } else if $in < 1wk {
-        { fg: "#05cb0d" attr: "b" }
-      } else if $in < 6wk {
-        "#b900b1"
-      } else if $in < 52wk {
-        "#550068"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#00d9e9" attr: "b" }
+        } else if $in < 6hr {
+            "#00d9e9"
+        } else if $in < 1day {
+            "#955ae7"
+        } else if $in < 3day {
+            "#05cb0d"
+        } else if $in < 1wk {
+            { fg: "#05cb0d" attr: "b" }
+        } else if $in < 6wk {
+            "#b900b1"
+        } else if $in < 52wk {
+            "#550068"
+        } else { "dark_gray" }
     }
     range: "#ffeeff"
     float: "#ffeeff"

--- a/themes/themes/mexico-light.nu
+++ b/themes/themes/mexico-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4b8093" } else { "light_gray" } }
     int: "#383838"
     filesize: {|e|
-      if $e == 0b {
-        "#383838"
-      } else if $e < 1mb {
-        "#4b8093"
-      } else {{ fg: "#7cafc2" }}
+        if $e == 0b {
+            "#383838"
+        } else if $e < 1mb {
+            "#4b8093"
+        } else {{ fg: "#7cafc2" }}
     }
     duration: "#383838"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ab4642" attr: "b" }
-      } else if $in < 6hr {
-        "#ab4642"
-      } else if $in < 1day {
-        "#f79a0e"
-      } else if $in < 3day {
-        "#538947"
-      } else if $in < 1wk {
-        { fg: "#538947" attr: "b" }
-      } else if $in < 6wk {
-        "#4b8093"
-      } else if $in < 52wk {
-        "#7cafc2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ab4642" attr: "b" }
+        } else if $in < 6hr {
+            "#ab4642"
+        } else if $in < 1day {
+            "#f79a0e"
+        } else if $in < 3day {
+            "#538947"
+        } else if $in < 1wk {
+            { fg: "#538947" attr: "b" }
+        } else if $in < 6wk {
+            "#4b8093"
+        } else if $in < 52wk {
+            "#7cafc2"
+        } else { "dark_gray" }
     }
     range: "#383838"
     float: "#383838"

--- a/themes/themes/miramare.nu
+++ b/themes/themes/miramare.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#87c095" } else { "light_gray" } }
     int: "#444444"
     filesize: {|e|
-      if $e == 0b {
-        "#444444"
-      } else if $e < 1mb {
-        "#87c095"
-      } else {{ fg: "#89beba" }}
+        if $e == 0b {
+            "#444444"
+        } else if $e < 1mb {
+            "#87c095"
+        } else {{ fg: "#89beba" }}
     }
     duration: "#444444"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e68183" attr: "b" }
-      } else if $in < 6hr {
-        "#e68183"
-      } else if $in < 1day {
-        "#d9bb80"
-      } else if $in < 3day {
-        "#87af87"
-      } else if $in < 1wk {
-        { fg: "#87af87" attr: "b" }
-      } else if $in < 6wk {
-        "#87c095"
-      } else if $in < 52wk {
-        "#89beba"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e68183" attr: "b" }
+        } else if $in < 6hr {
+            "#e68183"
+        } else if $in < 1day {
+            "#d9bb80"
+        } else if $in < 3day {
+            "#87af87"
+        } else if $in < 1wk {
+            { fg: "#87af87" attr: "b" }
+        } else if $in < 6wk {
+            "#87c095"
+        } else if $in < 52wk {
+            "#89beba"
+        } else { "dark_gray" }
     }
     range: "#444444"
     float: "#444444"

--- a/themes/themes/misterioso.nu
+++ b/themes/themes/misterioso.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00ede1" } else { "light_gray" } }
     int: "#e1e1e0"
     filesize: {|e|
-      if $e == 0b {
-        "#e1e1e0"
-      } else if $e < 1mb {
-        "#23d7d7"
-      } else {{ fg: "#338f86" }}
+        if $e == 0b {
+            "#e1e1e0"
+        } else if $e < 1mb {
+            "#23d7d7"
+        } else {{ fg: "#338f86" }}
     }
     duration: "#e1e1e0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff4242" attr: "b" }
-      } else if $in < 6hr {
-        "#ff4242"
-      } else if $in < 1day {
-        "#ffad29"
-      } else if $in < 3day {
-        "#74af68"
-      } else if $in < 1wk {
-        { fg: "#74af68" attr: "b" }
-      } else if $in < 6wk {
-        "#23d7d7"
-      } else if $in < 52wk {
-        "#338f86"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff4242" attr: "b" }
+        } else if $in < 6hr {
+            "#ff4242"
+        } else if $in < 1day {
+            "#ffad29"
+        } else if $in < 3day {
+            "#74af68"
+        } else if $in < 1wk {
+            { fg: "#74af68" attr: "b" }
+        } else if $in < 6wk {
+            "#23d7d7"
+        } else if $in < 52wk {
+            "#338f86"
+        } else { "dark_gray" }
     }
     range: "#e1e1e0"
     float: "#e1e1e0"

--- a/themes/themes/miu.nu
+++ b/themes/themes/miu.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#bddbdb" } else { "light_gray" } }
     int: "#d9d9d9"
     filesize: {|e|
-      if $e == 0b {
-        "#d9d9d9"
-      } else if $e < 1mb {
-        "#7ab8b8"
-      } else {{ fg: "#7a7ab8" }}
+        if $e == 0b {
+            "#d9d9d9"
+        } else if $e < 1mb {
+            "#7ab8b8"
+        } else {{ fg: "#7a7ab8" }}
     }
     duration: "#d9d9d9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b87a7a" attr: "b" }
-      } else if $in < 6hr {
-        "#b87a7a"
-      } else if $in < 1day {
-        "#b8b87a"
-      } else if $in < 3day {
-        "#7ab87a"
-      } else if $in < 1wk {
-        { fg: "#7ab87a" attr: "b" }
-      } else if $in < 6wk {
-        "#7ab8b8"
-      } else if $in < 52wk {
-        "#7a7ab8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b87a7a" attr: "b" }
+        } else if $in < 6hr {
+            "#b87a7a"
+        } else if $in < 1day {
+            "#b8b87a"
+        } else if $in < 3day {
+            "#7ab87a"
+        } else if $in < 1wk {
+            { fg: "#7ab87a" attr: "b" }
+        } else if $in < 6wk {
+            "#7ab8b8"
+        } else if $in < 52wk {
+            "#7a7ab8"
+        } else { "dark_gray" }
     }
     range: "#d9d9d9"
     float: "#d9d9d9"

--- a/themes/themes/mocha.nu
+++ b/themes/themes/mocha.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7bbda4" } else { "light_gray" } }
     int: "#d0c8c6"
     filesize: {|e|
-      if $e == 0b {
-        "#d0c8c6"
-      } else if $e < 1mb {
-        "#7bbda4"
-      } else {{ fg: "#8ab3b5" }}
+        if $e == 0b {
+            "#d0c8c6"
+        } else if $e < 1mb {
+            "#7bbda4"
+        } else {{ fg: "#8ab3b5" }}
     }
     duration: "#d0c8c6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cb6077" attr: "b" }
-      } else if $in < 6hr {
-        "#cb6077"
-      } else if $in < 1day {
-        "#f4bc87"
-      } else if $in < 3day {
-        "#beb55b"
-      } else if $in < 1wk {
-        { fg: "#beb55b" attr: "b" }
-      } else if $in < 6wk {
-        "#7bbda4"
-      } else if $in < 52wk {
-        "#8ab3b5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cb6077" attr: "b" }
+        } else if $in < 6hr {
+            "#cb6077"
+        } else if $in < 1day {
+            "#f4bc87"
+        } else if $in < 3day {
+            "#beb55b"
+        } else if $in < 1wk {
+            { fg: "#beb55b" attr: "b" }
+        } else if $in < 6wk {
+            "#7bbda4"
+        } else if $in < 52wk {
+            "#8ab3b5"
+        } else { "dark_gray" }
     }
     range: "#d0c8c6"
     float: "#d0c8c6"

--- a/themes/themes/molokai.nu
+++ b/themes/themes/molokai.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ffce51" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#d0a843"
-      } else {{ fg: "#d08010" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#d0a843"
+        } else {{ fg: "#d08010" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#7325fa" attr: "b" }
-      } else if $in < 6hr {
-        "#7325fa"
-      } else if $in < 1day {
-        "#60d4df"
-      } else if $in < 3day {
-        "#23e298"
-      } else if $in < 1wk {
-        { fg: "#23e298" attr: "b" }
-      } else if $in < 6wk {
-        "#d0a843"
-      } else if $in < 52wk {
-        "#d08010"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#7325fa" attr: "b" }
+        } else if $in < 6hr {
+            "#7325fa"
+        } else if $in < 1day {
+            "#60d4df"
+        } else if $in < 3day {
+            "#23e298"
+        } else if $in < 1wk {
+            { fg: "#23e298" attr: "b" }
+        } else if $in < 6wk {
+            "#d0a843"
+        } else if $in < 52wk {
+            "#d08010"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/mona-lisa.nu
+++ b/themes/themes/mona-lisa.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8acd8f" } else { "light_gray" } }
     int: "#f7d75c"
     filesize: {|e|
-      if $e == 0b {
-        "#f7d75c"
-      } else if $e < 1mb {
-        "#588056"
-      } else {{ fg: "#515c5d" }}
+        if $e == 0b {
+            "#f7d75c"
+        } else if $e < 1mb {
+            "#588056"
+        } else {{ fg: "#515c5d" }}
     }
     duration: "#f7d75c"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9b291c" attr: "b" }
-      } else if $in < 6hr {
-        "#9b291c"
-      } else if $in < 1day {
-        "#c36e28"
-      } else if $in < 3day {
-        "#636232"
-      } else if $in < 1wk {
-        { fg: "#636232" attr: "b" }
-      } else if $in < 6wk {
-        "#588056"
-      } else if $in < 52wk {
-        "#515c5d"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9b291c" attr: "b" }
+        } else if $in < 6hr {
+            "#9b291c"
+        } else if $in < 1day {
+            "#c36e28"
+        } else if $in < 3day {
+            "#636232"
+        } else if $in < 1wk {
+            { fg: "#636232" attr: "b" }
+        } else if $in < 6wk {
+            "#588056"
+        } else if $in < 52wk {
+            "#515c5d"
+        } else { "dark_gray" }
     }
     range: "#f7d75c"
     float: "#f7d75c"

--- a/themes/themes/mono-amber.nu
+++ b/themes/themes/mono-amber.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ff9400" } else { "light_gray" } }
     int: "#ff9400"
     filesize: {|e|
-      if $e == 0b {
-        "#ff9400"
-      } else if $e < 1mb {
-        "#ff9400"
-      } else {{ fg: "#ff9400" }}
+        if $e == 0b {
+            "#ff9400"
+        } else if $e < 1mb {
+            "#ff9400"
+        } else {{ fg: "#ff9400" }}
     }
     duration: "#ff9400"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff9400" attr: "b" }
-      } else if $in < 6hr {
-        "#ff9400"
-      } else if $in < 1day {
-        "#ff9400"
-      } else if $in < 3day {
-        "#ff9400"
-      } else if $in < 1wk {
-        { fg: "#ff9400" attr: "b" }
-      } else if $in < 6wk {
-        "#ff9400"
-      } else if $in < 52wk {
-        "#ff9400"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff9400" attr: "b" }
+        } else if $in < 6hr {
+            "#ff9400"
+        } else if $in < 1day {
+            "#ff9400"
+        } else if $in < 3day {
+            "#ff9400"
+        } else if $in < 1wk {
+            { fg: "#ff9400" attr: "b" }
+        } else if $in < 6wk {
+            "#ff9400"
+        } else if $in < 52wk {
+            "#ff9400"
+        } else { "dark_gray" }
     }
     range: "#ff9400"
     float: "#ff9400"

--- a/themes/themes/mono-cyan.nu
+++ b/themes/themes/mono-cyan.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00ccff" } else { "light_gray" } }
     int: "#00ccff"
     filesize: {|e|
-      if $e == 0b {
-        "#00ccff"
-      } else if $e < 1mb {
-        "#00ccff"
-      } else {{ fg: "#00ccff" }}
+        if $e == 0b {
+            "#00ccff"
+        } else if $e < 1mb {
+            "#00ccff"
+        } else {{ fg: "#00ccff" }}
     }
     duration: "#00ccff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#00ccff" attr: "b" }
-      } else if $in < 6hr {
-        "#00ccff"
-      } else if $in < 1day {
-        "#00ccff"
-      } else if $in < 3day {
-        "#00ccff"
-      } else if $in < 1wk {
-        { fg: "#00ccff" attr: "b" }
-      } else if $in < 6wk {
-        "#00ccff"
-      } else if $in < 52wk {
-        "#00ccff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#00ccff" attr: "b" }
+        } else if $in < 6hr {
+            "#00ccff"
+        } else if $in < 1day {
+            "#00ccff"
+        } else if $in < 3day {
+            "#00ccff"
+        } else if $in < 1wk {
+            { fg: "#00ccff" attr: "b" }
+        } else if $in < 6wk {
+            "#00ccff"
+        } else if $in < 52wk {
+            "#00ccff"
+        } else { "dark_gray" }
     }
     range: "#00ccff"
     float: "#00ccff"

--- a/themes/themes/mono-green.nu
+++ b/themes/themes/mono-green.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#0bff00" } else { "light_gray" } }
     int: "#0bff00"
     filesize: {|e|
-      if $e == 0b {
-        "#0bff00"
-      } else if $e < 1mb {
-        "#0bff00"
-      } else {{ fg: "#0bff00" }}
+        if $e == 0b {
+            "#0bff00"
+        } else if $e < 1mb {
+            "#0bff00"
+        } else {{ fg: "#0bff00" }}
     }
     duration: "#0bff00"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#0bff00" attr: "b" }
-      } else if $in < 6hr {
-        "#0bff00"
-      } else if $in < 1day {
-        "#0bff00"
-      } else if $in < 3day {
-        "#0bff00"
-      } else if $in < 1wk {
-        { fg: "#0bff00" attr: "b" }
-      } else if $in < 6wk {
-        "#0bff00"
-      } else if $in < 52wk {
-        "#0bff00"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#0bff00" attr: "b" }
+        } else if $in < 6hr {
+            "#0bff00"
+        } else if $in < 1day {
+            "#0bff00"
+        } else if $in < 3day {
+            "#0bff00"
+        } else if $in < 1wk {
+            { fg: "#0bff00" attr: "b" }
+        } else if $in < 6wk {
+            "#0bff00"
+        } else if $in < 52wk {
+            "#0bff00"
+        } else { "dark_gray" }
     }
     range: "#0bff00"
     float: "#0bff00"

--- a/themes/themes/mono-red.nu
+++ b/themes/themes/mono-red.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ff3600" } else { "light_gray" } }
     int: "#ff3600"
     filesize: {|e|
-      if $e == 0b {
-        "#ff3600"
-      } else if $e < 1mb {
-        "#ff3600"
-      } else {{ fg: "#ff3600" }}
+        if $e == 0b {
+            "#ff3600"
+        } else if $e < 1mb {
+            "#ff3600"
+        } else {{ fg: "#ff3600" }}
     }
     duration: "#ff3600"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff3600" attr: "b" }
-      } else if $in < 6hr {
-        "#ff3600"
-      } else if $in < 1day {
-        "#ff3600"
-      } else if $in < 3day {
-        "#ff3600"
-      } else if $in < 1wk {
-        { fg: "#ff3600" attr: "b" }
-      } else if $in < 6wk {
-        "#ff3600"
-      } else if $in < 52wk {
-        "#ff3600"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff3600" attr: "b" }
+        } else if $in < 6hr {
+            "#ff3600"
+        } else if $in < 1day {
+            "#ff3600"
+        } else if $in < 3day {
+            "#ff3600"
+        } else if $in < 1wk {
+            { fg: "#ff3600" attr: "b" }
+        } else if $in < 6wk {
+            "#ff3600"
+        } else if $in < 52wk {
+            "#ff3600"
+        } else { "dark_gray" }
     }
     range: "#ff3600"
     float: "#ff3600"

--- a/themes/themes/mono-white.nu
+++ b/themes/themes/mono-white.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#fafafa" } else { "light_gray" } }
     int: "#fafafa"
     filesize: {|e|
-      if $e == 0b {
-        "#fafafa"
-      } else if $e < 1mb {
-        "#fafafa"
-      } else {{ fg: "#fafafa" }}
+        if $e == 0b {
+            "#fafafa"
+        } else if $e < 1mb {
+            "#fafafa"
+        } else {{ fg: "#fafafa" }}
     }
     duration: "#fafafa"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fafafa" attr: "b" }
-      } else if $in < 6hr {
-        "#fafafa"
-      } else if $in < 1day {
-        "#fafafa"
-      } else if $in < 3day {
-        "#fafafa"
-      } else if $in < 1wk {
-        { fg: "#fafafa" attr: "b" }
-      } else if $in < 6wk {
-        "#fafafa"
-      } else if $in < 52wk {
-        "#fafafa"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fafafa" attr: "b" }
+        } else if $in < 6hr {
+            "#fafafa"
+        } else if $in < 1day {
+            "#fafafa"
+        } else if $in < 3day {
+            "#fafafa"
+        } else if $in < 1wk {
+            { fg: "#fafafa" attr: "b" }
+        } else if $in < 6wk {
+            "#fafafa"
+        } else if $in < 52wk {
+            "#fafafa"
+        } else { "dark_gray" }
     }
     range: "#fafafa"
     float: "#fafafa"

--- a/themes/themes/mono-yellow.nu
+++ b/themes/themes/mono-yellow.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ffd300" } else { "light_gray" } }
     int: "#ffd300"
     filesize: {|e|
-      if $e == 0b {
-        "#ffd300"
-      } else if $e < 1mb {
-        "#ffd300"
-      } else {{ fg: "#ffd300" }}
+        if $e == 0b {
+            "#ffd300"
+        } else if $e < 1mb {
+            "#ffd300"
+        } else {{ fg: "#ffd300" }}
     }
     duration: "#ffd300"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ffd300" attr: "b" }
-      } else if $in < 6hr {
-        "#ffd300"
-      } else if $in < 1day {
-        "#ffd300"
-      } else if $in < 3day {
-        "#ffd300"
-      } else if $in < 1wk {
-        { fg: "#ffd300" attr: "b" }
-      } else if $in < 6wk {
-        "#ffd300"
-      } else if $in < 52wk {
-        "#ffd300"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ffd300" attr: "b" }
+        } else if $in < 6hr {
+            "#ffd300"
+        } else if $in < 1day {
+            "#ffd300"
+        } else if $in < 3day {
+            "#ffd300"
+        } else if $in < 1wk {
+            { fg: "#ffd300" attr: "b" }
+        } else if $in < 6wk {
+            "#ffd300"
+        } else if $in < 52wk {
+            "#ffd300"
+        } else { "dark_gray" }
     }
     range: "#ffd300"
     float: "#ffd300"

--- a/themes/themes/monokai-dark.nu
+++ b/themes/themes/monokai-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2aa198" } else { "light_gray" } }
     int: "#f9f8f5"
     filesize: {|e|
-      if $e == 0b {
-        "#f9f8f5"
-      } else if $e < 1mb {
-        "#2aa198"
-      } else {{ fg: "#66d9ef" }}
+        if $e == 0b {
+            "#f9f8f5"
+        } else if $e < 1mb {
+            "#2aa198"
+        } else {{ fg: "#66d9ef" }}
     }
     duration: "#f9f8f5"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f92672" attr: "b" }
-      } else if $in < 6hr {
-        "#f92672"
-      } else if $in < 1day {
-        "#f4bf75"
-      } else if $in < 3day {
-        "#a6e22e"
-      } else if $in < 1wk {
-        { fg: "#a6e22e" attr: "b" }
-      } else if $in < 6wk {
-        "#2aa198"
-      } else if $in < 52wk {
-        "#66d9ef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f92672" attr: "b" }
+        } else if $in < 6hr {
+            "#f92672"
+        } else if $in < 1day {
+            "#f4bf75"
+        } else if $in < 3day {
+            "#a6e22e"
+        } else if $in < 1wk {
+            { fg: "#a6e22e" attr: "b" }
+        } else if $in < 6wk {
+            "#2aa198"
+        } else if $in < 52wk {
+            "#66d9ef"
+        } else { "dark_gray" }
     }
     range: "#f9f8f5"
     float: "#f9f8f5"

--- a/themes/themes/monokai-soda.nu
+++ b/themes/themes/monokai-soda.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#58d1eb" } else { "light_gray" } }
     int: "#c4c5b5"
     filesize: {|e|
-      if $e == 0b {
-        "#c4c5b5"
-      } else if $e < 1mb {
-        "#58d1eb"
-      } else {{ fg: "#9d65ff" }}
+        if $e == 0b {
+            "#c4c5b5"
+        } else if $e < 1mb {
+            "#58d1eb"
+        } else {{ fg: "#9d65ff" }}
     }
     duration: "#c4c5b5"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f4005f" attr: "b" }
-      } else if $in < 6hr {
-        "#f4005f"
-      } else if $in < 1day {
-        "#fa8419"
-      } else if $in < 3day {
-        "#98e024"
-      } else if $in < 1wk {
-        { fg: "#98e024" attr: "b" }
-      } else if $in < 6wk {
-        "#58d1eb"
-      } else if $in < 52wk {
-        "#9d65ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f4005f" attr: "b" }
+        } else if $in < 6hr {
+            "#f4005f"
+        } else if $in < 1day {
+            "#fa8419"
+        } else if $in < 3day {
+            "#98e024"
+        } else if $in < 1wk {
+            { fg: "#98e024" attr: "b" }
+        } else if $in < 6wk {
+            "#58d1eb"
+        } else if $in < 52wk {
+            "#9d65ff"
+        } else { "dark_gray" }
     }
     range: "#c4c5b5"
     float: "#c4c5b5"

--- a/themes/themes/monokai.nu
+++ b/themes/themes/monokai.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a1efe4" } else { "light_gray" } }
     int: "#f8f8f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f8f8f2"
-      } else if $e < 1mb {
-        "#a1efe4"
-      } else {{ fg: "#66d9ef" }}
+        if $e == 0b {
+            "#f8f8f2"
+        } else if $e < 1mb {
+            "#a1efe4"
+        } else {{ fg: "#66d9ef" }}
     }
     duration: "#f8f8f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f92672" attr: "b" }
-      } else if $in < 6hr {
-        "#f92672"
-      } else if $in < 1day {
-        "#f4bf75"
-      } else if $in < 3day {
-        "#a6e22e"
-      } else if $in < 1wk {
-        { fg: "#a6e22e" attr: "b" }
-      } else if $in < 6wk {
-        "#a1efe4"
-      } else if $in < 52wk {
-        "#66d9ef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f92672" attr: "b" }
+        } else if $in < 6hr {
+            "#f92672"
+        } else if $in < 1day {
+            "#f4bf75"
+        } else if $in < 3day {
+            "#a6e22e"
+        } else if $in < 1wk {
+            { fg: "#a6e22e" attr: "b" }
+        } else if $in < 6wk {
+            "#a1efe4"
+        } else if $in < 52wk {
+            "#66d9ef"
+        } else { "dark_gray" }
     }
     range: "#f8f8f2"
     float: "#f8f8f2"

--- a/themes/themes/mountaineer-grey.nu
+++ b/themes/themes/mountaineer-grey.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8abeb7" } else { "light_gray" } }
     int: "#c5c8c6"
     filesize: {|e|
-      if $e == 0b {
-        "#c5c8c6"
-      } else if $e < 1mb {
-        "#8abeb7"
-      } else {{ fg: "#81a2be" }}
+        if $e == 0b {
+            "#c5c8c6"
+        } else if $e < 1mb {
+            "#8abeb7"
+        } else {{ fg: "#81a2be" }}
     }
     duration: "#c5c8c6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc6666" attr: "b" }
-      } else if $in < 6hr {
-        "#cc6666"
-      } else if $in < 1day {
-        "#f0c674"
-      } else if $in < 3day {
-        "#b5bd68"
-      } else if $in < 1wk {
-        { fg: "#b5bd68" attr: "b" }
-      } else if $in < 6wk {
-        "#8abeb7"
-      } else if $in < 52wk {
-        "#81a2be"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc6666" attr: "b" }
+        } else if $in < 6hr {
+            "#cc6666"
+        } else if $in < 1day {
+            "#f0c674"
+        } else if $in < 3day {
+            "#b5bd68"
+        } else if $in < 1wk {
+            { fg: "#b5bd68" attr: "b" }
+        } else if $in < 6wk {
+            "#8abeb7"
+        } else if $in < 52wk {
+            "#81a2be"
+        } else { "dark_gray" }
     }
     range: "#c5c8c6"
     float: "#c5c8c6"

--- a/themes/themes/mountaineer.nu
+++ b/themes/themes/mountaineer.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8abeb7" } else { "light_gray" } }
     int: "#c5c8c6"
     filesize: {|e|
-      if $e == 0b {
-        "#c5c8c6"
-      } else if $e < 1mb {
-        "#8abeb7"
-      } else {{ fg: "#81a2be" }}
+        if $e == 0b {
+            "#c5c8c6"
+        } else if $e < 1mb {
+            "#8abeb7"
+        } else {{ fg: "#81a2be" }}
     }
     duration: "#c5c8c6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc6666" attr: "b" }
-      } else if $in < 6hr {
-        "#cc6666"
-      } else if $in < 1day {
-        "#f0c674"
-      } else if $in < 3day {
-        "#b5bd68"
-      } else if $in < 1wk {
-        { fg: "#b5bd68" attr: "b" }
-      } else if $in < 6wk {
-        "#8abeb7"
-      } else if $in < 52wk {
-        "#81a2be"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc6666" attr: "b" }
+        } else if $in < 6hr {
+            "#cc6666"
+        } else if $in < 1day {
+            "#f0c674"
+        } else if $in < 3day {
+            "#b5bd68"
+        } else if $in < 1wk {
+            { fg: "#b5bd68" attr: "b" }
+        } else if $in < 6wk {
+            "#8abeb7"
+        } else if $in < 52wk {
+            "#81a2be"
+        } else { "dark_gray" }
     }
     range: "#c5c8c6"
     float: "#c5c8c6"

--- a/themes/themes/n0tch2k.nu
+++ b/themes/themes/n0tch2k.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#dcdcdc" } else { "light_gray" } }
     int: "#d0b8a3"
     filesize: {|e|
-      if $e == 0b {
-        "#d0b8a3"
-      } else if $e < 1mb {
-        "#c9c9c9"
-      } else {{ fg: "#657d3e" }}
+        if $e == 0b {
+            "#d0b8a3"
+        } else if $e < 1mb {
+            "#c9c9c9"
+        } else {{ fg: "#657d3e" }}
     }
     duration: "#d0b8a3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a95551" attr: "b" }
-      } else if $in < 6hr {
-        "#a95551"
-      } else if $in < 1day {
-        "#a98051"
-      } else if $in < 3day {
-        "#666666"
-      } else if $in < 1wk {
-        { fg: "#666666" attr: "b" }
-      } else if $in < 6wk {
-        "#c9c9c9"
-      } else if $in < 52wk {
-        "#657d3e"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a95551" attr: "b" }
+        } else if $in < 6hr {
+            "#a95551"
+        } else if $in < 1day {
+            "#a98051"
+        } else if $in < 3day {
+            "#666666"
+        } else if $in < 1wk {
+            { fg: "#666666" attr: "b" }
+        } else if $in < 6wk {
+            "#c9c9c9"
+        } else if $in < 52wk {
+            "#657d3e"
+        } else { "dark_gray" }
     }
     range: "#d0b8a3"
     float: "#d0b8a3"

--- a/themes/themes/nebula.nu
+++ b/themes/themes/nebula.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#226f68" } else { "light_gray" } }
     int: "#a4a6a9"
     filesize: {|e|
-      if $e == 0b {
-        "#a4a6a9"
-      } else if $e < 1mb {
-        "#226f68"
-      } else {{ fg: "#4d6bb6" }}
+        if $e == 0b {
+            "#a4a6a9"
+        } else if $e < 1mb {
+            "#226f68"
+        } else {{ fg: "#4d6bb6" }}
     }
     duration: "#a4a6a9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#777abc" attr: "b" }
-      } else if $in < 6hr {
-        "#777abc"
-      } else if $in < 1day {
-        "#4f9062"
-      } else if $in < 3day {
-        "#6562a8"
-      } else if $in < 1wk {
-        { fg: "#6562a8" attr: "b" }
-      } else if $in < 6wk {
-        "#226f68"
-      } else if $in < 52wk {
-        "#4d6bb6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#777abc" attr: "b" }
+        } else if $in < 6hr {
+            "#777abc"
+        } else if $in < 1day {
+            "#4f9062"
+        } else if $in < 3day {
+            "#6562a8"
+        } else if $in < 1wk {
+            { fg: "#6562a8" attr: "b" }
+        } else if $in < 6wk {
+            "#226f68"
+        } else if $in < 52wk {
+            "#4d6bb6"
+        } else { "dark_gray" }
     }
     range: "#a4a6a9"
     float: "#a4a6a9"

--- a/themes/themes/neon-night.nu
+++ b/themes/themes/neon-night.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8ce8ff" } else { "light_gray" } }
     int: "#c9cccd"
     filesize: {|e|
-      if $e == 0b {
-        "#c9cccd"
-      } else if $e < 1mb {
-        "#8ce8ff"
-      } else {{ fg: "#69b4f9" }}
+        if $e == 0b {
+            "#c9cccd"
+        } else if $e < 1mb {
+            "#8ce8ff"
+        } else {{ fg: "#69b4f9" }}
     }
     duration: "#c9cccd"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff8e8e" attr: "b" }
-      } else if $in < 6hr {
-        "#ff8e8e"
-      } else if $in < 1day {
-        "#fcad3f"
-      } else if $in < 3day {
-        "#7efdd0"
-      } else if $in < 1wk {
-        { fg: "#7efdd0" attr: "b" }
-      } else if $in < 6wk {
-        "#8ce8ff"
-      } else if $in < 52wk {
-        "#69b4f9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff8e8e" attr: "b" }
+        } else if $in < 6hr {
+            "#ff8e8e"
+        } else if $in < 1day {
+            "#fcad3f"
+        } else if $in < 3day {
+            "#7efdd0"
+        } else if $in < 1wk {
+            { fg: "#7efdd0" attr: "b" }
+        } else if $in < 6wk {
+            "#8ce8ff"
+        } else if $in < 52wk {
+            "#69b4f9"
+        } else { "dark_gray" }
     }
     range: "#c9cccd"
     float: "#c9cccd"

--- a/themes/themes/neopolitan.nu
+++ b/themes/themes/neopolitan.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8da6ce" } else { "light_gray" } }
     int: "#f8f8f8"
     filesize: {|e|
-      if $e == 0b {
-        "#f8f8f8"
-      } else if $e < 1mb {
-        "#8da6ce"
-      } else {{ fg: "#253b76" }}
+        if $e == 0b {
+            "#f8f8f8"
+        } else if $e < 1mb {
+            "#8da6ce"
+        } else {{ fg: "#253b76" }}
     }
     duration: "#f8f8f8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#800000" attr: "b" }
-      } else if $in < 6hr {
-        "#800000"
-      } else if $in < 1day {
-        "#fbde2d"
-      } else if $in < 3day {
-        "#61ce3c"
-      } else if $in < 1wk {
-        { fg: "#61ce3c" attr: "b" }
-      } else if $in < 6wk {
-        "#8da6ce"
-      } else if $in < 52wk {
-        "#253b76"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#800000" attr: "b" }
+        } else if $in < 6hr {
+            "#800000"
+        } else if $in < 1day {
+            "#fbde2d"
+        } else if $in < 3day {
+            "#61ce3c"
+        } else if $in < 1wk {
+            { fg: "#61ce3c" attr: "b" }
+        } else if $in < 6wk {
+            "#8da6ce"
+        } else if $in < 52wk {
+            "#253b76"
+        } else { "dark_gray" }
     }
     range: "#f8f8f8"
     float: "#f8f8f8"

--- a/themes/themes/nep.nu
+++ b/themes/themes/nep.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#74b9ff" } else { "light_gray" } }
     int: "#f2f2f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f2f2f2"
-      } else if $e < 1mb {
-        "#006fdd"
-      } else {{ fg: "#6f00dd" }}
+        if $e == 0b {
+            "#f2f2f2"
+        } else if $e < 1mb {
+            "#006fdd"
+        } else {{ fg: "#6f00dd" }}
     }
     duration: "#f2f2f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dd6f00" attr: "b" }
-      } else if $in < 6hr {
-        "#dd6f00"
-      } else if $in < 1day {
-        "#6fdd00"
-      } else if $in < 3day {
-        "#00dd6f"
-      } else if $in < 1wk {
-        { fg: "#00dd6f" attr: "b" }
-      } else if $in < 6wk {
-        "#006fdd"
-      } else if $in < 52wk {
-        "#6f00dd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dd6f00" attr: "b" }
+        } else if $in < 6hr {
+            "#dd6f00"
+        } else if $in < 1day {
+            "#6fdd00"
+        } else if $in < 3day {
+            "#00dd6f"
+        } else if $in < 1wk {
+            { fg: "#00dd6f" attr: "b" }
+        } else if $in < 6wk {
+            "#006fdd"
+        } else if $in < 52wk {
+            "#6f00dd"
+        } else { "dark_gray" }
     }
     range: "#f2f2f2"
     float: "#f2f2f2"

--- a/themes/themes/neutron.nu
+++ b/themes/themes/neutron.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3f94a8" } else { "light_gray" } }
     int: "#e6e8ef"
     filesize: {|e|
-      if $e == 0b {
-        "#e6e8ef"
-      } else if $e < 1mb {
-        "#3f94a8"
-      } else {{ fg: "#6a7c93" }}
+        if $e == 0b {
+            "#e6e8ef"
+        } else if $e < 1mb {
+            "#3f94a8"
+        } else {{ fg: "#6a7c93" }}
     }
     duration: "#e6e8ef"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b54036" attr: "b" }
-      } else if $in < 6hr {
-        "#b54036"
-      } else if $in < 1day {
-        "#deb566"
-      } else if $in < 3day {
-        "#5ab977"
-      } else if $in < 1wk {
-        { fg: "#5ab977" attr: "b" }
-      } else if $in < 6wk {
-        "#3f94a8"
-      } else if $in < 52wk {
-        "#6a7c93"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b54036" attr: "b" }
+        } else if $in < 6hr {
+            "#b54036"
+        } else if $in < 1day {
+            "#deb566"
+        } else if $in < 3day {
+            "#5ab977"
+        } else if $in < 1wk {
+            { fg: "#5ab977" attr: "b" }
+        } else if $in < 6wk {
+            "#3f94a8"
+        } else if $in < 52wk {
+            "#6a7c93"
+        } else { "dark_gray" }
     }
     range: "#e6e8ef"
     float: "#e6e8ef"

--- a/themes/themes/nightfly.nu
+++ b/themes/themes/nightfly.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7fdbca" } else { "light_gray" } }
     int: "#a1aab8"
     filesize: {|e|
-      if $e == 0b {
-        "#a1aab8"
-      } else if $e < 1mb {
-        "#7fdbca"
-      } else {{ fg: "#82aaff" }}
+        if $e == 0b {
+            "#a1aab8"
+        } else if $e < 1mb {
+            "#7fdbca"
+        } else {{ fg: "#82aaff" }}
     }
     duration: "#a1aab8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fc514e" attr: "b" }
-      } else if $in < 6hr {
-        "#fc514e"
-      } else if $in < 1day {
-        "#e7d37a"
-      } else if $in < 3day {
-        "#a1cd5e"
-      } else if $in < 1wk {
-        { fg: "#a1cd5e" attr: "b" }
-      } else if $in < 6wk {
-        "#7fdbca"
-      } else if $in < 52wk {
-        "#82aaff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fc514e" attr: "b" }
+        } else if $in < 6hr {
+            "#fc514e"
+        } else if $in < 1day {
+            "#e7d37a"
+        } else if $in < 3day {
+            "#a1cd5e"
+        } else if $in < 1wk {
+            { fg: "#a1cd5e" attr: "b" }
+        } else if $in < 6wk {
+            "#7fdbca"
+        } else if $in < 52wk {
+            "#82aaff"
+        } else { "dark_gray" }
     }
     range: "#a1aab8"
     float: "#a1aab8"

--- a/themes/themes/nightlion-v1.nu
+++ b/themes/themes/nightlion-v1.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#55ffff" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#00dadf"
-      } else {{ fg: "#276bd8" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#00dadf"
+        } else {{ fg: "#276bd8" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bb0000" attr: "b" }
-      } else if $in < 6hr {
-        "#bb0000"
-      } else if $in < 1day {
-        "#f3f167"
-      } else if $in < 3day {
-        "#5fde8f"
-      } else if $in < 1wk {
-        { fg: "#5fde8f" attr: "b" }
-      } else if $in < 6wk {
-        "#00dadf"
-      } else if $in < 52wk {
-        "#276bd8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bb0000" attr: "b" }
+        } else if $in < 6hr {
+            "#bb0000"
+        } else if $in < 1day {
+            "#f3f167"
+        } else if $in < 3day {
+            "#5fde8f"
+        } else if $in < 1wk {
+            { fg: "#5fde8f" attr: "b" }
+        } else if $in < 6wk {
+            "#00dadf"
+        } else if $in < 52wk {
+            "#276bd8"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/nightlion-v2.nu
+++ b/themes/themes/nightlion-v2.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00ccd8" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#00dadf"
-      } else {{ fg: "#64d0f0" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#00dadf"
+        } else {{ fg: "#64d0f0" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bb0000" attr: "b" }
-      } else if $in < 6hr {
-        "#bb0000"
-      } else if $in < 1day {
-        "#f3f167"
-      } else if $in < 3day {
-        "#04f623"
-      } else if $in < 1wk {
-        { fg: "#04f623" attr: "b" }
-      } else if $in < 6wk {
-        "#00dadf"
-      } else if $in < 52wk {
-        "#64d0f0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bb0000" attr: "b" }
+        } else if $in < 6hr {
+            "#bb0000"
+        } else if $in < 1day {
+            "#f3f167"
+        } else if $in < 3day {
+            "#04f623"
+        } else if $in < 1wk {
+            { fg: "#04f623" attr: "b" }
+        } else if $in < 6wk {
+            "#00dadf"
+        } else if $in < 52wk {
+            "#64d0f0"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/nighty.nu
+++ b/themes/themes/nighty.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#70d2a4" } else { "light_gray" } }
     int: "#828282"
     filesize: {|e|
-      if $e == 0b {
-        "#828282"
-      } else if $e < 1mb {
-        "#3a7458"
-      } else {{ fg: "#1d3e6f" }}
+        if $e == 0b {
+            "#828282"
+        } else if $e < 1mb {
+            "#3a7458"
+        } else {{ fg: "#1d3e6f" }}
     }
     duration: "#828282"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#9b3e46" attr: "b" }
-      } else if $in < 6hr {
-        "#9b3e46"
-      } else if $in < 1day {
-        "#808020"
-      } else if $in < 3day {
-        "#095b32"
-      } else if $in < 1wk {
-        { fg: "#095b32" attr: "b" }
-      } else if $in < 6wk {
-        "#3a7458"
-      } else if $in < 52wk {
-        "#1d3e6f"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#9b3e46" attr: "b" }
+        } else if $in < 6hr {
+            "#9b3e46"
+        } else if $in < 1day {
+            "#808020"
+        } else if $in < 3day {
+            "#095b32"
+        } else if $in < 1wk {
+            { fg: "#095b32" attr: "b" }
+        } else if $in < 6wk {
+            "#3a7458"
+        } else if $in < 52wk {
+            "#1d3e6f"
+        } else { "dark_gray" }
     }
     range: "#828282"
     float: "#828282"

--- a/themes/themes/nord-alt.nu
+++ b/themes/themes/nord-alt.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b48ead" } else { "light_gray" } }
     int: "#8fbcbb"
     filesize: {|e|
-      if $e == 0b {
-        "#8fbcbb"
-      } else if $e < 1mb {
-        "#eceff4"
-      } else {{ fg: "#d8dee9" }}
+        if $e == 0b {
+            "#8fbcbb"
+        } else if $e < 1mb {
+            "#eceff4"
+        } else {{ fg: "#d8dee9" }}
     }
     duration: "#8fbcbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#3b4252" attr: "b" }
-      } else if $in < 6hr {
-        "#3b4252"
-      } else if $in < 1day {
-        "#4c566a"
-      } else if $in < 3day {
-        "#434c5e"
-      } else if $in < 1wk {
-        { fg: "#434c5e" attr: "b" }
-      } else if $in < 6wk {
-        "#eceff4"
-      } else if $in < 52wk {
-        "#d8dee9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#3b4252" attr: "b" }
+        } else if $in < 6hr {
+            "#3b4252"
+        } else if $in < 1day {
+            "#4c566a"
+        } else if $in < 3day {
+            "#434c5e"
+        } else if $in < 1wk {
+            { fg: "#434c5e" attr: "b" }
+        } else if $in < 6wk {
+            "#eceff4"
+        } else if $in < 52wk {
+            "#d8dee9"
+        } else { "dark_gray" }
     }
     range: "#8fbcbb"
     float: "#8fbcbb"

--- a/themes/themes/nord-light.nu
+++ b/themes/themes/nord-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#96dcda" } else { "light_gray" } }
     int: "#b3b3b3"
     filesize: {|e|
-      if $e == 0b {
-        "#b3b3b3"
-      } else if $e < 1mb {
-        "#64aaaf"
-      } else {{ fg: "#439ecf" }}
+        if $e == 0b {
+            "#b3b3b3"
+        } else if $e < 1mb {
+            "#64aaaf"
+        } else {{ fg: "#439ecf" }}
     }
     duration: "#b3b3b3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e64569" attr: "b" }
-      } else if $in < 6hr {
-        "#e64569"
-      } else if $in < 1day {
-        "#dab752"
-      } else if $in < 3day {
-        "#89d287"
-      } else if $in < 1wk {
-        { fg: "#89d287" attr: "b" }
-      } else if $in < 6wk {
-        "#64aaaf"
-      } else if $in < 52wk {
-        "#439ecf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e64569" attr: "b" }
+        } else if $in < 6hr {
+            "#e64569"
+        } else if $in < 1day {
+            "#dab752"
+        } else if $in < 3day {
+            "#89d287"
+        } else if $in < 1wk {
+            { fg: "#89d287" attr: "b" }
+        } else if $in < 6wk {
+            "#64aaaf"
+        } else if $in < 52wk {
+            "#439ecf"
+        } else { "dark_gray" }
     }
     range: "#b3b3b3"
     float: "#b3b3b3"

--- a/themes/themes/nord.nu
+++ b/themes/themes/nord.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#88c0d0" } else { "light_gray" } }
     int: "#e5e9f0"
     filesize: {|e|
-      if $e == 0b {
-        "#e5e9f0"
-      } else if $e < 1mb {
-        "#88c0d0"
-      } else {{ fg: "#81a1c1" }}
+        if $e == 0b {
+            "#e5e9f0"
+        } else if $e < 1mb {
+            "#88c0d0"
+        } else {{ fg: "#81a1c1" }}
     }
     duration: "#e5e9f0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bf616a" attr: "b" }
-      } else if $in < 6hr {
-        "#bf616a"
-      } else if $in < 1day {
-        "#ebcb8b"
-      } else if $in < 3day {
-        "#a3be8c"
-      } else if $in < 1wk {
-        { fg: "#a3be8c" attr: "b" }
-      } else if $in < 6wk {
-        "#88c0d0"
-      } else if $in < 52wk {
-        "#81a1c1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bf616a" attr: "b" }
+        } else if $in < 6hr {
+            "#bf616a"
+        } else if $in < 1day {
+            "#ebcb8b"
+        } else if $in < 3day {
+            "#a3be8c"
+        } else if $in < 1wk {
+            { fg: "#a3be8c" attr: "b" }
+        } else if $in < 6wk {
+            "#88c0d0"
+        } else if $in < 52wk {
+            "#81a1c1"
+        } else { "dark_gray" }
     }
     range: "#e5e9f0"
     float: "#e5e9f0"

--- a/themes/themes/nova.nu
+++ b/themes/themes/nova.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#f2c38f" } else { "light_gray" } }
     int: "#c5d4dd"
     filesize: {|e|
-      if $e == 0b {
-        "#c5d4dd"
-      } else if $e < 1mb {
-        "#f2c38f"
-      } else {{ fg: "#83afe5" }}
+        if $e == 0b {
+            "#c5d4dd"
+        } else if $e < 1mb {
+            "#f2c38f"
+        } else {{ fg: "#83afe5" }}
     }
     duration: "#c5d4dd"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#83afe5" attr: "b" }
-      } else if $in < 6hr {
-        "#83afe5"
-      } else if $in < 1day {
-        "#a8ce93"
-      } else if $in < 3day {
-        "#7fc1ca"
-      } else if $in < 1wk {
-        { fg: "#7fc1ca" attr: "b" }
-      } else if $in < 6wk {
-        "#f2c38f"
-      } else if $in < 52wk {
-        "#83afe5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#83afe5" attr: "b" }
+        } else if $in < 6hr {
+            "#83afe5"
+        } else if $in < 1day {
+            "#a8ce93"
+        } else if $in < 3day {
+            "#7fc1ca"
+        } else if $in < 1wk {
+            { fg: "#7fc1ca" attr: "b" }
+        } else if $in < 6wk {
+            "#f2c38f"
+        } else if $in < 52wk {
+            "#83afe5"
+        } else { "dark_gray" }
     }
     range: "#c5d4dd"
     float: "#c5d4dd"

--- a/themes/themes/novel.nu
+++ b/themes/themes/novel.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#0087cc" } else { "light_gray" } }
     int: "#cccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#cccccc"
-      } else if $e < 1mb {
-        "#0087cc"
-      } else {{ fg: "#0000cc" }}
+        if $e == 0b {
+            "#cccccc"
+        } else if $e < 1mb {
+            "#0087cc"
+        } else {{ fg: "#0000cc" }}
     }
     duration: "#cccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc0000" attr: "b" }
-      } else if $in < 6hr {
-        "#cc0000"
-      } else if $in < 1day {
-        "#d06b00"
-      } else if $in < 3day {
-        "#009600"
-      } else if $in < 1wk {
-        { fg: "#009600" attr: "b" }
-      } else if $in < 6wk {
-        "#0087cc"
-      } else if $in < 52wk {
-        "#0000cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc0000" attr: "b" }
+        } else if $in < 6hr {
+            "#cc0000"
+        } else if $in < 1day {
+            "#d06b00"
+        } else if $in < 3day {
+            "#009600"
+        } else if $in < 1wk {
+            { fg: "#009600" attr: "b" }
+        } else if $in < 6wk {
+            "#0087cc"
+        } else if $in < 52wk {
+            "#0000cc"
+        } else { "dark_gray" }
     }
     range: "#cccccc"
     float: "#cccccc"

--- a/themes/themes/obsidian.nu
+++ b/themes/themes/obsidian.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#55ffff" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#00bbbb"
-      } else {{ fg: "#3a9bdb" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#00bbbb"
+        } else {{ fg: "#3a9bdb" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a60001" attr: "b" }
-      } else if $in < 6hr {
-        "#a60001"
-      } else if $in < 1day {
-        "#fecd22"
-      } else if $in < 3day {
-        "#00bb00"
-      } else if $in < 1wk {
-        { fg: "#00bb00" attr: "b" }
-      } else if $in < 6wk {
-        "#00bbbb"
-      } else if $in < 52wk {
-        "#3a9bdb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a60001" attr: "b" }
+        } else if $in < 6hr {
+            "#a60001"
+        } else if $in < 1day {
+            "#fecd22"
+        } else if $in < 3day {
+            "#00bb00"
+        } else if $in < 1wk {
+            { fg: "#00bb00" attr: "b" }
+        } else if $in < 6wk {
+            "#00bbbb"
+        } else if $in < 52wk {
+            "#3a9bdb"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/ocean-dark.nu
+++ b/themes/themes/ocean-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#dfdffd" } else { "light_gray" } }
     int: "#eeedee"
     filesize: {|e|
-      if $e == 0b {
-        "#eeedee"
-      } else if $e < 1mb {
-        "#85a6a5"
-      } else {{ fg: "#7d90a4" }}
+        if $e == 0b {
+            "#eeedee"
+        } else if $e < 1mb {
+            "#85a6a5"
+        } else {{ fg: "#7d90a4" }}
     }
     duration: "#eeedee"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#af4b57" attr: "b" }
-      } else if $in < 6hr {
-        "#af4b57"
-      } else if $in < 1day {
-        "#e5c079"
-      } else if $in < 3day {
-        "#afd383"
-      } else if $in < 1wk {
-        { fg: "#afd383" attr: "b" }
-      } else if $in < 6wk {
-        "#85a6a5"
-      } else if $in < 52wk {
-        "#7d90a4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#af4b57" attr: "b" }
+        } else if $in < 6hr {
+            "#af4b57"
+        } else if $in < 1day {
+            "#e5c079"
+        } else if $in < 3day {
+            "#afd383"
+        } else if $in < 1wk {
+            { fg: "#afd383" attr: "b" }
+        } else if $in < 6wk {
+            "#85a6a5"
+        } else if $in < 52wk {
+            "#7d90a4"
+        } else { "dark_gray" }
     }
     range: "#eeedee"
     float: "#eeedee"

--- a/themes/themes/ocean.nu
+++ b/themes/themes/ocean.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#96b5b4" } else { "light_gray" } }
     int: "#c0c5ce"
     filesize: {|e|
-      if $e == 0b {
-        "#c0c5ce"
-      } else if $e < 1mb {
-        "#96b5b4"
-      } else {{ fg: "#8fa1b3" }}
+        if $e == 0b {
+            "#c0c5ce"
+        } else if $e < 1mb {
+            "#96b5b4"
+        } else {{ fg: "#8fa1b3" }}
     }
     duration: "#c0c5ce"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bf616a" attr: "b" }
-      } else if $in < 6hr {
-        "#bf616a"
-      } else if $in < 1day {
-        "#ebcb8b"
-      } else if $in < 3day {
-        "#a3be8c"
-      } else if $in < 1wk {
-        { fg: "#a3be8c" attr: "b" }
-      } else if $in < 6wk {
-        "#96b5b4"
-      } else if $in < 52wk {
-        "#8fa1b3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bf616a" attr: "b" }
+        } else if $in < 6hr {
+            "#bf616a"
+        } else if $in < 1day {
+            "#ebcb8b"
+        } else if $in < 3day {
+            "#a3be8c"
+        } else if $in < 1wk {
+            { fg: "#a3be8c" attr: "b" }
+        } else if $in < 6wk {
+            "#96b5b4"
+        } else if $in < 52wk {
+            "#8fa1b3"
+        } else { "dark_gray" }
     }
     range: "#c0c5ce"
     float: "#c0c5ce"

--- a/themes/themes/oceanic-material.nu
+++ b/themes/themes/oceanic-material.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#42c6d9" } else { "light_gray" } }
     int: "#a4a4a4"
     filesize: {|e|
-      if $e == 0b {
-        "#a4a4a4"
-      } else if $e < 1mb {
-        "#16aec9"
-      } else {{ fg: "#1d80ef" }}
+        if $e == 0b {
+            "#a4a4a4"
+        } else if $e < 1mb {
+            "#16aec9"
+        } else {{ fg: "#1d80ef" }}
     }
     duration: "#a4a4a4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ee2a29" attr: "b" }
-      } else if $in < 6hr {
-        "#ee2a29"
-      } else if $in < 1day {
-        "#fee92e"
-      } else if $in < 3day {
-        "#3fa33f"
-      } else if $in < 1wk {
-        { fg: "#3fa33f" attr: "b" }
-      } else if $in < 6wk {
-        "#16aec9"
-      } else if $in < 52wk {
-        "#1d80ef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ee2a29" attr: "b" }
+        } else if $in < 6hr {
+            "#ee2a29"
+        } else if $in < 1day {
+            "#fee92e"
+        } else if $in < 3day {
+            "#3fa33f"
+        } else if $in < 1wk {
+            { fg: "#3fa33f" attr: "b" }
+        } else if $in < 6wk {
+            "#16aec9"
+        } else if $in < 52wk {
+            "#1d80ef"
+        } else { "dark_gray" }
     }
     range: "#a4a4a4"
     float: "#a4a4a4"

--- a/themes/themes/oceanic-next.nu
+++ b/themes/themes/oceanic-next.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#50a5a4" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#50a5a4"
-      } else {{ fg: "#5486c0" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#50a5a4"
+        } else {{ fg: "#5486c0" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e44754" attr: "b" }
-      } else if $in < 6hr {
-        "#e44754"
-      } else if $in < 1day {
-        "#f7bd51"
-      } else if $in < 3day {
-        "#89bd82"
-      } else if $in < 1wk {
-        { fg: "#89bd82" attr: "b" }
-      } else if $in < 6wk {
-        "#50a5a4"
-      } else if $in < 52wk {
-        "#5486c0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e44754" attr: "b" }
+        } else if $in < 6hr {
+            "#e44754"
+        } else if $in < 1day {
+            "#f7bd51"
+        } else if $in < 3day {
+            "#89bd82"
+        } else if $in < 1wk {
+            { fg: "#89bd82" attr: "b" }
+        } else if $in < 6wk {
+            "#50a5a4"
+        } else if $in < 52wk {
+            "#5486c0"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/oceanicnext.nu
+++ b/themes/themes/oceanicnext.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5fb3b3" } else { "light_gray" } }
     int: "#c0c5ce"
     filesize: {|e|
-      if $e == 0b {
-        "#c0c5ce"
-      } else if $e < 1mb {
-        "#5fb3b3"
-      } else {{ fg: "#6699cc" }}
+        if $e == 0b {
+            "#c0c5ce"
+        } else if $e < 1mb {
+            "#5fb3b3"
+        } else {{ fg: "#6699cc" }}
     }
     duration: "#c0c5ce"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ec5f67" attr: "b" }
-      } else if $in < 6hr {
-        "#ec5f67"
-      } else if $in < 1day {
-        "#fac863"
-      } else if $in < 3day {
-        "#99c794"
-      } else if $in < 1wk {
-        { fg: "#99c794" attr: "b" }
-      } else if $in < 6wk {
-        "#5fb3b3"
-      } else if $in < 52wk {
-        "#6699cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ec5f67" attr: "b" }
+        } else if $in < 6hr {
+            "#ec5f67"
+        } else if $in < 1day {
+            "#fac863"
+        } else if $in < 3day {
+            "#99c794"
+        } else if $in < 1wk {
+            { fg: "#99c794" attr: "b" }
+        } else if $in < 6wk {
+            "#5fb3b3"
+        } else if $in < 52wk {
+            "#6699cc"
+        } else { "dark_gray" }
     }
     range: "#c0c5ce"
     float: "#c0c5ce"

--- a/themes/themes/ollie.nu
+++ b/themes/themes/ollie.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1ffaff" } else { "light_gray" } }
     int: "#8a8eac"
     filesize: {|e|
-      if $e == 0b {
-        "#8a8eac"
-      } else if $e < 1mb {
-        "#1fa6ac"
-      } else {{ fg: "#2d57ac" }}
+        if $e == 0b {
+            "#8a8eac"
+        } else if $e < 1mb {
+            "#1fa6ac"
+        } else {{ fg: "#2d57ac" }}
     }
     duration: "#8a8eac"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ac2e31" attr: "b" }
-      } else if $in < 6hr {
-        "#ac2e31"
-      } else if $in < 1day {
-        "#ac4300"
-      } else if $in < 3day {
-        "#31ac61"
-      } else if $in < 1wk {
-        { fg: "#31ac61" attr: "b" }
-      } else if $in < 6wk {
-        "#1fa6ac"
-      } else if $in < 52wk {
-        "#2d57ac"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ac2e31" attr: "b" }
+        } else if $in < 6hr {
+            "#ac2e31"
+        } else if $in < 1day {
+            "#ac4300"
+        } else if $in < 3day {
+            "#31ac61"
+        } else if $in < 1wk {
+            { fg: "#31ac61" attr: "b" }
+        } else if $in < 6wk {
+            "#1fa6ac"
+        } else if $in < 52wk {
+            "#2d57ac"
+        } else { "dark_gray" }
     }
     range: "#8a8eac"
     float: "#8a8eac"

--- a/themes/themes/one-dark.nu
+++ b/themes/themes/one-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#56b6c2" } else { "light_gray" } }
     int: "#abb2bf"
     filesize: {|e|
-      if $e == 0b {
-        "#abb2bf"
-      } else if $e < 1mb {
-        "#56b6c2"
-      } else {{ fg: "#61afef" }}
+        if $e == 0b {
+            "#abb2bf"
+        } else if $e < 1mb {
+            "#56b6c2"
+        } else {{ fg: "#61afef" }}
     }
     duration: "#abb2bf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e06c75" attr: "b" }
-      } else if $in < 6hr {
-        "#e06c75"
-      } else if $in < 1day {
-        "#d19a66"
-      } else if $in < 3day {
-        "#98c379"
-      } else if $in < 1wk {
-        { fg: "#98c379" attr: "b" }
-      } else if $in < 6wk {
-        "#56b6c2"
-      } else if $in < 52wk {
-        "#61afef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e06c75" attr: "b" }
+        } else if $in < 6hr {
+            "#e06c75"
+        } else if $in < 1day {
+            "#d19a66"
+        } else if $in < 3day {
+            "#98c379"
+        } else if $in < 1wk {
+            { fg: "#98c379" attr: "b" }
+        } else if $in < 6wk {
+            "#56b6c2"
+        } else if $in < 52wk {
+            "#61afef"
+        } else { "dark_gray" }
     }
     range: "#abb2bf"
     float: "#abb2bf"

--- a/themes/themes/one-half-black.nu
+++ b/themes/themes/one-half-black.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#56b6c2" } else { "light_gray" } }
     int: "#dcdfe4"
     filesize: {|e|
-      if $e == 0b {
-        "#dcdfe4"
-      } else if $e < 1mb {
-        "#56b6c2"
-      } else {{ fg: "#61afef" }}
+        if $e == 0b {
+            "#dcdfe4"
+        } else if $e < 1mb {
+            "#56b6c2"
+        } else {{ fg: "#61afef" }}
     }
     duration: "#dcdfe4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e06c75" attr: "b" }
-      } else if $in < 6hr {
-        "#e06c75"
-      } else if $in < 1day {
-        "#e5c07b"
-      } else if $in < 3day {
-        "#98c379"
-      } else if $in < 1wk {
-        { fg: "#98c379" attr: "b" }
-      } else if $in < 6wk {
-        "#56b6c2"
-      } else if $in < 52wk {
-        "#61afef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e06c75" attr: "b" }
+        } else if $in < 6hr {
+            "#e06c75"
+        } else if $in < 1day {
+            "#e5c07b"
+        } else if $in < 3day {
+            "#98c379"
+        } else if $in < 1wk {
+            { fg: "#98c379" attr: "b" }
+        } else if $in < 6wk {
+            "#56b6c2"
+        } else if $in < 52wk {
+            "#61afef"
+        } else { "dark_gray" }
     }
     range: "#dcdfe4"
     float: "#dcdfe4"

--- a/themes/themes/one-half-light.nu
+++ b/themes/themes/one-half-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#0997b3" } else { "light_gray" } }
     int: "#fafafa"
     filesize: {|e|
-      if $e == 0b {
-        "#fafafa"
-      } else if $e < 1mb {
-        "#0997b3"
-      } else {{ fg: "#0184bc" }}
+        if $e == 0b {
+            "#fafafa"
+        } else if $e < 1mb {
+            "#0997b3"
+        } else {{ fg: "#0184bc" }}
     }
     duration: "#fafafa"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e45649" attr: "b" }
-      } else if $in < 6hr {
-        "#e45649"
-      } else if $in < 1day {
-        "#c18401"
-      } else if $in < 3day {
-        "#40a14f"
-      } else if $in < 1wk {
-        { fg: "#40a14f" attr: "b" }
-      } else if $in < 6wk {
-        "#0997b3"
-      } else if $in < 52wk {
-        "#0184bc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e45649" attr: "b" }
+        } else if $in < 6hr {
+            "#e45649"
+        } else if $in < 1day {
+            "#c18401"
+        } else if $in < 3day {
+            "#40a14f"
+        } else if $in < 1wk {
+            { fg: "#40a14f" attr: "b" }
+        } else if $in < 6wk {
+            "#0997b3"
+        } else if $in < 52wk {
+            "#0184bc"
+        } else { "dark_gray" }
     }
     range: "#fafafa"
     float: "#fafafa"

--- a/themes/themes/one-light.nu
+++ b/themes/themes/one-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#0184bc" } else { "light_gray" } }
     int: "#383a42"
     filesize: {|e|
-      if $e == 0b {
-        "#383a42"
-      } else if $e < 1mb {
-        "#0184bc"
-      } else {{ fg: "#4078f2" }}
+        if $e == 0b {
+            "#383a42"
+        } else if $e < 1mb {
+            "#0184bc"
+        } else {{ fg: "#4078f2" }}
     }
     duration: "#383a42"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ca1243" attr: "b" }
-      } else if $in < 6hr {
-        "#ca1243"
-      } else if $in < 1day {
-        "#c18401"
-      } else if $in < 3day {
-        "#50a14f"
-      } else if $in < 1wk {
-        { fg: "#50a14f" attr: "b" }
-      } else if $in < 6wk {
-        "#0184bc"
-      } else if $in < 52wk {
-        "#4078f2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ca1243" attr: "b" }
+        } else if $in < 6hr {
+            "#ca1243"
+        } else if $in < 1day {
+            "#c18401"
+        } else if $in < 3day {
+            "#50a14f"
+        } else if $in < 1wk {
+            { fg: "#50a14f" attr: "b" }
+        } else if $in < 6wk {
+            "#0184bc"
+        } else if $in < 52wk {
+            "#4078f2"
+        } else { "dark_gray" }
     }
     range: "#383a42"
     float: "#383a42"

--- a/themes/themes/onedark.nu
+++ b/themes/themes/onedark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#56b6c2" } else { "light_gray" } }
     int: "#abb2bf"
     filesize: {|e|
-      if $e == 0b {
-        "#abb2bf"
-      } else if $e < 1mb {
-        "#56b6c2"
-      } else {{ fg: "#61afef" }}
+        if $e == 0b {
+            "#abb2bf"
+        } else if $e < 1mb {
+            "#56b6c2"
+        } else {{ fg: "#61afef" }}
     }
     duration: "#abb2bf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e06c75" attr: "b" }
-      } else if $in < 6hr {
-        "#e06c75"
-      } else if $in < 1day {
-        "#e5c07b"
-      } else if $in < 3day {
-        "#98c379"
-      } else if $in < 1wk {
-        { fg: "#98c379" attr: "b" }
-      } else if $in < 6wk {
-        "#56b6c2"
-      } else if $in < 52wk {
-        "#61afef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e06c75" attr: "b" }
+        } else if $in < 6hr {
+            "#e06c75"
+        } else if $in < 1day {
+            "#e5c07b"
+        } else if $in < 3day {
+            "#98c379"
+        } else if $in < 1wk {
+            { fg: "#98c379" attr: "b" }
+        } else if $in < 6wk {
+            "#56b6c2"
+        } else if $in < 52wk {
+            "#61afef"
+        } else { "dark_gray" }
     }
     range: "#abb2bf"
     float: "#abb2bf"

--- a/themes/themes/orbital.nu
+++ b/themes/themes/orbital.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#005faf" } else { "light_gray" } }
     int: "#0000d7"
     filesize: {|e|
-      if $e == 0b {
-        "#0000d7"
-      } else if $e < 1mb {
-        "#0087d7"
-      } else {{ fg: "#5f87d7" }}
+        if $e == 0b {
+            "#0000d7"
+        } else if $e < 1mb {
+            "#0087d7"
+        } else {{ fg: "#5f87d7" }}
     }
     duration: "#0000d7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#5f5f5f" attr: "b" }
-      } else if $in < 6hr {
-        "#5f5f5f"
-      } else if $in < 1day {
-        "#d7af87"
-      } else if $in < 3day {
-        "#bcbcbc"
-      } else if $in < 1wk {
-        { fg: "#bcbcbc" attr: "b" }
-      } else if $in < 6wk {
-        "#0087d7"
-      } else if $in < 52wk {
-        "#5f87d7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#5f5f5f" attr: "b" }
+        } else if $in < 6hr {
+            "#5f5f5f"
+        } else if $in < 1day {
+            "#d7af87"
+        } else if $in < 3day {
+            "#bcbcbc"
+        } else if $in < 1wk {
+            { fg: "#bcbcbc" attr: "b" }
+        } else if $in < 6wk {
+            "#0087d7"
+        } else if $in < 52wk {
+            "#5f87d7"
+        } else { "dark_gray" }
     }
     range: "#0000d7"
     float: "#0000d7"

--- a/themes/themes/outrun-dark.nu
+++ b/themes/themes/outrun-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#0ef0f0" } else { "light_gray" } }
     int: "#d0d0fa"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0fa"
-      } else if $e < 1mb {
-        "#0ef0f0"
-      } else {{ fg: "#66b0ff" }}
+        if $e == 0b {
+            "#d0d0fa"
+        } else if $e < 1mb {
+            "#0ef0f0"
+        } else {{ fg: "#66b0ff" }}
     }
     duration: "#d0d0fa"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff4242" attr: "b" }
-      } else if $in < 6hr {
-        "#ff4242"
-      } else if $in < 1day {
-        "#f3e877"
-      } else if $in < 3day {
-        "#59f176"
-      } else if $in < 1wk {
-        { fg: "#59f176" attr: "b" }
-      } else if $in < 6wk {
-        "#0ef0f0"
-      } else if $in < 52wk {
-        "#66b0ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff4242" attr: "b" }
+        } else if $in < 6hr {
+            "#ff4242"
+        } else if $in < 1day {
+            "#f3e877"
+        } else if $in < 3day {
+            "#59f176"
+        } else if $in < 1wk {
+            { fg: "#59f176" attr: "b" }
+        } else if $in < 6wk {
+            "#0ef0f0"
+        } else if $in < 52wk {
+            "#66b0ff"
+        } else { "dark_gray" }
     }
     range: "#d0d0fa"
     float: "#d0d0fa"

--- a/themes/themes/pali.nu
+++ b/themes/themes/pali.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4bb8fd" } else { "light_gray" } }
     int: "#f2f2f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f2f2f2"
-      } else if $e < 1mb {
-        "#748fab"
-      } else {{ fg: "#8f74ab" }}
+        if $e == 0b {
+            "#f2f2f2"
+        } else if $e < 1mb {
+            "#748fab"
+        } else {{ fg: "#8f74ab" }}
     }
     duration: "#f2f2f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ab8f74" attr: "b" }
-      } else if $in < 6hr {
-        "#ab8f74"
-      } else if $in < 1day {
-        "#8fab74"
-      } else if $in < 3day {
-        "#74ab8f"
-      } else if $in < 1wk {
-        { fg: "#74ab8f" attr: "b" }
-      } else if $in < 6wk {
-        "#748fab"
-      } else if $in < 52wk {
-        "#8f74ab"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ab8f74" attr: "b" }
+        } else if $in < 6hr {
+            "#ab8f74"
+        } else if $in < 1day {
+            "#8fab74"
+        } else if $in < 3day {
+            "#74ab8f"
+        } else if $in < 1wk {
+            { fg: "#74ab8f" attr: "b" }
+        } else if $in < 6wk {
+            "#748fab"
+        } else if $in < 52wk {
+            "#8f74ab"
+        } else { "dark_gray" }
     }
     range: "#f2f2f2"
     float: "#f2f2f2"

--- a/themes/themes/palmtree.nu
+++ b/themes/themes/palmtree.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3fdcee" } else { "light_gray" } }
     int: "#fdfdfd"
     filesize: {|e|
-      if $e == 0b {
-        "#fdfdfd"
-      } else if $e < 1mb {
-        "#79e6f3"
-      } else {{ fg: "#8897f4" }}
+        if $e == 0b {
+            "#fdfdfd"
+        } else if $e < 1mb {
+            "#79e6f3"
+        } else {{ fg: "#8897f4" }}
     }
     duration: "#fdfdfd"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f37f97" attr: "b" }
-      } else if $in < 6hr {
-        "#f37f97"
-      } else if $in < 1day {
-        "#f2a272"
-      } else if $in < 3day {
-        "#5adecd"
-      } else if $in < 1wk {
-        { fg: "#5adecd" attr: "b" }
-      } else if $in < 6wk {
-        "#79e6f3"
-      } else if $in < 52wk {
-        "#8897f4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f37f97" attr: "b" }
+        } else if $in < 6hr {
+            "#f37f97"
+        } else if $in < 1day {
+            "#f2a272"
+        } else if $in < 3day {
+            "#5adecd"
+        } else if $in < 1wk {
+            { fg: "#5adecd" attr: "b" }
+        } else if $in < 6wk {
+            "#79e6f3"
+        } else if $in < 52wk {
+            "#8897f4"
+        } else { "dark_gray" }
     }
     range: "#fdfdfd"
     float: "#fdfdfd"

--- a/themes/themes/papercolor-dark.nu
+++ b/themes/themes/papercolor-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ffaf00" } else { "light_gray" } }
     int: "#808080"
     filesize: {|e|
-      if $e == 0b {
-        "#808080"
-      } else if $e < 1mb {
-        "#ffaf00"
-      } else {{ fg: "#ff5faf" }}
+        if $e == 0b {
+            "#808080"
+        } else if $e < 1mb {
+            "#ffaf00"
+        } else {{ fg: "#ff5faf" }}
     }
     duration: "#808080"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#585858" attr: "b" }
-      } else if $in < 6hr {
-        "#585858"
-      } else if $in < 1day {
-        "#afd700"
-      } else if $in < 3day {
-        "#af87d7"
-      } else if $in < 1wk {
-        { fg: "#af87d7" attr: "b" }
-      } else if $in < 6wk {
-        "#ffaf00"
-      } else if $in < 52wk {
-        "#ff5faf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#585858" attr: "b" }
+        } else if $in < 6hr {
+            "#585858"
+        } else if $in < 1day {
+            "#afd700"
+        } else if $in < 3day {
+            "#af87d7"
+        } else if $in < 1wk {
+            { fg: "#af87d7" attr: "b" }
+        } else if $in < 6wk {
+            "#ffaf00"
+        } else if $in < 52wk {
+            "#ff5faf"
+        } else { "dark_gray" }
     }
     range: "#808080"
     float: "#808080"

--- a/themes/themes/papercolor-light.nu
+++ b/themes/themes/papercolor-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#d75f00" } else { "light_gray" } }
     int: "#444444"
     filesize: {|e|
-      if $e == 0b {
-        "#444444"
-      } else if $e < 1mb {
-        "#d75f00"
-      } else {{ fg: "#d75f00" }}
+        if $e == 0b {
+            "#444444"
+        } else if $e < 1mb {
+            "#d75f00"
+        } else {{ fg: "#d75f00" }}
     }
     duration: "#444444"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bcbcbc" attr: "b" }
-      } else if $in < 6hr {
-        "#bcbcbc"
-      } else if $in < 1day {
-        "#d70087"
-      } else if $in < 3day {
-        "#8700af"
-      } else if $in < 1wk {
-        { fg: "#8700af" attr: "b" }
-      } else if $in < 6wk {
-        "#d75f00"
-      } else if $in < 52wk {
-        "#d75f00"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bcbcbc" attr: "b" }
+        } else if $in < 6hr {
+            "#bcbcbc"
+        } else if $in < 1day {
+            "#d70087"
+        } else if $in < 3day {
+            "#8700af"
+        } else if $in < 1wk {
+            { fg: "#8700af" attr: "b" }
+        } else if $in < 6wk {
+            "#d75f00"
+        } else if $in < 52wk {
+            "#d75f00"
+        } else { "dark_gray" }
     }
     range: "#444444"
     float: "#444444"

--- a/themes/themes/paraiso-dark.nu
+++ b/themes/themes/paraiso-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5bc4bf" } else { "light_gray" } }
     int: "#a39e9b"
     filesize: {|e|
-      if $e == 0b {
-        "#a39e9b"
-      } else if $e < 1mb {
-        "#5bc4bf"
-      } else {{ fg: "#06b6ef" }}
+        if $e == 0b {
+            "#a39e9b"
+        } else if $e < 1mb {
+            "#5bc4bf"
+        } else {{ fg: "#06b6ef" }}
     }
     duration: "#a39e9b"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ef6155" attr: "b" }
-      } else if $in < 6hr {
-        "#ef6155"
-      } else if $in < 1day {
-        "#fec418"
-      } else if $in < 3day {
-        "#48b685"
-      } else if $in < 1wk {
-        { fg: "#48b685" attr: "b" }
-      } else if $in < 6wk {
-        "#5bc4bf"
-      } else if $in < 52wk {
-        "#06b6ef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ef6155" attr: "b" }
+        } else if $in < 6hr {
+            "#ef6155"
+        } else if $in < 1day {
+            "#fec418"
+        } else if $in < 3day {
+            "#48b685"
+        } else if $in < 1wk {
+            { fg: "#48b685" attr: "b" }
+        } else if $in < 6wk {
+            "#5bc4bf"
+        } else if $in < 52wk {
+            "#06b6ef"
+        } else { "dark_gray" }
     }
     range: "#a39e9b"
     float: "#a39e9b"

--- a/themes/themes/paraiso.nu
+++ b/themes/themes/paraiso.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5bc4bf" } else { "light_gray" } }
     int: "#a39e9b"
     filesize: {|e|
-      if $e == 0b {
-        "#a39e9b"
-      } else if $e < 1mb {
-        "#5bc4bf"
-      } else {{ fg: "#06b6ef" }}
+        if $e == 0b {
+            "#a39e9b"
+        } else if $e < 1mb {
+            "#5bc4bf"
+        } else {{ fg: "#06b6ef" }}
     }
     duration: "#a39e9b"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ef6155" attr: "b" }
-      } else if $in < 6hr {
-        "#ef6155"
-      } else if $in < 1day {
-        "#fec418"
-      } else if $in < 3day {
-        "#48b685"
-      } else if $in < 1wk {
-        { fg: "#48b685" attr: "b" }
-      } else if $in < 6wk {
-        "#5bc4bf"
-      } else if $in < 52wk {
-        "#06b6ef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ef6155" attr: "b" }
+        } else if $in < 6hr {
+            "#ef6155"
+        } else if $in < 1day {
+            "#fec418"
+        } else if $in < 3day {
+            "#48b685"
+        } else if $in < 1wk {
+            { fg: "#48b685" attr: "b" }
+        } else if $in < 6wk {
+            "#5bc4bf"
+        } else if $in < 52wk {
+            "#06b6ef"
+        } else { "dark_gray" }
     }
     range: "#a39e9b"
     float: "#a39e9b"

--- a/themes/themes/pasque.nu
+++ b/themes/themes/pasque.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7263aa" } else { "light_gray" } }
     int: "#dedcdf"
     filesize: {|e|
-      if $e == 0b {
-        "#dedcdf"
-      } else if $e < 1mb {
-        "#7263aa"
-      } else {{ fg: "#8e7dc6" }}
+        if $e == 0b {
+            "#dedcdf"
+        } else if $e < 1mb {
+            "#7263aa"
+        } else {{ fg: "#8e7dc6" }}
     }
     duration: "#dedcdf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a92258" attr: "b" }
-      } else if $in < 6hr {
-        "#a92258"
-      } else if $in < 1day {
-        "#804ead"
-      } else if $in < 3day {
-        "#c6914b"
-      } else if $in < 1wk {
-        { fg: "#c6914b" attr: "b" }
-      } else if $in < 6wk {
-        "#7263aa"
-      } else if $in < 52wk {
-        "#8e7dc6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a92258" attr: "b" }
+        } else if $in < 6hr {
+            "#a92258"
+        } else if $in < 1day {
+            "#804ead"
+        } else if $in < 3day {
+            "#c6914b"
+        } else if $in < 1wk {
+            { fg: "#c6914b" attr: "b" }
+        } else if $in < 6wk {
+            "#7263aa"
+        } else if $in < 52wk {
+            "#8e7dc6"
+        } else { "dark_gray" }
     }
     range: "#dedcdf"
     float: "#dedcdf"

--- a/themes/themes/paul-millr.nu
+++ b/themes/themes/paul-millr.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7adff2" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#66ccff"
-      } else {{ fg: "#396bd7" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#66ccff"
+        } else {{ fg: "#396bd7" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0000" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0000"
-      } else if $in < 1day {
-        "#d3bf00"
-      } else if $in < 3day {
-        "#79ff0f"
-      } else if $in < 1wk {
-        { fg: "#79ff0f" attr: "b" }
-      } else if $in < 6wk {
-        "#66ccff"
-      } else if $in < 52wk {
-        "#396bd7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0000" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0000"
+        } else if $in < 1day {
+            "#d3bf00"
+        } else if $in < 3day {
+            "#79ff0f"
+        } else if $in < 1wk {
+            { fg: "#79ff0f" attr: "b" }
+        } else if $in < 6wk {
+            "#66ccff"
+        } else if $in < 52wk {
+            "#396bd7"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/pencil-dark.nu
+++ b/themes/themes/pencil-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4fb8cc" } else { "light_gray" } }
     int: "#d9d9d9"
     filesize: {|e|
-      if $e == 0b {
-        "#d9d9d9"
-      } else if $e < 1mb {
-        "#20a5ba"
-      } else {{ fg: "#008ec4" }}
+        if $e == 0b {
+            "#d9d9d9"
+        } else if $e < 1mb {
+            "#20a5ba"
+        } else {{ fg: "#008ec4" }}
     }
     duration: "#d9d9d9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c30771" attr: "b" }
-      } else if $in < 6hr {
-        "#c30771"
-      } else if $in < 1day {
-        "#a89c14"
-      } else if $in < 3day {
-        "#10a778"
-      } else if $in < 1wk {
-        { fg: "#10a778" attr: "b" }
-      } else if $in < 6wk {
-        "#20a5ba"
-      } else if $in < 52wk {
-        "#008ec4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c30771" attr: "b" }
+        } else if $in < 6hr {
+            "#c30771"
+        } else if $in < 1day {
+            "#a89c14"
+        } else if $in < 3day {
+            "#10a778"
+        } else if $in < 1wk {
+            { fg: "#10a778" attr: "b" }
+        } else if $in < 6wk {
+            "#20a5ba"
+        } else if $in < 52wk {
+            "#008ec4"
+        } else { "dark_gray" }
     }
     range: "#d9d9d9"
     float: "#d9d9d9"

--- a/themes/themes/pencil-light.nu
+++ b/themes/themes/pencil-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#4fb8cc" } else { "light_gray" } }
     int: "#d9d9d9"
     filesize: {|e|
-      if $e == 0b {
-        "#d9d9d9"
-      } else if $e < 1mb {
-        "#20a5ba"
-      } else {{ fg: "#008ec4" }}
+        if $e == 0b {
+            "#d9d9d9"
+        } else if $e < 1mb {
+            "#20a5ba"
+        } else {{ fg: "#008ec4" }}
     }
     duration: "#d9d9d9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c30771" attr: "b" }
-      } else if $in < 6hr {
-        "#c30771"
-      } else if $in < 1day {
-        "#a89c14"
-      } else if $in < 3day {
-        "#10a778"
-      } else if $in < 1wk {
-        { fg: "#10a778" attr: "b" }
-      } else if $in < 6wk {
-        "#20a5ba"
-      } else if $in < 52wk {
-        "#008ec4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c30771" attr: "b" }
+        } else if $in < 6hr {
+            "#c30771"
+        } else if $in < 1day {
+            "#a89c14"
+        } else if $in < 3day {
+            "#10a778"
+        } else if $in < 1wk {
+            { fg: "#10a778" attr: "b" }
+        } else if $in < 6wk {
+            "#20a5ba"
+        } else if $in < 52wk {
+            "#008ec4"
+        } else { "dark_gray" }
     }
     range: "#d9d9d9"
     float: "#d9d9d9"

--- a/themes/themes/peppermint.nu
+++ b/themes/themes/peppermint.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#96dcda" } else { "light_gray" } }
     int: "#b3b3b3"
     filesize: {|e|
-      if $e == 0b {
-        "#b3b3b3"
-      } else if $e < 1mb {
-        "#64aaaf"
-      } else {{ fg: "#439ecf" }}
+        if $e == 0b {
+            "#b3b3b3"
+        } else if $e < 1mb {
+            "#64aaaf"
+        } else {{ fg: "#439ecf" }}
     }
     duration: "#b3b3b3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e64569" attr: "b" }
-      } else if $in < 6hr {
-        "#e64569"
-      } else if $in < 1day {
-        "#dab752"
-      } else if $in < 3day {
-        "#89d287"
-      } else if $in < 1wk {
-        { fg: "#89d287" attr: "b" }
-      } else if $in < 6wk {
-        "#64aaaf"
-      } else if $in < 52wk {
-        "#439ecf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e64569" attr: "b" }
+        } else if $in < 6hr {
+            "#e64569"
+        } else if $in < 1day {
+            "#dab752"
+        } else if $in < 3day {
+            "#89d287"
+        } else if $in < 1wk {
+            { fg: "#89d287" attr: "b" }
+        } else if $in < 6wk {
+            "#64aaaf"
+        } else if $in < 52wk {
+            "#439ecf"
+        } else { "dark_gray" }
     }
     range: "#b3b3b3"
     float: "#b3b3b3"

--- a/themes/themes/phd.nu
+++ b/themes/themes/phd.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#72b9bf" } else { "light_gray" } }
     int: "#b8bbc2"
     filesize: {|e|
-      if $e == 0b {
-        "#b8bbc2"
-      } else if $e < 1mb {
-        "#72b9bf"
-      } else {{ fg: "#5299bf" }}
+        if $e == 0b {
+            "#b8bbc2"
+        } else if $e < 1mb {
+            "#72b9bf"
+        } else {{ fg: "#5299bf" }}
     }
     duration: "#b8bbc2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d07346" attr: "b" }
-      } else if $in < 6hr {
-        "#d07346"
-      } else if $in < 1day {
-        "#fbd461"
-      } else if $in < 3day {
-        "#99bf52"
-      } else if $in < 1wk {
-        { fg: "#99bf52" attr: "b" }
-      } else if $in < 6wk {
-        "#72b9bf"
-      } else if $in < 52wk {
-        "#5299bf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d07346" attr: "b" }
+        } else if $in < 6hr {
+            "#d07346"
+        } else if $in < 1day {
+            "#fbd461"
+        } else if $in < 3day {
+            "#99bf52"
+        } else if $in < 1wk {
+            { fg: "#99bf52" attr: "b" }
+        } else if $in < 6wk {
+            "#72b9bf"
+        } else if $in < 52wk {
+            "#5299bf"
+        } else { "dark_gray" }
     }
     range: "#b8bbc2"
     float: "#b8bbc2"

--- a/themes/themes/piatto-light.nu
+++ b/themes/themes/piatto-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#829428" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#66781d"
-      } else {{ fg: "#3b5ea7" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#66781d"
+        } else {{ fg: "#3b5ea7" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b23670" attr: "b" }
-      } else if $in < 6hr {
-        "#b23670"
-      } else if $in < 1day {
-        "#cc6e33"
-      } else if $in < 3day {
-        "#66781d"
-      } else if $in < 1wk {
-        { fg: "#66781d" attr: "b" }
-      } else if $in < 6wk {
-        "#66781d"
-      } else if $in < 52wk {
-        "#3b5ea7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b23670" attr: "b" }
+        } else if $in < 6hr {
+            "#b23670"
+        } else if $in < 1day {
+            "#cc6e33"
+        } else if $in < 3day {
+            "#66781d"
+        } else if $in < 1wk {
+            { fg: "#66781d" attr: "b" }
+        } else if $in < 6wk {
+            "#66781d"
+        } else if $in < 52wk {
+            "#3b5ea7"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/pico.nu
+++ b/themes/themes/pico.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#29adff" } else { "light_gray" } }
     int: "#5f574f"
     filesize: {|e|
-      if $e == 0b {
-        "#5f574f"
-      } else if $e < 1mb {
-        "#29adff"
-      } else {{ fg: "#83769c" }}
+        if $e == 0b {
+            "#5f574f"
+        } else if $e < 1mb {
+            "#29adff"
+        } else {{ fg: "#83769c" }}
     }
     duration: "#5f574f"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff004d" attr: "b" }
-      } else if $in < 6hr {
-        "#ff004d"
-      } else if $in < 1day {
-        "#fff024"
-      } else if $in < 3day {
-        "#00e756"
-      } else if $in < 1wk {
-        { fg: "#00e756" attr: "b" }
-      } else if $in < 6wk {
-        "#29adff"
-      } else if $in < 52wk {
-        "#83769c"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff004d" attr: "b" }
+        } else if $in < 6hr {
+            "#ff004d"
+        } else if $in < 1day {
+            "#fff024"
+        } else if $in < 3day {
+            "#00e756"
+        } else if $in < 1wk {
+            { fg: "#00e756" attr: "b" }
+        } else if $in < 6wk {
+            "#29adff"
+        } else if $in < 52wk {
+            "#83769c"
+        } else { "dark_gray" }
     }
     range: "#5f574f"
     float: "#5f574f"

--- a/themes/themes/pnevma.nu
+++ b/themes/themes/pnevma.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b1e7dd" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#8adbb4"
-      } else {{ fg: "#7fa5bd" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#8adbb4"
+        } else {{ fg: "#7fa5bd" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a36666" attr: "b" }
-      } else if $in < 6hr {
-        "#a36666"
-      } else if $in < 1day {
-        "#d7af87"
-      } else if $in < 3day {
-        "#90a57d"
-      } else if $in < 1wk {
-        { fg: "#90a57d" attr: "b" }
-      } else if $in < 6wk {
-        "#8adbb4"
-      } else if $in < 52wk {
-        "#7fa5bd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a36666" attr: "b" }
+        } else if $in < 6hr {
+            "#a36666"
+        } else if $in < 1day {
+            "#d7af87"
+        } else if $in < 3day {
+            "#90a57d"
+        } else if $in < 1wk {
+            { fg: "#90a57d" attr: "b" }
+        } else if $in < 6wk {
+            "#8adbb4"
+        } else if $in < 52wk {
+            "#7fa5bd"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/pop.nu
+++ b/themes/themes/pop.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00aabb" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#00aabb"
-      } else {{ fg: "#0e5a94" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#00aabb"
+        } else {{ fg: "#0e5a94" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#eb008a" attr: "b" }
-      } else if $in < 6hr {
-        "#eb008a"
-      } else if $in < 1day {
-        "#f8ca12"
-      } else if $in < 3day {
-        "#37b349"
-      } else if $in < 1wk {
-        { fg: "#37b349" attr: "b" }
-      } else if $in < 6wk {
-        "#00aabb"
-      } else if $in < 52wk {
-        "#0e5a94"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#eb008a" attr: "b" }
+        } else if $in < 6hr {
+            "#eb008a"
+        } else if $in < 1day {
+            "#f8ca12"
+        } else if $in < 3day {
+            "#37b349"
+        } else if $in < 1wk {
+            { fg: "#37b349" attr: "b" }
+        } else if $in < 6wk {
+            "#00aabb"
+        } else if $in < 52wk {
+            "#0e5a94"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/porple.nu
+++ b/themes/themes/porple.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#64878f" } else { "light_gray" } }
     int: "#d8d8d8"
     filesize: {|e|
-      if $e == 0b {
-        "#d8d8d8"
-      } else if $e < 1mb {
-        "#64878f"
-      } else {{ fg: "#8485ce" }}
+        if $e == 0b {
+            "#d8d8d8"
+        } else if $e < 1mb {
+            "#64878f"
+        } else {{ fg: "#8485ce" }}
     }
     duration: "#d8d8d8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f84547" attr: "b" }
-      } else if $in < 6hr {
-        "#f84547"
-      } else if $in < 1day {
-        "#efa16b"
-      } else if $in < 3day {
-        "#95c76f"
-      } else if $in < 1wk {
-        { fg: "#95c76f" attr: "b" }
-      } else if $in < 6wk {
-        "#64878f"
-      } else if $in < 52wk {
-        "#8485ce"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f84547" attr: "b" }
+        } else if $in < 6hr {
+            "#f84547"
+        } else if $in < 1day {
+            "#efa16b"
+        } else if $in < 3day {
+            "#95c76f"
+        } else if $in < 1wk {
+            { fg: "#95c76f" attr: "b" }
+        } else if $in < 6wk {
+            "#64878f"
+        } else if $in < 52wk {
+            "#8485ce"
+        } else { "dark_gray" }
     }
     range: "#d8d8d8"
     float: "#d8d8d8"

--- a/themes/themes/pro.nu
+++ b/themes/themes/pro.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00e5e5" } else { "light_gray" } }
     int: "#bfbfbf"
     filesize: {|e|
-      if $e == 0b {
-        "#bfbfbf"
-      } else if $e < 1mb {
-        "#00a6b2"
-      } else {{ fg: "#2009db" }}
+        if $e == 0b {
+            "#bfbfbf"
+        } else if $e < 1mb {
+            "#00a6b2"
+        } else {{ fg: "#2009db" }}
     }
     duration: "#bfbfbf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#990000" attr: "b" }
-      } else if $in < 6hr {
-        "#990000"
-      } else if $in < 1day {
-        "#999900"
-      } else if $in < 3day {
-        "#00a600"
-      } else if $in < 1wk {
-        { fg: "#00a600" attr: "b" }
-      } else if $in < 6wk {
-        "#00a6b2"
-      } else if $in < 52wk {
-        "#2009db"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#990000" attr: "b" }
+        } else if $in < 6hr {
+            "#990000"
+        } else if $in < 1day {
+            "#999900"
+        } else if $in < 3day {
+            "#00a600"
+        } else if $in < 1wk {
+            { fg: "#00a600" attr: "b" }
+        } else if $in < 6wk {
+            "#00a6b2"
+        } else if $in < 52wk {
+            "#2009db"
+        } else { "dark_gray" }
     }
     range: "#bfbfbf"
     float: "#bfbfbf"

--- a/themes/themes/railscasts.nu
+++ b/themes/themes/railscasts.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#519f50" } else { "light_gray" } }
     int: "#e6e1dc"
     filesize: {|e|
-      if $e == 0b {
-        "#e6e1dc"
-      } else if $e < 1mb {
-        "#519f50"
-      } else {{ fg: "#6d9cbe" }}
+        if $e == 0b {
+            "#e6e1dc"
+        } else if $e < 1mb {
+            "#519f50"
+        } else {{ fg: "#6d9cbe" }}
     }
     duration: "#e6e1dc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#da4939" attr: "b" }
-      } else if $in < 6hr {
-        "#da4939"
-      } else if $in < 1day {
-        "#ffc66d"
-      } else if $in < 3day {
-        "#a5c261"
-      } else if $in < 1wk {
-        { fg: "#a5c261" attr: "b" }
-      } else if $in < 6wk {
-        "#519f50"
-      } else if $in < 52wk {
-        "#6d9cbe"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#da4939" attr: "b" }
+        } else if $in < 6hr {
+            "#da4939"
+        } else if $in < 1day {
+            "#ffc66d"
+        } else if $in < 3day {
+            "#a5c261"
+        } else if $in < 1wk {
+            { fg: "#a5c261" attr: "b" }
+        } else if $in < 6wk {
+            "#519f50"
+        } else if $in < 52wk {
+            "#6d9cbe"
+        } else { "dark_gray" }
     }
     range: "#e6e1dc"
     float: "#e6e1dc"

--- a/themes/themes/rebecca.nu
+++ b/themes/themes/rebecca.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8eaee0" } else { "light_gray" } }
     int: "#f1eff8"
     filesize: {|e|
-      if $e == 0b {
-        "#f1eff8"
-      } else if $e < 1mb {
-        "#8eaee0"
-      } else {{ fg: "#2de0a7" }}
+        if $e == 0b {
+            "#f1eff8"
+        } else if $e < 1mb {
+            "#8eaee0"
+        } else {{ fg: "#2de0a7" }}
     }
     duration: "#f1eff8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a0a0c5" attr: "b" }
-      } else if $in < 6hr {
-        "#a0a0c5"
-      } else if $in < 1day {
-        "#ae81ff"
-      } else if $in < 3day {
-        "#6dfedf"
-      } else if $in < 1wk {
-        { fg: "#6dfedf" attr: "b" }
-      } else if $in < 6wk {
-        "#8eaee0"
-      } else if $in < 52wk {
-        "#2de0a7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a0a0c5" attr: "b" }
+        } else if $in < 6hr {
+            "#a0a0c5"
+        } else if $in < 1day {
+            "#ae81ff"
+        } else if $in < 3day {
+            "#6dfedf"
+        } else if $in < 1wk {
+            { fg: "#6dfedf" attr: "b" }
+        } else if $in < 6wk {
+            "#8eaee0"
+        } else if $in < 52wk {
+            "#2de0a7"
+        } else { "dark_gray" }
     }
     range: "#f1eff8"
     float: "#f1eff8"

--- a/themes/themes/red-alert.nu
+++ b/themes/themes/red-alert.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b7dfdd" } else { "light_gray" } }
     int: "#d6d6d6"
     filesize: {|e|
-      if $e == 0b {
-        "#d6d6d6"
-      } else if $e < 1mb {
-        "#6bbeb8"
-      } else {{ fg: "#489bee" }}
+        if $e == 0b {
+            "#d6d6d6"
+        } else if $e < 1mb {
+            "#6bbeb8"
+        } else {{ fg: "#489bee" }}
     }
     duration: "#d6d6d6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d62e4e" attr: "b" }
-      } else if $in < 6hr {
-        "#d62e4e"
-      } else if $in < 1day {
-        "#beb86b"
-      } else if $in < 3day {
-        "#71be6b"
-      } else if $in < 1wk {
-        { fg: "#71be6b" attr: "b" }
-      } else if $in < 6wk {
-        "#6bbeb8"
-      } else if $in < 52wk {
-        "#489bee"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d62e4e" attr: "b" }
+        } else if $in < 6hr {
+            "#d62e4e"
+        } else if $in < 1day {
+            "#beb86b"
+        } else if $in < 3day {
+            "#71be6b"
+        } else if $in < 1wk {
+            { fg: "#71be6b" attr: "b" }
+        } else if $in < 6wk {
+            "#6bbeb8"
+        } else if $in < 52wk {
+            "#489bee"
+        } else { "dark_gray" }
     }
     range: "#d6d6d6"
     float: "#d6d6d6"

--- a/themes/themes/red-sands.nu
+++ b/themes/themes/red-sands.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#55ffff" } else { "light_gray" } }
     int: "#bbbbbb"
     filesize: {|e|
-      if $e == 0b {
-        "#bbbbbb"
-      } else if $e < 1mb {
-        "#00bbbb"
-      } else {{ fg: "#0072ff" }}
+        if $e == 0b {
+            "#bbbbbb"
+        } else if $e < 1mb {
+            "#00bbbb"
+        } else {{ fg: "#0072ff" }}
     }
     duration: "#bbbbbb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff3f00" attr: "b" }
-      } else if $in < 6hr {
-        "#ff3f00"
-      } else if $in < 1day {
-        "#e7b000"
-      } else if $in < 3day {
-        "#00bb00"
-      } else if $in < 1wk {
-        { fg: "#00bb00" attr: "b" }
-      } else if $in < 6wk {
-        "#00bbbb"
-      } else if $in < 52wk {
-        "#0072ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff3f00" attr: "b" }
+        } else if $in < 6hr {
+            "#ff3f00"
+        } else if $in < 1day {
+            "#e7b000"
+        } else if $in < 3day {
+            "#00bb00"
+        } else if $in < 1wk {
+            { fg: "#00bb00" attr: "b" }
+        } else if $in < 6wk {
+            "#00bbbb"
+        } else if $in < 52wk {
+            "#0072ff"
+        } else { "dark_gray" }
     }
     range: "#bbbbbb"
     float: "#bbbbbb"

--- a/themes/themes/relaxed-afterglow.nu
+++ b/themes/themes/relaxed-afterglow.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#acbbd0" } else { "light_gray" } }
     int: "#d9d9d9"
     filesize: {|e|
-      if $e == 0b {
-        "#d9d9d9"
-      } else if $e < 1mb {
-        "#c9dfff"
-      } else {{ fg: "#6a8799" }}
+        if $e == 0b {
+            "#d9d9d9"
+        } else if $e < 1mb {
+            "#c9dfff"
+        } else {{ fg: "#6a8799" }}
     }
     duration: "#d9d9d9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#bc5653" attr: "b" }
-      } else if $in < 6hr {
-        "#bc5653"
-      } else if $in < 1day {
-        "#ebc17a"
-      } else if $in < 3day {
-        "#909d63"
-      } else if $in < 1wk {
-        { fg: "#909d63" attr: "b" }
-      } else if $in < 6wk {
-        "#c9dfff"
-      } else if $in < 52wk {
-        "#6a8799"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#bc5653" attr: "b" }
+        } else if $in < 6hr {
+            "#bc5653"
+        } else if $in < 1day {
+            "#ebc17a"
+        } else if $in < 3day {
+            "#909d63"
+        } else if $in < 1wk {
+            { fg: "#909d63" attr: "b" }
+        } else if $in < 6wk {
+            "#c9dfff"
+        } else if $in < 52wk {
+            "#6a8799"
+        } else { "dark_gray" }
     }
     range: "#d9d9d9"
     float: "#d9d9d9"

--- a/themes/themes/renault-style-light.nu
+++ b/themes/themes/renault-style-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a4d4f8" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#87c1f1"
-      } else {{ fg: "#46657d" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#87c1f1"
+        } else {{ fg: "#46657d" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#da4839" attr: "b" }
-      } else if $in < 6hr {
-        "#da4839"
-      } else if $in < 1day {
-        "#ffd249"
-      } else if $in < 3day {
-        "#509f50"
-      } else if $in < 1wk {
-        { fg: "#509f50" attr: "b" }
-      } else if $in < 6wk {
-        "#87c1f1"
-      } else if $in < 52wk {
-        "#46657d"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#da4839" attr: "b" }
+        } else if $in < 6hr {
+            "#da4839"
+        } else if $in < 1day {
+            "#ffd249"
+        } else if $in < 3day {
+            "#509f50"
+        } else if $in < 1wk {
+            { fg: "#509f50" attr: "b" }
+        } else if $in < 6wk {
+            "#87c1f1"
+        } else if $in < 52wk {
+            "#46657d"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/rippedcasts.nu
+++ b/themes/themes/rippedcasts.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8c9bc4" } else { "light_gray" } }
     int: "#bfbfbf"
     filesize: {|e|
-      if $e == 0b {
-        "#bfbfbf"
-      } else if $e < 1mb {
-        "#5a647e"
-      } else {{ fg: "#75a5b0" }}
+        if $e == 0b {
+            "#bfbfbf"
+        } else if $e < 1mb {
+            "#5a647e"
+        } else {{ fg: "#75a5b0" }}
     }
     duration: "#bfbfbf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cdaf95" attr: "b" }
-      } else if $in < 6hr {
-        "#cdaf95"
-      } else if $in < 1day {
-        "#bfbb1f"
-      } else if $in < 3day {
-        "#a8ff60"
-      } else if $in < 1wk {
-        { fg: "#a8ff60" attr: "b" }
-      } else if $in < 6wk {
-        "#5a647e"
-      } else if $in < 52wk {
-        "#75a5b0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cdaf95" attr: "b" }
+        } else if $in < 6hr {
+            "#cdaf95"
+        } else if $in < 1day {
+            "#bfbb1f"
+        } else if $in < 3day {
+            "#a8ff60"
+        } else if $in < 1wk {
+            { fg: "#a8ff60" attr: "b" }
+        } else if $in < 6wk {
+            "#5a647e"
+        } else if $in < 52wk {
+            "#75a5b0"
+        } else { "dark_gray" }
     }
     range: "#bfbfbf"
     float: "#bfbfbf"

--- a/themes/themes/rose-pine-dawn.nu
+++ b/themes/themes/rose-pine-dawn.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#286983" } else { "light_gray" } }
     int: "#575279"
     filesize: {|e|
-      if $e == 0b {
-        "#575279"
-      } else if $e < 1mb {
-        "#286983"
-      } else {{ fg: "#56949f" }}
+        if $e == 0b {
+            "#575279"
+        } else if $e < 1mb {
+            "#286983"
+        } else {{ fg: "#56949f" }}
     }
     duration: "#575279"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#1f1d2e" attr: "b" }
-      } else if $in < 6hr {
-        "#1f1d2e"
-      } else if $in < 1day {
-        "#ea9d34"
-      } else if $in < 3day {
-        "#d7827e"
-      } else if $in < 1wk {
-        { fg: "#d7827e" attr: "b" }
-      } else if $in < 6wk {
-        "#286983"
-      } else if $in < 52wk {
-        "#56949f"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#1f1d2e" attr: "b" }
+        } else if $in < 6hr {
+            "#1f1d2e"
+        } else if $in < 1day {
+            "#ea9d34"
+        } else if $in < 3day {
+            "#d7827e"
+        } else if $in < 1wk {
+            { fg: "#d7827e" attr: "b" }
+        } else if $in < 6wk {
+            "#286983"
+        } else if $in < 52wk {
+            "#56949f"
+        } else { "dark_gray" }
     }
     range: "#575279"
     float: "#575279"

--- a/themes/themes/rose-pine-moon.nu
+++ b/themes/themes/rose-pine-moon.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3e8fb0" } else { "light_gray" } }
     int: "#e0def4"
     filesize: {|e|
-      if $e == 0b {
-        "#e0def4"
-      } else if $e < 1mb {
-        "#3e8fb0"
-      } else {{ fg: "#9ccfd8" }}
+        if $e == 0b {
+            "#e0def4"
+        } else if $e < 1mb {
+            "#3e8fb0"
+        } else {{ fg: "#9ccfd8" }}
     }
     duration: "#e0def4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ecebf0" attr: "b" }
-      } else if $in < 6hr {
-        "#ecebf0"
-      } else if $in < 1day {
-        "#f6c177"
-      } else if $in < 3day {
-        "#ea9a97"
-      } else if $in < 1wk {
-        { fg: "#ea9a97" attr: "b" }
-      } else if $in < 6wk {
-        "#3e8fb0"
-      } else if $in < 52wk {
-        "#9ccfd8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ecebf0" attr: "b" }
+        } else if $in < 6hr {
+            "#ecebf0"
+        } else if $in < 1day {
+            "#f6c177"
+        } else if $in < 3day {
+            "#ea9a97"
+        } else if $in < 1wk {
+            { fg: "#ea9a97" attr: "b" }
+        } else if $in < 6wk {
+            "#3e8fb0"
+        } else if $in < 52wk {
+            "#9ccfd8"
+        } else { "dark_gray" }
     }
     range: "#e0def4"
     float: "#e0def4"

--- a/themes/themes/rose-pine.nu
+++ b/themes/themes/rose-pine.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#31748f" } else { "light_gray" } }
     int: "#e0def4"
     filesize: {|e|
-      if $e == 0b {
-        "#e0def4"
-      } else if $e < 1mb {
-        "#31748f"
-      } else {{ fg: "#9ccfd8" }}
+        if $e == 0b {
+            "#e0def4"
+        } else if $e < 1mb {
+            "#31748f"
+        } else {{ fg: "#9ccfd8" }}
     }
     duration: "#e0def4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e2e1e7" attr: "b" }
-      } else if $in < 6hr {
-        "#e2e1e7"
-      } else if $in < 1day {
-        "#f6c177"
-      } else if $in < 3day {
-        "#ebbcba"
-      } else if $in < 1wk {
-        { fg: "#ebbcba" attr: "b" }
-      } else if $in < 6wk {
-        "#31748f"
-      } else if $in < 52wk {
-        "#9ccfd8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e2e1e7" attr: "b" }
+        } else if $in < 6hr {
+            "#e2e1e7"
+        } else if $in < 1day {
+            "#f6c177"
+        } else if $in < 3day {
+            "#ebbcba"
+        } else if $in < 1wk {
+            { fg: "#ebbcba" attr: "b" }
+        } else if $in < 6wk {
+            "#31748f"
+        } else if $in < 52wk {
+            "#9ccfd8"
+        } else { "dark_gray" }
     }
     range: "#e0def4"
     float: "#e0def4"

--- a/themes/themes/royal.nu
+++ b/themes/themes/royal.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#acd4eb" } else { "light_gray" } }
     int: "#524966"
     filesize: {|e|
-      if $e == 0b {
-        "#524966"
-      } else if $e < 1mb {
-        "#8aaabe"
-      } else {{ fg: "#6580b0" }}
+        if $e == 0b {
+            "#524966"
+        } else if $e < 1mb {
+            "#8aaabe"
+        } else {{ fg: "#6580b0" }}
     }
     duration: "#524966"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#91284c" attr: "b" }
-      } else if $in < 6hr {
-        "#91284c"
-      } else if $in < 1day {
-        "#b49d27"
-      } else if $in < 3day {
-        "#23801c"
-      } else if $in < 1wk {
-        { fg: "#23801c" attr: "b" }
-      } else if $in < 6wk {
-        "#8aaabe"
-      } else if $in < 52wk {
-        "#6580b0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#91284c" attr: "b" }
+        } else if $in < 6hr {
+            "#91284c"
+        } else if $in < 1day {
+            "#b49d27"
+        } else if $in < 3day {
+            "#23801c"
+        } else if $in < 1wk {
+            { fg: "#23801c" attr: "b" }
+        } else if $in < 6wk {
+            "#8aaabe"
+        } else if $in < 52wk {
+            "#6580b0"
+        } else { "dark_gray" }
     }
     range: "#524966"
     float: "#524966"

--- a/themes/themes/sagelight.nu
+++ b/themes/themes/sagelight.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a2d6f5" } else { "light_gray" } }
     int: "#383838"
     filesize: {|e|
-      if $e == 0b {
-        "#383838"
-      } else if $e < 1mb {
-        "#a2d6f5"
-      } else {{ fg: "#a0a7d2" }}
+        if $e == 0b {
+            "#383838"
+        } else if $e < 1mb {
+            "#a2d6f5"
+        } else {{ fg: "#a0a7d2" }}
     }
     duration: "#383838"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fa8480" attr: "b" }
-      } else if $in < 6hr {
-        "#fa8480"
-      } else if $in < 1day {
-        "#ffdc61"
-      } else if $in < 3day {
-        "#a0d2c8"
-      } else if $in < 1wk {
-        { fg: "#a0d2c8" attr: "b" }
-      } else if $in < 6wk {
-        "#a2d6f5"
-      } else if $in < 52wk {
-        "#a0a7d2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fa8480" attr: "b" }
+        } else if $in < 6hr {
+            "#fa8480"
+        } else if $in < 1day {
+            "#ffdc61"
+        } else if $in < 3day {
+            "#a0d2c8"
+        } else if $in < 1wk {
+            { fg: "#a0d2c8" attr: "b" }
+        } else if $in < 6wk {
+            "#a2d6f5"
+        } else if $in < 52wk {
+            "#a0a7d2"
+        } else { "dark_gray" }
     }
     range: "#383838"
     float: "#383838"

--- a/themes/themes/sandcastle.nu
+++ b/themes/themes/sandcastle.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#83a598" } else { "light_gray" } }
     int: "#a89984"
     filesize: {|e|
-      if $e == 0b {
-        "#a89984"
-      } else if $e < 1mb {
-        "#83a598"
-      } else {{ fg: "#83a598" }}
+        if $e == 0b {
+            "#a89984"
+        } else if $e < 1mb {
+            "#83a598"
+        } else {{ fg: "#83a598" }}
     }
     duration: "#a89984"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#83a598" attr: "b" }
-      } else if $in < 6hr {
-        "#83a598"
-      } else if $in < 1day {
-        "#a07e3b"
-      } else if $in < 3day {
-        "#528b8b"
-      } else if $in < 1wk {
-        { fg: "#528b8b" attr: "b" }
-      } else if $in < 6wk {
-        "#83a598"
-      } else if $in < 52wk {
-        "#83a598"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#83a598" attr: "b" }
+        } else if $in < 6hr {
+            "#83a598"
+        } else if $in < 1day {
+            "#a07e3b"
+        } else if $in < 3day {
+            "#528b8b"
+        } else if $in < 1wk {
+            { fg: "#528b8b" attr: "b" }
+        } else if $in < 6wk {
+            "#83a598"
+        } else if $in < 52wk {
+            "#83a598"
+        } else { "dark_gray" }
     }
     range: "#a89984"
     float: "#a89984"

--- a/themes/themes/sat.nu
+++ b/themes/themes/sat.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#74fffa" } else { "light_gray" } }
     int: "#f2f2f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f2f2f2"
-      } else if $e < 1mb {
-        "#00ddd6"
-      } else {{ fg: "#0007dd" }}
+        if $e == 0b {
+            "#f2f2f2"
+        } else if $e < 1mb {
+            "#00ddd6"
+        } else {{ fg: "#0007dd" }}
     }
     duration: "#f2f2f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dd0007" attr: "b" }
-      } else if $in < 6hr {
-        "#dd0007"
-      } else if $in < 1day {
-        "#ddd600"
-      } else if $in < 3day {
-        "#07dd00"
-      } else if $in < 1wk {
-        { fg: "#07dd00" attr: "b" }
-      } else if $in < 6wk {
-        "#00ddd6"
-      } else if $in < 52wk {
-        "#0007dd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dd0007" attr: "b" }
+        } else if $in < 6hr {
+            "#dd0007"
+        } else if $in < 1day {
+            "#ddd600"
+        } else if $in < 3day {
+            "#07dd00"
+        } else if $in < 1wk {
+            { fg: "#07dd00" attr: "b" }
+        } else if $in < 6wk {
+            "#00ddd6"
+        } else if $in < 52wk {
+            "#0007dd"
+        } else { "dark_gray" }
     }
     range: "#f2f2f2"
     float: "#f2f2f2"

--- a/themes/themes/sea-shells.nu
+++ b/themes/themes/sea-shells.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#87acb4" } else { "light_gray" } }
     int: "#deb88d"
     filesize: {|e|
-      if $e == 0b {
-        "#deb88d"
-      } else if $e < 1mb {
-        "#50a3b5"
-      } else {{ fg: "#1e4950" }}
+        if $e == 0b {
+            "#deb88d"
+        } else if $e < 1mb {
+            "#50a3b5"
+        } else {{ fg: "#1e4950" }}
     }
     duration: "#deb88d"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d15123" attr: "b" }
-      } else if $in < 6hr {
-        "#d15123"
-      } else if $in < 1day {
-        "#fca02f"
-      } else if $in < 3day {
-        "#027c9b"
-      } else if $in < 1wk {
-        { fg: "#027c9b" attr: "b" }
-      } else if $in < 6wk {
-        "#50a3b5"
-      } else if $in < 52wk {
-        "#1e4950"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d15123" attr: "b" }
+        } else if $in < 6hr {
+            "#d15123"
+        } else if $in < 1day {
+            "#fca02f"
+        } else if $in < 3day {
+            "#027c9b"
+        } else if $in < 1wk {
+            { fg: "#027c9b" attr: "b" }
+        } else if $in < 6wk {
+            "#50a3b5"
+        } else if $in < 52wk {
+            "#1e4950"
+        } else { "dark_gray" }
     }
     range: "#deb88d"
     float: "#deb88d"

--- a/themes/themes/seafoam-pastel.nu
+++ b/themes/themes/seafoam-pastel.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ade0e0" } else { "light_gray" } }
     int: "#e0e0e0"
     filesize: {|e|
-      if $e == 0b {
-        "#e0e0e0"
-      } else if $e < 1mb {
-        "#729494"
-      } else {{ fg: "#4d7b82" }}
+        if $e == 0b {
+            "#e0e0e0"
+        } else if $e < 1mb {
+            "#729494"
+        } else {{ fg: "#4d7b82" }}
     }
     duration: "#e0e0e0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#825d4d" attr: "b" }
-      } else if $in < 6hr {
-        "#825d4d"
-      } else if $in < 1day {
-        "#ada16d"
-      } else if $in < 3day {
-        "#728c62"
-      } else if $in < 1wk {
-        { fg: "#728c62" attr: "b" }
-      } else if $in < 6wk {
-        "#729494"
-      } else if $in < 52wk {
-        "#4d7b82"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#825d4d" attr: "b" }
+        } else if $in < 6hr {
+            "#825d4d"
+        } else if $in < 1day {
+            "#ada16d"
+        } else if $in < 3day {
+            "#728c62"
+        } else if $in < 1wk {
+            { fg: "#728c62" attr: "b" }
+        } else if $in < 6wk {
+            "#729494"
+        } else if $in < 52wk {
+            "#4d7b82"
+        } else { "dark_gray" }
     }
     range: "#e0e0e0"
     float: "#e0e0e0"

--- a/themes/themes/selenized-black.nu
+++ b/themes/themes/selenized-black.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#56d8c9" } else { "light_gray" } }
     int: "#777777"
     filesize: {|e|
-      if $e == 0b {
-        "#777777"
-      } else if $e < 1mb {
-        "#3fc5b7"
-      } else {{ fg: "#368aeb" }}
+        if $e == 0b {
+            "#777777"
+        } else if $e < 1mb {
+            "#3fc5b7"
+        } else {{ fg: "#368aeb" }}
     }
     duration: "#777777"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ed4a46" attr: "b" }
-      } else if $in < 6hr {
-        "#ed4a46"
-      } else if $in < 1day {
-        "#dbb32d"
-      } else if $in < 3day {
-        "#70b433"
-      } else if $in < 1wk {
-        { fg: "#70b433" attr: "b" }
-      } else if $in < 6wk {
-        "#3fc5b7"
-      } else if $in < 52wk {
-        "#368aeb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ed4a46" attr: "b" }
+        } else if $in < 6hr {
+            "#ed4a46"
+        } else if $in < 1day {
+            "#dbb32d"
+        } else if $in < 3day {
+            "#70b433"
+        } else if $in < 1wk {
+            { fg: "#70b433" attr: "b" }
+        } else if $in < 6wk {
+            "#3fc5b7"
+        } else if $in < 52wk {
+            "#368aeb"
+        } else { "dark_gray" }
     }
     range: "#777777"
     float: "#777777"

--- a/themes/themes/selenized-dark.nu
+++ b/themes/themes/selenized-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#53d6c7" } else { "light_gray" } }
     int: "#72898f"
     filesize: {|e|
-      if $e == 0b {
-        "#72898f"
-      } else if $e < 1mb {
-        "#41c7b9"
-      } else {{ fg: "#4695f7" }}
+        if $e == 0b {
+            "#72898f"
+        } else if $e < 1mb {
+            "#41c7b9"
+        } else {{ fg: "#4695f7" }}
     }
     duration: "#72898f"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fa5750" attr: "b" }
-      } else if $in < 6hr {
-        "#fa5750"
-      } else if $in < 1day {
-        "#dbb32d"
-      } else if $in < 3day {
-        "#75b938"
-      } else if $in < 1wk {
-        { fg: "#75b938" attr: "b" }
-      } else if $in < 6wk {
-        "#41c7b9"
-      } else if $in < 52wk {
-        "#4695f7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fa5750" attr: "b" }
+        } else if $in < 6hr {
+            "#fa5750"
+        } else if $in < 1day {
+            "#dbb32d"
+        } else if $in < 3day {
+            "#75b938"
+        } else if $in < 1wk {
+            { fg: "#75b938" attr: "b" }
+        } else if $in < 6wk {
+            "#41c7b9"
+        } else if $in < 52wk {
+            "#4695f7"
+        } else { "dark_gray" }
     }
     range: "#72898f"
     float: "#72898f"

--- a/themes/themes/selenized-light.nu
+++ b/themes/themes/selenized-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00978a" } else { "light_gray" } }
     int: "#909995"
     filesize: {|e|
-      if $e == 0b {
-        "#909995"
-      } else if $e < 1mb {
-        "#009c8f"
-      } else {{ fg: "#0072d4" }}
+        if $e == 0b {
+            "#909995"
+        } else if $e < 1mb {
+            "#009c8f"
+        } else {{ fg: "#0072d4" }}
     }
     duration: "#909995"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d2212d" attr: "b" }
-      } else if $in < 6hr {
-        "#d2212d"
-      } else if $in < 1day {
-        "#ad8900"
-      } else if $in < 3day {
-        "#489100"
-      } else if $in < 1wk {
-        { fg: "#489100" attr: "b" }
-      } else if $in < 6wk {
-        "#009c8f"
-      } else if $in < 52wk {
-        "#0072d4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d2212d" attr: "b" }
+        } else if $in < 6hr {
+            "#d2212d"
+        } else if $in < 1day {
+            "#ad8900"
+        } else if $in < 3day {
+            "#489100"
+        } else if $in < 1wk {
+            { fg: "#489100" attr: "b" }
+        } else if $in < 6wk {
+            "#009c8f"
+        } else if $in < 52wk {
+            "#0072d4"
+        } else { "dark_gray" }
     }
     range: "#909995"
     float: "#909995"

--- a/themes/themes/selenized-white.nu
+++ b/themes/themes/selenized-white.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#009a8a" } else { "light_gray" } }
     int: "#878787"
     filesize: {|e|
-      if $e == 0b {
-        "#878787"
-      } else if $e < 1mb {
-        "#00ad9c"
-      } else {{ fg: "#0064e4" }}
+        if $e == 0b {
+            "#878787"
+        } else if $e < 1mb {
+            "#00ad9c"
+        } else {{ fg: "#0064e4" }}
     }
     duration: "#878787"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d6000c" attr: "b" }
-      } else if $in < 6hr {
-        "#d6000c"
-      } else if $in < 1day {
-        "#c49700"
-      } else if $in < 3day {
-        "#1d9700"
-      } else if $in < 1wk {
-        { fg: "#1d9700" attr: "b" }
-      } else if $in < 6wk {
-        "#00ad9c"
-      } else if $in < 52wk {
-        "#0064e4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d6000c" attr: "b" }
+        } else if $in < 6hr {
+            "#d6000c"
+        } else if $in < 1day {
+            "#c49700"
+        } else if $in < 3day {
+            "#1d9700"
+        } else if $in < 1wk {
+            { fg: "#1d9700" attr: "b" }
+        } else if $in < 6wk {
+            "#00ad9c"
+        } else if $in < 52wk {
+            "#0064e4"
+        } else { "dark_gray" }
     }
     range: "#878787"
     float: "#878787"

--- a/themes/themes/seoul256.nu
+++ b/themes/themes/seoul256.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#87d7d7" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#87afaf"
-      } else {{ fg: "#85add4" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#87afaf"
+        } else {{ fg: "#85add4" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d68787" attr: "b" }
-      } else if $in < 6hr {
-        "#d68787"
-      } else if $in < 1day {
-        "#d8af5f"
-      } else if $in < 3day {
-        "#5f865f"
-      } else if $in < 1wk {
-        { fg: "#5f865f" attr: "b" }
-      } else if $in < 6wk {
-        "#87afaf"
-      } else if $in < 52wk {
-        "#85add4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d68787" attr: "b" }
+        } else if $in < 6hr {
+            "#d68787"
+        } else if $in < 1day {
+            "#d8af5f"
+        } else if $in < 3day {
+            "#5f865f"
+        } else if $in < 1wk {
+            { fg: "#5f865f" attr: "b" }
+        } else if $in < 6wk {
+            "#87afaf"
+        } else if $in < 52wk {
+            "#85add4"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/seti-ui.nu
+++ b/themes/themes/seti-ui.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#55dbbe" } else { "light_gray" } }
     int: "#d6d6d6"
     filesize: {|e|
-      if $e == 0b {
-        "#d6d6d6"
-      } else if $e < 1mb {
-        "#55dbbe"
-      } else {{ fg: "#55b5db" }}
+        if $e == 0b {
+            "#d6d6d6"
+        } else if $e < 1mb {
+            "#55dbbe"
+        } else {{ fg: "#55b5db" }}
     }
     duration: "#d6d6d6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#Cd3f45" attr: "b" }
-      } else if $in < 6hr {
-        "#Cd3f45"
-      } else if $in < 1day {
-        "#e6cd69"
-      } else if $in < 3day {
-        "#9fca56"
-      } else if $in < 1wk {
-        { fg: "#9fca56" attr: "b" }
-      } else if $in < 6wk {
-        "#55dbbe"
-      } else if $in < 52wk {
-        "#55b5db"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#Cd3f45" attr: "b" }
+        } else if $in < 6hr {
+            "#Cd3f45"
+        } else if $in < 1day {
+            "#e6cd69"
+        } else if $in < 3day {
+            "#9fca56"
+        } else if $in < 1wk {
+            { fg: "#9fca56" attr: "b" }
+        } else if $in < 6wk {
+            "#55dbbe"
+        } else if $in < 52wk {
+            "#55b5db"
+        } else { "dark_gray" }
     }
     range: "#d6d6d6"
     float: "#d6d6d6"

--- a/themes/themes/seti.nu
+++ b/themes/themes/seti.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#55dbbe" } else { "light_gray" } }
     int: "#d6d6d6"
     filesize: {|e|
-      if $e == 0b {
-        "#d6d6d6"
-      } else if $e < 1mb {
-        "#55dbbe"
-      } else {{ fg: "#55b5db" }}
+        if $e == 0b {
+            "#d6d6d6"
+        } else if $e < 1mb {
+            "#55dbbe"
+        } else {{ fg: "#55b5db" }}
     }
     duration: "#d6d6d6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cd3f45" attr: "b" }
-      } else if $in < 6hr {
-        "#cd3f45"
-      } else if $in < 1day {
-        "#e6cd69"
-      } else if $in < 3day {
-        "#9fca56"
-      } else if $in < 1wk {
-        { fg: "#9fca56" attr: "b" }
-      } else if $in < 6wk {
-        "#55dbbe"
-      } else if $in < 52wk {
-        "#55b5db"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cd3f45" attr: "b" }
+        } else if $in < 6hr {
+            "#cd3f45"
+        } else if $in < 1day {
+            "#e6cd69"
+        } else if $in < 3day {
+            "#9fca56"
+        } else if $in < 1wk {
+            { fg: "#9fca56" attr: "b" }
+        } else if $in < 6wk {
+            "#55dbbe"
+        } else if $in < 52wk {
+            "#55b5db"
+        } else { "dark_gray" }
     }
     range: "#d6d6d6"
     float: "#d6d6d6"

--- a/themes/themes/shaman.nu
+++ b/themes/themes/shaman.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#98d028" } else { "light_gray" } }
     int: "#405555"
     filesize: {|e|
-      if $e == 0b {
-        "#405555"
-      } else if $e < 1mb {
-        "#5d7e19"
-      } else {{ fg: "#449a86" }}
+        if $e == 0b {
+            "#405555"
+        } else if $e < 1mb {
+            "#5d7e19"
+        } else {{ fg: "#449a86" }}
     }
     duration: "#405555"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b2302d" attr: "b" }
-      } else if $in < 6hr {
-        "#b2302d"
-      } else if $in < 1day {
-        "#5e8baa"
-      } else if $in < 3day {
-        "#00a941"
-      } else if $in < 1wk {
-        { fg: "#00a941" attr: "b" }
-      } else if $in < 6wk {
-        "#5d7e19"
-      } else if $in < 52wk {
-        "#449a86"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b2302d" attr: "b" }
+        } else if $in < 6hr {
+            "#b2302d"
+        } else if $in < 1day {
+            "#5e8baa"
+        } else if $in < 3day {
+            "#00a941"
+        } else if $in < 1wk {
+            { fg: "#00a941" attr: "b" }
+        } else if $in < 6wk {
+            "#5d7e19"
+        } else if $in < 52wk {
+            "#449a86"
+        } else { "dark_gray" }
     }
     range: "#405555"
     float: "#405555"

--- a/themes/themes/shapeshifter.nu
+++ b/themes/themes/shapeshifter.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#23edda" } else { "light_gray" } }
     int: "#102015"
     filesize: {|e|
-      if $e == 0b {
-        "#102015"
-      } else if $e < 1mb {
-        "#23edda"
-      } else {{ fg: "#3b48e3" }}
+        if $e == 0b {
+            "#102015"
+        } else if $e < 1mb {
+            "#23edda"
+        } else {{ fg: "#3b48e3" }}
     }
     duration: "#102015"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e92f2f" attr: "b" }
-      } else if $in < 6hr {
-        "#e92f2f"
-      } else if $in < 1day {
-        "#dddd13"
-      } else if $in < 3day {
-        "#0ed839"
-      } else if $in < 1wk {
-        { fg: "#0ed839" attr: "b" }
-      } else if $in < 6wk {
-        "#23edda"
-      } else if $in < 52wk {
-        "#3b48e3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e92f2f" attr: "b" }
+        } else if $in < 6hr {
+            "#e92f2f"
+        } else if $in < 1day {
+            "#dddd13"
+        } else if $in < 3day {
+            "#0ed839"
+        } else if $in < 1wk {
+            { fg: "#0ed839" attr: "b" }
+        } else if $in < 6wk {
+            "#23edda"
+        } else if $in < 52wk {
+            "#3b48e3"
+        } else { "dark_gray" }
     }
     range: "#102015"
     float: "#102015"

--- a/themes/themes/shel.nu
+++ b/themes/themes/shel.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8feeb9" } else { "light_gray" } }
     int: "#918988"
     filesize: {|e|
-      if $e == 0b {
-        "#918988"
-      } else if $e < 1mb {
-        "#2ca363"
-      } else {{ fg: "#2c64a2" }}
+        if $e == 0b {
+            "#918988"
+        } else if $e < 1mb {
+            "#2ca363"
+        } else {{ fg: "#2c64a2" }}
     }
     duration: "#918988"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ab2463" attr: "b" }
-      } else if $in < 6hr {
-        "#ab2463"
-      } else if $in < 1day {
-        "#ab6423"
-      } else if $in < 3day {
-        "#6ca323"
-      } else if $in < 1wk {
-        { fg: "#6ca323" attr: "b" }
-      } else if $in < 6wk {
-        "#2ca363"
-      } else if $in < 52wk {
-        "#2c64a2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ab2463" attr: "b" }
+        } else if $in < 6hr {
+            "#ab2463"
+        } else if $in < 1day {
+            "#ab6423"
+        } else if $in < 3day {
+            "#6ca323"
+        } else if $in < 1wk {
+            { fg: "#6ca323" attr: "b" }
+        } else if $in < 6wk {
+            "#2ca363"
+        } else if $in < 52wk {
+            "#2c64a2"
+        } else { "dark_gray" }
     }
     range: "#918988"
     float: "#918988"

--- a/themes/themes/sierra.nu
+++ b/themes/themes/sierra.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#a17140" } else { "light_gray" } }
     int: "#bb7774"
     filesize: {|e|
-      if $e == 0b {
-        "#bb7774"
-      } else if $e < 1mb {
-        "#a18e60"
-      } else {{ fg: "#989876" }}
+        if $e == 0b {
+            "#bb7774"
+        } else if $e < 1mb {
+            "#a18e60"
+        } else {{ fg: "#989876" }}
     }
     duration: "#bb7774"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#515a45" attr: "b" }
-      } else if $in < 6hr {
-        "#515a45"
-      } else if $in < 1day {
-        "#7f7f60"
-      } else if $in < 3day {
-        "#68694f"
-      } else if $in < 1wk {
-        { fg: "#68694f" attr: "b" }
-      } else if $in < 6wk {
-        "#a18e60"
-      } else if $in < 52wk {
-        "#989876"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#515a45" attr: "b" }
+        } else if $in < 6hr {
+            "#515a45"
+        } else if $in < 1day {
+            "#7f7f60"
+        } else if $in < 3day {
+            "#68694f"
+        } else if $in < 1wk {
+            { fg: "#68694f" attr: "b" }
+        } else if $in < 6wk {
+            "#a18e60"
+        } else if $in < 52wk {
+            "#989876"
+        } else { "dark_gray" }
     }
     range: "#bb7774"
     float: "#bb7774"

--- a/themes/themes/silk-dark.nu
+++ b/themes/themes/silk-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3fb2b9" } else { "light_gray" } }
     int: "#c7dbdd"
     filesize: {|e|
-      if $e == 0b {
-        "#c7dbdd"
-      } else if $e < 1mb {
-        "#3fb2b9"
-      } else {{ fg: "#46bddd" }}
+        if $e == 0b {
+            "#c7dbdd"
+        } else if $e < 1mb {
+            "#3fb2b9"
+        } else {{ fg: "#46bddd" }}
     }
     duration: "#c7dbdd"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb6953" attr: "b" }
-      } else if $in < 6hr {
-        "#fb6953"
-      } else if $in < 1day {
-        "#fce380"
-      } else if $in < 3day {
-        "#73d8ad"
-      } else if $in < 1wk {
-        { fg: "#73d8ad" attr: "b" }
-      } else if $in < 6wk {
-        "#3fb2b9"
-      } else if $in < 52wk {
-        "#46bddd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb6953" attr: "b" }
+        } else if $in < 6hr {
+            "#fb6953"
+        } else if $in < 1day {
+            "#fce380"
+        } else if $in < 3day {
+            "#73d8ad"
+        } else if $in < 1wk {
+            { fg: "#73d8ad" attr: "b" }
+        } else if $in < 6wk {
+            "#3fb2b9"
+        } else if $in < 52wk {
+            "#46bddd"
+        } else { "dark_gray" }
     }
     range: "#c7dbdd"
     float: "#c7dbdd"

--- a/themes/themes/silk-light.nu
+++ b/themes/themes/silk-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#329ca2" } else { "light_gray" } }
     int: "#385156"
     filesize: {|e|
-      if $e == 0b {
-        "#385156"
-      } else if $e < 1mb {
-        "#329ca2"
-      } else {{ fg: "#39aac9" }}
+        if $e == 0b {
+            "#385156"
+        } else if $e < 1mb {
+            "#329ca2"
+        } else {{ fg: "#39aac9" }}
     }
     duration: "#385156"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cf432e" attr: "b" }
-      } else if $in < 6hr {
-        "#cf432e"
-      } else if $in < 1day {
-        "#cfad25"
-      } else if $in < 3day {
-        "#6ca38c"
-      } else if $in < 1wk {
-        { fg: "#6ca38c" attr: "b" }
-      } else if $in < 6wk {
-        "#329ca2"
-      } else if $in < 52wk {
-        "#39aac9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cf432e" attr: "b" }
+        } else if $in < 6hr {
+            "#cf432e"
+        } else if $in < 1day {
+            "#cfad25"
+        } else if $in < 3day {
+            "#6ca38c"
+        } else if $in < 1wk {
+            { fg: "#6ca38c" attr: "b" }
+        } else if $in < 6wk {
+            "#329ca2"
+        } else if $in < 52wk {
+            "#39aac9"
+        } else { "dark_gray" }
     }
     range: "#385156"
     float: "#385156"

--- a/themes/themes/slate.nu
+++ b/themes/themes/slate.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8cdfe0" } else { "light_gray" } }
     int: "#02c5e0"
     filesize: {|e|
-      if $e == 0b {
-        "#02c5e0"
-      } else if $e < 1mb {
-        "#15ab9c"
-      } else {{ fg: "#264b49" }}
+        if $e == 0b {
+            "#02c5e0"
+        } else if $e < 1mb {
+            "#15ab9c"
+        } else {{ fg: "#264b49" }}
     }
     duration: "#02c5e0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e2a8bf" attr: "b" }
-      } else if $in < 6hr {
-        "#e2a8bf"
-      } else if $in < 1day {
-        "#c4c9c0"
-      } else if $in < 3day {
-        "#81d778"
-      } else if $in < 1wk {
-        { fg: "#81d778" attr: "b" }
-      } else if $in < 6wk {
-        "#15ab9c"
-      } else if $in < 52wk {
-        "#264b49"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e2a8bf" attr: "b" }
+        } else if $in < 6hr {
+            "#e2a8bf"
+        } else if $in < 1day {
+            "#c4c9c0"
+        } else if $in < 3day {
+            "#81d778"
+        } else if $in < 1wk {
+            { fg: "#81d778" attr: "b" }
+        } else if $in < 6wk {
+            "#15ab9c"
+        } else if $in < 52wk {
+            "#264b49"
+        } else { "dark_gray" }
     }
     range: "#02c5e0"
     float: "#02c5e0"

--- a/themes/themes/smyck.nu
+++ b/themes/themes/smyck.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#77dfd8" } else { "light_gray" } }
     int: "#b0b0b0"
     filesize: {|e|
-      if $e == 0b {
-        "#b0b0b0"
-      } else if $e < 1mb {
-        "#218693"
-      } else {{ fg: "#72b3cc" }}
+        if $e == 0b {
+            "#b0b0b0"
+        } else if $e < 1mb {
+            "#218693"
+        } else {{ fg: "#72b3cc" }}
     }
     duration: "#b0b0b0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c75646" attr: "b" }
-      } else if $in < 6hr {
-        "#c75646"
-      } else if $in < 1day {
-        "#d0b03c"
-      } else if $in < 3day {
-        "#8eb33b"
-      } else if $in < 1wk {
-        { fg: "#8eb33b" attr: "b" }
-      } else if $in < 6wk {
-        "#218693"
-      } else if $in < 52wk {
-        "#72b3cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c75646" attr: "b" }
+        } else if $in < 6hr {
+            "#c75646"
+        } else if $in < 1day {
+            "#d0b03c"
+        } else if $in < 3day {
+            "#8eb33b"
+        } else if $in < 1wk {
+            { fg: "#8eb33b" attr: "b" }
+        } else if $in < 6wk {
+            "#218693"
+        } else if $in < 52wk {
+            "#72b3cc"
+        } else { "dark_gray" }
     }
     range: "#b0b0b0"
     float: "#b0b0b0"

--- a/themes/themes/snazzy.nu
+++ b/themes/themes/snazzy.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#9aedfe" } else { "light_gray" } }
     int: "#e2e4e5"
     filesize: {|e|
-      if $e == 0b {
-        "#e2e4e5"
-      } else if $e < 1mb {
-        "#9aedfe"
-      } else {{ fg: "#57c7ff" }}
+        if $e == 0b {
+            "#e2e4e5"
+        } else if $e < 1mb {
+            "#9aedfe"
+        } else {{ fg: "#57c7ff" }}
     }
     duration: "#e2e4e5"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff5c57" attr: "b" }
-      } else if $in < 6hr {
-        "#ff5c57"
-      } else if $in < 1day {
-        "#f3f99d"
-      } else if $in < 3day {
-        "#5af78e"
-      } else if $in < 1wk {
-        { fg: "#5af78e" attr: "b" }
-      } else if $in < 6wk {
-        "#9aedfe"
-      } else if $in < 52wk {
-        "#57c7ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff5c57" attr: "b" }
+        } else if $in < 6hr {
+            "#ff5c57"
+        } else if $in < 1day {
+            "#f3f99d"
+        } else if $in < 3day {
+            "#5af78e"
+        } else if $in < 1wk {
+            { fg: "#5af78e" attr: "b" }
+        } else if $in < 6wk {
+            "#9aedfe"
+        } else if $in < 52wk {
+            "#57c7ff"
+        } else { "dark_gray" }
     }
     range: "#e2e4e5"
     float: "#e2e4e5"

--- a/themes/themes/snow-dark.nu
+++ b/themes/themes/snow-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5da19f" } else { "light_gray" } }
     int: "#afb7c0"
     filesize: {|e|
-      if $e == 0b {
-        "#afb7c0"
-      } else if $e < 1mb {
-        "#5da19f"
-      } else {{ fg: "#759abd" }}
+        if $e == 0b {
+            "#afb7c0"
+        } else if $e < 1mb {
+            "#5da19f"
+        } else {{ fg: "#759abd" }}
     }
     duration: "#afb7c0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#be868c" attr: "b" }
-      } else if $in < 6hr {
-        "#be868c"
-      } else if $in < 1day {
-        "#ab916d"
-      } else if $in < 3day {
-        "#7f9d77"
-      } else if $in < 1wk {
-        { fg: "#7f9d77" attr: "b" }
-      } else if $in < 6wk {
-        "#5da19f"
-      } else if $in < 52wk {
-        "#759abd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#be868c" attr: "b" }
+        } else if $in < 6hr {
+            "#be868c"
+        } else if $in < 1day {
+            "#ab916d"
+        } else if $in < 3day {
+            "#7f9d77"
+        } else if $in < 1wk {
+            { fg: "#7f9d77" attr: "b" }
+        } else if $in < 6wk {
+            "#5da19f"
+        } else if $in < 52wk {
+            "#759abd"
+        } else { "dark_gray" }
     }
     range: "#afb7c0"
     float: "#afb7c0"

--- a/themes/themes/snow-light.nu
+++ b/themes/themes/snow-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#008483" } else { "light_gray" } }
     int: "#535c65"
     filesize: {|e|
-      if $e == 0b {
-        "#535c65"
-      } else if $e < 1mb {
-        "#008483"
-      } else {{ fg: "#2b7ab2" }}
+        if $e == 0b {
+            "#535c65"
+        } else if $e < 1mb {
+            "#008483"
+        } else {{ fg: "#2b7ab2" }}
     }
     duration: "#535c65"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ae5865" attr: "b" }
-      } else if $in < 6hr {
-        "#ae5865"
-      } else if $in < 1day {
-        "#906c33"
-      } else if $in < 3day {
-        "#4d7f43"
-      } else if $in < 1wk {
-        { fg: "#4d7f43" attr: "b" }
-      } else if $in < 6wk {
-        "#008483"
-      } else if $in < 52wk {
-        "#2b7ab2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ae5865" attr: "b" }
+        } else if $in < 6hr {
+            "#ae5865"
+        } else if $in < 1day {
+            "#906c33"
+        } else if $in < 3day {
+            "#4d7f43"
+        } else if $in < 1wk {
+            { fg: "#4d7f43" attr: "b" }
+        } else if $in < 6wk {
+            "#008483"
+        } else if $in < 52wk {
+            "#2b7ab2"
+        } else { "dark_gray" }
     }
     range: "#535c65"
     float: "#535c65"

--- a/themes/themes/soft-server.nu
+++ b/themes/themes/soft-server.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#64e39c" } else { "light_gray" } }
     int: "#99a3a2"
     filesize: {|e|
-      if $e == 0b {
-        "#99a3a2"
-      } else if $e < 1mb {
-        "#6ba58f"
-      } else {{ fg: "#6b8fa3" }}
+        if $e == 0b {
+            "#99a3a2"
+        } else if $e < 1mb {
+            "#6ba58f"
+        } else {{ fg: "#6b8fa3" }}
     }
     duration: "#99a3a2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a2686a" attr: "b" }
-      } else if $in < 6hr {
-        "#a2686a"
-      } else if $in < 1day {
-        "#a3906a"
-      } else if $in < 3day {
-        "#9aa56a"
-      } else if $in < 1wk {
-        { fg: "#9aa56a" attr: "b" }
-      } else if $in < 6wk {
-        "#6ba58f"
-      } else if $in < 52wk {
-        "#6b8fa3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a2686a" attr: "b" }
+        } else if $in < 6hr {
+            "#a2686a"
+        } else if $in < 1day {
+            "#a3906a"
+        } else if $in < 3day {
+            "#9aa56a"
+        } else if $in < 1wk {
+            { fg: "#9aa56a" attr: "b" }
+        } else if $in < 6wk {
+            "#6ba58f"
+        } else if $in < 52wk {
+            "#6b8fa3"
+        } else { "dark_gray" }
     }
     range: "#99a3a2"
     float: "#99a3a2"

--- a/themes/themes/solar-flare.nu
+++ b/themes/themes/solar-flare.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#52CBB0" } else { "light_gray" } }
     int: "#A6AFB8"
     filesize: {|e|
-      if $e == 0b {
-        "#A6AFB8"
-      } else if $e < 1mb {
-        "#52CBB0"
-      } else {{ fg: "#33B5E1" }}
+        if $e == 0b {
+            "#A6AFB8"
+        } else if $e < 1mb {
+            "#52CBB0"
+        } else {{ fg: "#33B5E1" }}
     }
     duration: "#A6AFB8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#EF5253" attr: "b" }
-      } else if $in < 6hr {
-        "#EF5253"
-      } else if $in < 1day {
-        "#E4B51C"
-      } else if $in < 3day {
-        "#7CC844"
-      } else if $in < 1wk {
-        { fg: "#7CC844" attr: "b" }
-      } else if $in < 6wk {
-        "#52CBB0"
-      } else if $in < 52wk {
-        "#33B5E1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#EF5253" attr: "b" }
+        } else if $in < 6hr {
+            "#EF5253"
+        } else if $in < 1day {
+            "#E4B51C"
+        } else if $in < 3day {
+            "#7CC844"
+        } else if $in < 1wk {
+            { fg: "#7CC844" attr: "b" }
+        } else if $in < 6wk {
+            "#52CBB0"
+        } else if $in < 52wk {
+            "#33B5E1"
+        } else { "dark_gray" }
     }
     range: "#A6AFB8"
     float: "#A6AFB8"

--- a/themes/themes/solarflare-light.nu
+++ b/themes/themes/solarflare-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#52cbb0" } else { "light_gray" } }
     int: "#586875"
     filesize: {|e|
-      if $e == 0b {
-        "#586875"
-      } else if $e < 1mb {
-        "#52cbb0"
-      } else {{ fg: "#33b5e1" }}
+        if $e == 0b {
+            "#586875"
+        } else if $e < 1mb {
+            "#52cbb0"
+        } else {{ fg: "#33b5e1" }}
     }
     duration: "#586875"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ef5253" attr: "b" }
-      } else if $in < 6hr {
-        "#ef5253"
-      } else if $in < 1day {
-        "#e4b51c"
-      } else if $in < 3day {
-        "#7cc844"
-      } else if $in < 1wk {
-        { fg: "#7cc844" attr: "b" }
-      } else if $in < 6wk {
-        "#52cbb0"
-      } else if $in < 52wk {
-        "#33b5e1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ef5253" attr: "b" }
+        } else if $in < 6hr {
+            "#ef5253"
+        } else if $in < 1day {
+            "#e4b51c"
+        } else if $in < 3day {
+            "#7cc844"
+        } else if $in < 1wk {
+            { fg: "#7cc844" attr: "b" }
+        } else if $in < 6wk {
+            "#52cbb0"
+        } else if $in < 52wk {
+            "#33b5e1"
+        } else { "dark_gray" }
     }
     range: "#586875"
     float: "#586875"

--- a/themes/themes/solarflare.nu
+++ b/themes/themes/solarflare.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#52cbb0" } else { "light_gray" } }
     int: "#a6afb8"
     filesize: {|e|
-      if $e == 0b {
-        "#a6afb8"
-      } else if $e < 1mb {
-        "#52cbb0"
-      } else {{ fg: "#33b5e1" }}
+        if $e == 0b {
+            "#a6afb8"
+        } else if $e < 1mb {
+            "#52cbb0"
+        } else {{ fg: "#33b5e1" }}
     }
     duration: "#a6afb8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ef5253" attr: "b" }
-      } else if $in < 6hr {
-        "#ef5253"
-      } else if $in < 1day {
-        "#e4b51c"
-      } else if $in < 3day {
-        "#7cc844"
-      } else if $in < 1wk {
-        { fg: "#7cc844" attr: "b" }
-      } else if $in < 6wk {
-        "#52cbb0"
-      } else if $in < 52wk {
-        "#33b5e1"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ef5253" attr: "b" }
+        } else if $in < 6hr {
+            "#ef5253"
+        } else if $in < 1day {
+            "#e4b51c"
+        } else if $in < 3day {
+            "#7cc844"
+        } else if $in < 1wk {
+            { fg: "#7cc844" attr: "b" }
+        } else if $in < 6wk {
+            "#52cbb0"
+        } else if $in < 52wk {
+            "#33b5e1"
+        } else { "dark_gray" }
     }
     range: "#a6afb8"
     float: "#a6afb8"

--- a/themes/themes/solarized-darcula.nu
+++ b/themes/themes/solarized-darcula.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#15968d" } else { "light_gray" } }
     int: "#d2d8d9"
     filesize: {|e|
-      if $e == 0b {
-        "#d2d8d9"
-      } else if $e < 1mb {
-        "#15968d"
-      } else {{ fg: "#2075c7" }}
+        if $e == 0b {
+            "#d2d8d9"
+        } else if $e < 1mb {
+            "#15968d"
+        } else {{ fg: "#2075c7" }}
     }
     duration: "#d2d8d9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f24840" attr: "b" }
-      } else if $in < 6hr {
-        "#f24840"
-      } else if $in < 1day {
-        "#b68800"
-      } else if $in < 3day {
-        "#629655"
-      } else if $in < 1wk {
-        { fg: "#629655" attr: "b" }
-      } else if $in < 6wk {
-        "#15968d"
-      } else if $in < 52wk {
-        "#2075c7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f24840" attr: "b" }
+        } else if $in < 6hr {
+            "#f24840"
+        } else if $in < 1day {
+            "#b68800"
+        } else if $in < 3day {
+            "#629655"
+        } else if $in < 1wk {
+            { fg: "#629655" attr: "b" }
+        } else if $in < 6wk {
+            "#15968d"
+        } else if $in < 52wk {
+            "#2075c7"
+        } else { "dark_gray" }
     }
     range: "#d2d8d9"
     float: "#d2d8d9"

--- a/themes/themes/solarized-dark-higher-contrast.nu
+++ b/themes/themes/solarized-dark-higher-contrast.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00b39e" } else { "light_gray" } }
     int: "#eae3cb"
     filesize: {|e|
-      if $e == 0b {
-        "#eae3cb"
-      } else if $e < 1mb {
-        "#259286"
-      } else {{ fg: "#2176c7" }}
+        if $e == 0b {
+            "#eae3cb"
+        } else if $e < 1mb {
+            "#259286"
+        } else {{ fg: "#2176c7" }}
     }
     duration: "#eae3cb"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d11c24" attr: "b" }
-      } else if $in < 6hr {
-        "#d11c24"
-      } else if $in < 1day {
-        "#a57706"
-      } else if $in < 3day {
-        "#6cbe6c"
-      } else if $in < 1wk {
-        { fg: "#6cbe6c" attr: "b" }
-      } else if $in < 6wk {
-        "#259286"
-      } else if $in < 52wk {
-        "#2176c7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d11c24" attr: "b" }
+        } else if $in < 6hr {
+            "#d11c24"
+        } else if $in < 1day {
+            "#a57706"
+        } else if $in < 3day {
+            "#6cbe6c"
+        } else if $in < 1wk {
+            { fg: "#6cbe6c" attr: "b" }
+        } else if $in < 6wk {
+            "#259286"
+        } else if $in < 52wk {
+            "#2176c7"
+        } else { "dark_gray" }
     }
     range: "#eae3cb"
     float: "#eae3cb"

--- a/themes/themes/solarized-dark.nu
+++ b/themes/themes/solarized-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2aa198" } else { "light_gray" } }
     int: "#93a1a1"
     filesize: {|e|
-      if $e == 0b {
-        "#93a1a1"
-      } else if $e < 1mb {
-        "#2aa198"
-      } else {{ fg: "#268bd2" }}
+        if $e == 0b {
+            "#93a1a1"
+        } else if $e < 1mb {
+            "#2aa198"
+        } else {{ fg: "#268bd2" }}
     }
     duration: "#93a1a1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dc322f" attr: "b" }
-      } else if $in < 6hr {
-        "#dc322f"
-      } else if $in < 1day {
-        "#b58900"
-      } else if $in < 3day {
-        "#859900"
-      } else if $in < 1wk {
-        { fg: "#859900" attr: "b" }
-      } else if $in < 6wk {
-        "#2aa198"
-      } else if $in < 52wk {
-        "#268bd2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dc322f" attr: "b" }
+        } else if $in < 6hr {
+            "#dc322f"
+        } else if $in < 1day {
+            "#b58900"
+        } else if $in < 3day {
+            "#859900"
+        } else if $in < 1wk {
+            { fg: "#859900" attr: "b" }
+        } else if $in < 6wk {
+            "#2aa198"
+        } else if $in < 52wk {
+            "#268bd2"
+        } else { "dark_gray" }
     }
     range: "#93a1a1"
     float: "#93a1a1"

--- a/themes/themes/solarized-light.nu
+++ b/themes/themes/solarized-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2aa198" } else { "light_gray" } }
     int: "#586e75"
     filesize: {|e|
-      if $e == 0b {
-        "#586e75"
-      } else if $e < 1mb {
-        "#2aa198"
-      } else {{ fg: "#268bd2" }}
+        if $e == 0b {
+            "#586e75"
+        } else if $e < 1mb {
+            "#2aa198"
+        } else {{ fg: "#268bd2" }}
     }
     duration: "#586e75"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dc322f" attr: "b" }
-      } else if $in < 6hr {
-        "#dc322f"
-      } else if $in < 1day {
-        "#b58900"
-      } else if $in < 3day {
-        "#859900"
-      } else if $in < 1wk {
-        { fg: "#859900" attr: "b" }
-      } else if $in < 6wk {
-        "#2aa198"
-      } else if $in < 52wk {
-        "#268bd2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dc322f" attr: "b" }
+        } else if $in < 6hr {
+            "#dc322f"
+        } else if $in < 1day {
+            "#b58900"
+        } else if $in < 3day {
+            "#859900"
+        } else if $in < 1wk {
+            { fg: "#859900" attr: "b" }
+        } else if $in < 6wk {
+            "#2aa198"
+        } else if $in < 52wk {
+            "#268bd2"
+        } else { "dark_gray" }
     }
     range: "#586e75"
     float: "#586e75"

--- a/themes/themes/source-code-x.nu
+++ b/themes/themes/source-code-x.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#83d2c0" } else { "light_gray" } }
     int: "#bfbfbf"
     filesize: {|e|
-      if $e == 0b {
-        "#bfbfbf"
-      } else if $e < 1mb {
-        "#79c8b6"
-      } else {{ fg: "#9586f4" }}
+        if $e == 0b {
+            "#bfbfbf"
+        } else if $e < 1mb {
+            "#79c8b6"
+        } else {{ fg: "#9586f4" }}
     }
     duration: "#bfbfbf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb695d" attr: "b" }
-      } else if $in < 6hr {
-        "#fb695d"
-      } else if $in < 1day {
-        "#fc8e3e"
-      } else if $in < 3day {
-        "#74b391"
-      } else if $in < 1wk {
-        { fg: "#74b391" attr: "b" }
-      } else if $in < 6wk {
-        "#79c8b6"
-      } else if $in < 52wk {
-        "#9586f4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb695d" attr: "b" }
+        } else if $in < 6hr {
+            "#fb695d"
+        } else if $in < 1day {
+            "#fc8e3e"
+        } else if $in < 3day {
+            "#74b391"
+        } else if $in < 1wk {
+            { fg: "#74b391" attr: "b" }
+        } else if $in < 6wk {
+            "#79c8b6"
+        } else if $in < 52wk {
+            "#9586f4"
+        } else { "dark_gray" }
     }
     range: "#bfbfbf"
     float: "#bfbfbf"

--- a/themes/themes/sourcerer.nu
+++ b/themes/themes/sourcerer.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#87ceeb" } else { "light_gray" } }
     int: "#d3d3d3"
     filesize: {|e|
-      if $e == 0b {
-        "#d3d3d3"
-      } else if $e < 1mb {
-        "#528b8b"
-      } else {{ fg: "#6688aa" }}
+        if $e == 0b {
+            "#d3d3d3"
+        } else if $e < 1mb {
+            "#528b8b"
+        } else {{ fg: "#6688aa" }}
     }
     duration: "#d3d3d3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#aa4450" attr: "b" }
-      } else if $in < 6hr {
-        "#aa4450"
-      } else if $in < 1day {
-        "#ff9800"
-      } else if $in < 3day {
-        "#719611"
-      } else if $in < 1wk {
-        { fg: "#719611" attr: "b" }
-      } else if $in < 6wk {
-        "#528b8b"
-      } else if $in < 52wk {
-        "#6688aa"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#aa4450" attr: "b" }
+        } else if $in < 6hr {
+            "#aa4450"
+        } else if $in < 1day {
+            "#ff9800"
+        } else if $in < 3day {
+            "#719611"
+        } else if $in < 1wk {
+            { fg: "#719611" attr: "b" }
+        } else if $in < 6wk {
+            "#528b8b"
+        } else if $in < 52wk {
+            "#6688aa"
+        } else { "dark_gray" }
     }
     range: "#d3d3d3"
     float: "#d3d3d3"

--- a/themes/themes/sourcerer2.nu
+++ b/themes/themes/sourcerer2.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#87ceeb" } else { "light_gray" } }
     int: "#d3d3d3"
     filesize: {|e|
-      if $e == 0b {
-        "#d3d3d3"
-      } else if $e < 1mb {
-        "#528b8b"
-      } else {{ fg: "#6688aa" }}
+        if $e == 0b {
+            "#d3d3d3"
+        } else if $e < 1mb {
+            "#528b8b"
+        } else {{ fg: "#6688aa" }}
     }
     duration: "#d3d3d3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#aa4450" attr: "b" }
-      } else if $in < 6hr {
-        "#aa4450"
-      } else if $in < 1day {
-        "#ff9800"
-      } else if $in < 3day {
-        "#719611"
-      } else if $in < 1wk {
-        { fg: "#719611" attr: "b" }
-      } else if $in < 6wk {
-        "#528b8b"
-      } else if $in < 52wk {
-        "#6688aa"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#aa4450" attr: "b" }
+        } else if $in < 6hr {
+            "#aa4450"
+        } else if $in < 1day {
+            "#ff9800"
+        } else if $in < 3day {
+            "#719611"
+        } else if $in < 1wk {
+            { fg: "#719611" attr: "b" }
+        } else if $in < 6wk {
+            "#528b8b"
+        } else if $in < 52wk {
+            "#6688aa"
+        } else { "dark_gray" }
     }
     range: "#d3d3d3"
     float: "#d3d3d3"

--- a/themes/themes/spaceduck.nu
+++ b/themes/themes/spaceduck.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7a5ccc" } else { "light_gray" } }
     int: "#686f9a"
     filesize: {|e|
-      if $e == 0b {
-        "#686f9a"
-      } else if $e < 1mb {
-        "#7a5ccc"
-      } else {{ fg: "#00a3cc" }}
+        if $e == 0b {
+            "#686f9a"
+        } else if $e < 1mb {
+            "#7a5ccc"
+        } else {{ fg: "#00a3cc" }}
     }
     duration: "#686f9a"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e33400" attr: "b" }
-      } else if $in < 6hr {
-        "#e33400"
-      } else if $in < 1day {
-        "#b3a1e6"
-      } else if $in < 3day {
-        "#5ccc96"
-      } else if $in < 1wk {
-        { fg: "#5ccc96" attr: "b" }
-      } else if $in < 6wk {
-        "#7a5ccc"
-      } else if $in < 52wk {
-        "#00a3cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e33400" attr: "b" }
+        } else if $in < 6hr {
+            "#e33400"
+        } else if $in < 1day {
+            "#b3a1e6"
+        } else if $in < 3day {
+            "#5ccc96"
+        } else if $in < 1wk {
+            { fg: "#5ccc96" attr: "b" }
+        } else if $in < 6wk {
+            "#7a5ccc"
+        } else if $in < 52wk {
+            "#00a3cc"
+        } else { "dark_gray" }
     }
     range: "#686f9a"
     float: "#686f9a"

--- a/themes/themes/spacedust.nu
+++ b/themes/themes/spacedust.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#83a7b4" } else { "light_gray" } }
     int: "#f0f1ce"
     filesize: {|e|
-      if $e == 0b {
-        "#f0f1ce"
-      } else if $e < 1mb {
-        "#06afc7"
-      } else {{ fg: "#0f548b" }}
+        if $e == 0b {
+            "#f0f1ce"
+        } else if $e < 1mb {
+            "#06afc7"
+        } else {{ fg: "#0f548b" }}
     }
     duration: "#f0f1ce"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e35b00" attr: "b" }
-      } else if $in < 6hr {
-        "#e35b00"
-      } else if $in < 1day {
-        "#e3cd7b"
-      } else if $in < 3day {
-        "#5cab96"
-      } else if $in < 1wk {
-        { fg: "#5cab96" attr: "b" }
-      } else if $in < 6wk {
-        "#06afc7"
-      } else if $in < 52wk {
-        "#0f548b"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e35b00" attr: "b" }
+        } else if $in < 6hr {
+            "#e35b00"
+        } else if $in < 1day {
+            "#e3cd7b"
+        } else if $in < 3day {
+            "#5cab96"
+        } else if $in < 1wk {
+            { fg: "#5cab96" attr: "b" }
+        } else if $in < 6wk {
+            "#06afc7"
+        } else if $in < 52wk {
+            "#0f548b"
+        } else { "dark_gray" }
     }
     range: "#f0f1ce"
     float: "#f0f1ce"

--- a/themes/themes/spacegray-eighties-dull.nu
+++ b/themes/themes/spacegray-eighties-dull.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#58c2c1" } else { "light_gray" } }
     int: "#b3b8c3"
     filesize: {|e|
-      if $e == 0b {
-        "#b3b8c3"
-      } else if $e < 1mb {
-        "#80cdcb"
-      } else {{ fg: "#7c8fa5" }}
+        if $e == 0b {
+            "#b3b8c3"
+        } else if $e < 1mb {
+            "#80cdcb"
+        } else {{ fg: "#7c8fa5" }}
     }
     duration: "#b3b8c3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b24a56" attr: "b" }
-      } else if $in < 6hr {
-        "#b24a56"
-      } else if $in < 1day {
-        "#c6735a"
-      } else if $in < 3day {
-        "#92b477"
-      } else if $in < 1wk {
-        { fg: "#92b477" attr: "b" }
-      } else if $in < 6wk {
-        "#80cdcb"
-      } else if $in < 52wk {
-        "#7c8fa5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b24a56" attr: "b" }
+        } else if $in < 6hr {
+            "#b24a56"
+        } else if $in < 1day {
+            "#c6735a"
+        } else if $in < 3day {
+            "#92b477"
+        } else if $in < 1wk {
+            { fg: "#92b477" attr: "b" }
+        } else if $in < 6wk {
+            "#80cdcb"
+        } else if $in < 52wk {
+            "#7c8fa5"
+        } else { "dark_gray" }
     }
     range: "#b3b8c3"
     float: "#b3b8c3"

--- a/themes/themes/spacegray-eighties.nu
+++ b/themes/themes/spacegray-eighties.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#83e9e4" } else { "light_gray" } }
     int: "#efece7"
     filesize: {|e|
-      if $e == 0b {
-        "#efece7"
-      } else if $e < 1mb {
-        "#57c2c1"
-      } else {{ fg: "#5486c0" }}
+        if $e == 0b {
+            "#efece7"
+        } else if $e < 1mb {
+            "#57c2c1"
+        } else {{ fg: "#5486c0" }}
     }
     duration: "#efece7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ec5f67" attr: "b" }
-      } else if $in < 6hr {
-        "#ec5f67"
-      } else if $in < 1day {
-        "#fec254"
-      } else if $in < 3day {
-        "#81a764"
-      } else if $in < 1wk {
-        { fg: "#81a764" attr: "b" }
-      } else if $in < 6wk {
-        "#57c2c1"
-      } else if $in < 52wk {
-        "#5486c0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ec5f67" attr: "b" }
+        } else if $in < 6hr {
+            "#ec5f67"
+        } else if $in < 1day {
+            "#fec254"
+        } else if $in < 3day {
+            "#81a764"
+        } else if $in < 1wk {
+            { fg: "#81a764" attr: "b" }
+        } else if $in < 6wk {
+            "#57c2c1"
+        } else if $in < 52wk {
+            "#5486c0"
+        } else { "dark_gray" }
     }
     range: "#efece7"
     float: "#efece7"

--- a/themes/themes/spacegray.nu
+++ b/themes/themes/spacegray.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#85a7a5" } else { "light_gray" } }
     int: "#b3b8c3"
     filesize: {|e|
-      if $e == 0b {
-        "#b3b8c3"
-      } else if $e < 1mb {
-        "#85a7a5"
-      } else {{ fg: "#7d8fa4" }}
+        if $e == 0b {
+            "#b3b8c3"
+        } else if $e < 1mb {
+            "#85a7a5"
+        } else {{ fg: "#7d8fa4" }}
     }
     duration: "#b3b8c3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b04b57" attr: "b" }
-      } else if $in < 6hr {
-        "#b04b57"
-      } else if $in < 1day {
-        "#e5c179"
-      } else if $in < 3day {
-        "#87b379"
-      } else if $in < 1wk {
-        { fg: "#87b379" attr: "b" }
-      } else if $in < 6wk {
-        "#85a7a5"
-      } else if $in < 52wk {
-        "#7d8fa4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b04b57" attr: "b" }
+        } else if $in < 6hr {
+            "#b04b57"
+        } else if $in < 1day {
+            "#e5c179"
+        } else if $in < 3day {
+            "#87b379"
+        } else if $in < 1wk {
+            { fg: "#87b379" attr: "b" }
+        } else if $in < 6wk {
+            "#85a7a5"
+        } else if $in < 52wk {
+            "#7d8fa4"
+        } else { "dark_gray" }
     }
     range: "#b3b8c3"
     float: "#b3b8c3"

--- a/themes/themes/spacemacs.nu
+++ b/themes/themes/spacemacs.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2d9574" } else { "light_gray" } }
     int: "#a3a3a3"
     filesize: {|e|
-      if $e == 0b {
-        "#a3a3a3"
-      } else if $e < 1mb {
-        "#2d9574"
-      } else {{ fg: "#4f97d7" }}
+        if $e == 0b {
+            "#a3a3a3"
+        } else if $e < 1mb {
+            "#2d9574"
+        } else {{ fg: "#4f97d7" }}
     }
     duration: "#a3a3a3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f2241f" attr: "b" }
-      } else if $in < 6hr {
-        "#f2241f"
-      } else if $in < 1day {
-        "#b1951d"
-      } else if $in < 3day {
-        "#67b11d"
-      } else if $in < 1wk {
-        { fg: "#67b11d" attr: "b" }
-      } else if $in < 6wk {
-        "#2d9574"
-      } else if $in < 52wk {
-        "#4f97d7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f2241f" attr: "b" }
+        } else if $in < 6hr {
+            "#f2241f"
+        } else if $in < 1day {
+            "#b1951d"
+        } else if $in < 3day {
+            "#67b11d"
+        } else if $in < 1wk {
+            { fg: "#67b11d" attr: "b" }
+        } else if $in < 6wk {
+            "#2d9574"
+        } else if $in < 52wk {
+            "#4f97d7"
+        } else { "dark_gray" }
     }
     range: "#a3a3a3"
     float: "#a3a3a3"

--- a/themes/themes/spiderman.nu
+++ b/themes/themes/spiderman.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#6083ff" } else { "light_gray" } }
     int: "#fffef6"
     filesize: {|e|
-      if $e == 0b {
-        "#fffef6"
-      } else if $e < 1mb {
-        "#3255ff"
-      } else {{ fg: "#2b3fff" }}
+        if $e == 0b {
+            "#fffef6"
+        } else if $e < 1mb {
+            "#3255ff"
+        } else {{ fg: "#2b3fff" }}
     }
     duration: "#fffef6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e60712" attr: "b" }
-      } else if $in < 6hr {
-        "#e60712"
-      } else if $in < 1day {
-        "#e24655"
-      } else if $in < 3day {
-        "#e22828"
-      } else if $in < 1wk {
-        { fg: "#e22828" attr: "b" }
-      } else if $in < 6wk {
-        "#3255ff"
-      } else if $in < 52wk {
-        "#2b3fff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e60712" attr: "b" }
+        } else if $in < 6hr {
+            "#e60712"
+        } else if $in < 1day {
+            "#e24655"
+        } else if $in < 3day {
+            "#e22828"
+        } else if $in < 1wk {
+            { fg: "#e22828" attr: "b" }
+        } else if $in < 6wk {
+            "#3255ff"
+        } else if $in < 52wk {
+            "#2b3fff"
+        } else { "dark_gray" }
     }
     range: "#fffef6"
     float: "#fffef6"

--- a/themes/themes/spring.nu
+++ b/themes/themes/spring.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3e999f" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#3e999f"
-      } else {{ fg: "#1dd3ee" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#3e999f"
+        } else {{ fg: "#1dd3ee" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff4d83" attr: "b" }
-      } else if $in < 6hr {
-        "#ff4d83"
-      } else if $in < 1day {
-        "#1fc95b"
-      } else if $in < 3day {
-        "#1f8c3b"
-      } else if $in < 1wk {
-        { fg: "#1f8c3b" attr: "b" }
-      } else if $in < 6wk {
-        "#3e999f"
-      } else if $in < 52wk {
-        "#1dd3ee"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff4d83" attr: "b" }
+        } else if $in < 6hr {
+            "#ff4d83"
+        } else if $in < 1day {
+            "#1fc95b"
+        } else if $in < 3day {
+            "#1f8c3b"
+        } else if $in < 1wk {
+            { fg: "#1f8c3b" attr: "b" }
+        } else if $in < 6wk {
+            "#3e999f"
+        } else if $in < 52wk {
+            "#1dd3ee"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/square.nu
+++ b/themes/themes/square.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#d7d9fc" } else { "light_gray" } }
     int: "#f2f2f2"
     filesize: {|e|
-      if $e == 0b {
-        "#f2f2f2"
-      } else if $e < 1mb {
-        "#c9caec"
-      } else {{ fg: "#a9cdeb" }}
+        if $e == 0b {
+            "#f2f2f2"
+        } else if $e < 1mb {
+            "#c9caec"
+        } else {{ fg: "#a9cdeb" }}
     }
     duration: "#f2f2f2"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e9897c" attr: "b" }
-      } else if $in < 6hr {
-        "#e9897c"
-      } else if $in < 1day {
-        "#ecebbe"
-      } else if $in < 3day {
-        "#b6377d"
-      } else if $in < 1wk {
-        { fg: "#b6377d" attr: "b" }
-      } else if $in < 6wk {
-        "#c9caec"
-      } else if $in < 52wk {
-        "#a9cdeb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e9897c" attr: "b" }
+        } else if $in < 6hr {
+            "#e9897c"
+        } else if $in < 1day {
+            "#ecebbe"
+        } else if $in < 3day {
+            "#b6377d"
+        } else if $in < 1wk {
+            { fg: "#b6377d" attr: "b" }
+        } else if $in < 6wk {
+            "#c9caec"
+        } else if $in < 52wk {
+            "#a9cdeb"
+        } else { "dark_gray" }
     }
     range: "#f2f2f2"
     float: "#f2f2f2"

--- a/themes/themes/srcery.nu
+++ b/themes/themes/srcery.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2be4d0" } else { "light_gray" } }
     int: "#baa67f"
     filesize: {|e|
-      if $e == 0b {
-        "#baa67f"
-      } else if $e < 1mb {
-        "#0aaeb3"
-      } else {{ fg: "#2c78bf" }}
+        if $e == 0b {
+            "#baa67f"
+        } else if $e < 1mb {
+            "#0aaeb3"
+        } else {{ fg: "#2c78bf" }}
     }
     duration: "#baa67f"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ef2f27" attr: "b" }
-      } else if $in < 6hr {
-        "#ef2f27"
-      } else if $in < 1day {
-        "#fbb829"
-      } else if $in < 3day {
-        "#519f50"
-      } else if $in < 1wk {
-        { fg: "#519f50" attr: "b" }
-      } else if $in < 6wk {
-        "#0aaeb3"
-      } else if $in < 52wk {
-        "#2c78bf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ef2f27" attr: "b" }
+        } else if $in < 6hr {
+            "#ef2f27"
+        } else if $in < 1day {
+            "#fbb829"
+        } else if $in < 3day {
+            "#519f50"
+        } else if $in < 1wk {
+            { fg: "#519f50" attr: "b" }
+        } else if $in < 6wk {
+            "#0aaeb3"
+        } else if $in < 52wk {
+            "#2c78bf"
+        } else { "dark_gray" }
     }
     range: "#baa67f"
     float: "#baa67f"

--- a/themes/themes/substrata.nu
+++ b/themes/themes/substrata.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7dc2c7" } else { "light_gray" } }
     int: "#b5b4c9"
     filesize: {|e|
-      if $e == 0b {
-        "#b5b4c9"
-      } else if $e < 1mb {
-        "#659ea2"
-      } else {{ fg: "#8296b0" }}
+        if $e == 0b {
+            "#b5b4c9"
+        } else if $e < 1mb {
+            "#659ea2"
+        } else {{ fg: "#8296b0" }}
     }
     duration: "#b5b4c9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cf8164" attr: "b" }
-      } else if $in < 6hr {
-        "#cf8164"
-      } else if $in < 1day {
-        "#ab924c"
-      } else if $in < 3day {
-        "#76a065"
-      } else if $in < 1wk {
-        { fg: "#76a065" attr: "b" }
-      } else if $in < 6wk {
-        "#659ea2"
-      } else if $in < 52wk {
-        "#8296b0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cf8164" attr: "b" }
+        } else if $in < 6hr {
+            "#cf8164"
+        } else if $in < 1day {
+            "#ab924c"
+        } else if $in < 3day {
+            "#76a065"
+        } else if $in < 1wk {
+            { fg: "#76a065" attr: "b" }
+        } else if $in < 6wk {
+            "#659ea2"
+        } else if $in < 52wk {
+            "#8296b0"
+        } else { "dark_gray" }
     }
     range: "#b5b4c9"
     float: "#b5b4c9"

--- a/themes/themes/summercamp.nu
+++ b/themes/themes/summercamp.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5aebbc" } else { "light_gray" } }
     int: "#736e55"
     filesize: {|e|
-      if $e == 0b {
-        "#736e55"
-      } else if $e < 1mb {
-        "#5aebbc"
-      } else {{ fg: "#489bf0" }}
+        if $e == 0b {
+            "#736e55"
+        } else if $e < 1mb {
+            "#5aebbc"
+        } else {{ fg: "#489bf0" }}
     }
     duration: "#736e55"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e35142" attr: "b" }
-      } else if $in < 6hr {
-        "#e35142"
-      } else if $in < 1day {
-        "#f2ff27"
-      } else if $in < 3day {
-        "#5ceb5a"
-      } else if $in < 1wk {
-        { fg: "#5ceb5a" attr: "b" }
-      } else if $in < 6wk {
-        "#5aebbc"
-      } else if $in < 52wk {
-        "#489bf0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e35142" attr: "b" }
+        } else if $in < 6hr {
+            "#e35142"
+        } else if $in < 1day {
+            "#f2ff27"
+        } else if $in < 3day {
+            "#5ceb5a"
+        } else if $in < 1wk {
+            { fg: "#5ceb5a" attr: "b" }
+        } else if $in < 6wk {
+            "#5aebbc"
+        } else if $in < 52wk {
+            "#489bf0"
+        } else { "dark_gray" }
     }
     range: "#736e55"
     float: "#736e55"

--- a/themes/themes/summerfruit-dark.nu
+++ b/themes/themes/summerfruit-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1faaaa" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#1faaaa"
-      } else {{ fg: "#3777e6" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#1faaaa"
+        } else {{ fg: "#3777e6" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0086" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0086"
-      } else if $in < 1day {
-        "#aba800"
-      } else if $in < 3day {
-        "#00c918"
-      } else if $in < 1wk {
-        { fg: "#00c918" attr: "b" }
-      } else if $in < 6wk {
-        "#1faaaa"
-      } else if $in < 52wk {
-        "#3777e6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0086" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0086"
+        } else if $in < 1day {
+            "#aba800"
+        } else if $in < 3day {
+            "#00c918"
+        } else if $in < 1wk {
+            { fg: "#00c918" attr: "b" }
+        } else if $in < 6wk {
+            "#1faaaa"
+        } else if $in < 52wk {
+            "#3777e6"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/summerfruit-light.nu
+++ b/themes/themes/summerfruit-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1faaaa" } else { "light_gray" } }
     int: "#101010"
     filesize: {|e|
-      if $e == 0b {
-        "#101010"
-      } else if $e < 1mb {
-        "#1faaaa"
-      } else {{ fg: "#3777e6" }}
+        if $e == 0b {
+            "#101010"
+        } else if $e < 1mb {
+            "#1faaaa"
+        } else {{ fg: "#3777e6" }}
     }
     duration: "#101010"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0086" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0086"
-      } else if $in < 1day {
-        "#aba800"
-      } else if $in < 3day {
-        "#00c918"
-      } else if $in < 1wk {
-        { fg: "#00c918" attr: "b" }
-      } else if $in < 6wk {
-        "#1faaaa"
-      } else if $in < 52wk {
-        "#3777e6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0086" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0086"
+        } else if $in < 1day {
+            "#aba800"
+        } else if $in < 3day {
+            "#00c918"
+        } else if $in < 1wk {
+            { fg: "#00c918" attr: "b" }
+        } else if $in < 6wk {
+            "#1faaaa"
+        } else if $in < 52wk {
+            "#3777e6"
+        } else { "dark_gray" }
     }
     range: "#101010"
     float: "#101010"

--- a/themes/themes/sundried.nu
+++ b/themes/themes/sundried.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#fad484" } else { "light_gray" } }
     int: "#c9c9c9"
     filesize: {|e|
-      if $e == 0b {
-        "#c9c9c9"
-      } else if $e < 1mb {
-        "#9c814f"
-      } else {{ fg: "#485b98" }}
+        if $e == 0b {
+            "#c9c9c9"
+        } else if $e < 1mb {
+            "#9c814f"
+        } else {{ fg: "#485b98" }}
     }
     duration: "#c9c9c9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a7463d" attr: "b" }
-      } else if $in < 6hr {
-        "#a7463d"
-      } else if $in < 1day {
-        "#9d602a"
-      } else if $in < 3day {
-        "#587744"
-      } else if $in < 1wk {
-        { fg: "#587744" attr: "b" }
-      } else if $in < 6wk {
-        "#9c814f"
-      } else if $in < 52wk {
-        "#485b98"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a7463d" attr: "b" }
+        } else if $in < 6hr {
+            "#a7463d"
+        } else if $in < 1day {
+            "#9d602a"
+        } else if $in < 3day {
+            "#587744"
+        } else if $in < 1wk {
+            { fg: "#587744" attr: "b" }
+        } else if $in < 6wk {
+            "#9c814f"
+        } else if $in < 52wk {
+            "#485b98"
+        } else { "dark_gray" }
     }
     range: "#c9c9c9"
     float: "#c9c9c9"

--- a/themes/themes/symphonic.nu
+++ b/themes/themes/symphonic.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ccccff" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#ccccff"
-      } else {{ fg: "#0084d4" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#ccccff"
+        } else {{ fg: "#0084d4" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dc322f" attr: "b" }
-      } else if $in < 6hr {
-        "#dc322f"
-      } else if $in < 1day {
-        "#ff8400"
-      } else if $in < 3day {
-        "#56db3a"
-      } else if $in < 1wk {
-        { fg: "#56db3a" attr: "b" }
-      } else if $in < 6wk {
-        "#ccccff"
-      } else if $in < 52wk {
-        "#0084d4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dc322f" attr: "b" }
+        } else if $in < 6hr {
+            "#dc322f"
+        } else if $in < 1day {
+            "#ff8400"
+        } else if $in < 3day {
+            "#56db3a"
+        } else if $in < 1wk {
+            { fg: "#56db3a" attr: "b" }
+        } else if $in < 6wk {
+            "#ccccff"
+        } else if $in < 52wk {
+            "#0084d4"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/synth-midnight-dark.nu
+++ b/themes/themes/synth-midnight-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#42fff9" } else { "light_gray" } }
     int: "#c1c3c4"
     filesize: {|e|
-      if $e == 0b {
-        "#c1c3c4"
-      } else if $e < 1mb {
-        "#42fff9"
-      } else {{ fg: "#03aeff" }}
+        if $e == 0b {
+            "#c1c3c4"
+        } else if $e < 1mb {
+            "#42fff9"
+        } else {{ fg: "#03aeff" }}
     }
     duration: "#c1c3c4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b53b50" attr: "b" }
-      } else if $in < 6hr {
-        "#b53b50"
-      } else if $in < 1day {
-        "#c9d364"
-      } else if $in < 3day {
-        "#06ea61"
-      } else if $in < 1wk {
-        { fg: "#06ea61" attr: "b" }
-      } else if $in < 6wk {
-        "#42fff9"
-      } else if $in < 52wk {
-        "#03aeff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b53b50" attr: "b" }
+        } else if $in < 6hr {
+            "#b53b50"
+        } else if $in < 1day {
+            "#c9d364"
+        } else if $in < 3day {
+            "#06ea61"
+        } else if $in < 1wk {
+            { fg: "#06ea61" attr: "b" }
+        } else if $in < 6wk {
+            "#42fff9"
+        } else if $in < 52wk {
+            "#03aeff"
+        } else { "dark_gray" }
     }
     range: "#c1c3c4"
     float: "#c1c3c4"

--- a/themes/themes/synth-midnight-light.nu
+++ b/themes/themes/synth-midnight-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#42fff9" } else { "light_gray" } }
     int: "#28292a"
     filesize: {|e|
-      if $e == 0b {
-        "#28292a"
-      } else if $e < 1mb {
-        "#42fff9"
-      } else {{ fg: "#03aeff" }}
+        if $e == 0b {
+            "#28292a"
+        } else if $e < 1mb {
+            "#42fff9"
+        } else {{ fg: "#03aeff" }}
     }
     duration: "#28292a"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b53b50" attr: "b" }
-      } else if $in < 6hr {
-        "#b53b50"
-      } else if $in < 1day {
-        "#c9d364"
-      } else if $in < 3day {
-        "#06ea61"
-      } else if $in < 1wk {
-        { fg: "#06ea61" attr: "b" }
-      } else if $in < 6wk {
-        "#42fff9"
-      } else if $in < 52wk {
-        "#03aeff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b53b50" attr: "b" }
+        } else if $in < 6hr {
+            "#b53b50"
+        } else if $in < 1day {
+            "#c9d364"
+        } else if $in < 3day {
+            "#06ea61"
+        } else if $in < 1wk {
+            { fg: "#06ea61" attr: "b" }
+        } else if $in < 6wk {
+            "#42fff9"
+        } else if $in < 52wk {
+            "#03aeff"
+        } else { "dark_gray" }
     }
     range: "#28292a"
     float: "#28292a"

--- a/themes/themes/tango-dark.nu
+++ b/themes/themes/tango-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#34e2e2" } else { "light_gray" } }
     int: "#d3d7cf"
     filesize: {|e|
-      if $e == 0b {
-        "#d3d7cf"
-      } else if $e < 1mb {
-        "#05989a"
-      } else {{ fg: "#3464a4" }}
+        if $e == 0b {
+            "#d3d7cf"
+        } else if $e < 1mb {
+            "#05989a"
+        } else {{ fg: "#3464a4" }}
     }
     duration: "#d3d7cf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc0000" attr: "b" }
-      } else if $in < 6hr {
-        "#cc0000"
-      } else if $in < 1day {
-        "#c4a000"
-      } else if $in < 3day {
-        "#4e9a05"
-      } else if $in < 1wk {
-        { fg: "#4e9a05" attr: "b" }
-      } else if $in < 6wk {
-        "#05989a"
-      } else if $in < 52wk {
-        "#3464a4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc0000" attr: "b" }
+        } else if $in < 6hr {
+            "#cc0000"
+        } else if $in < 1day {
+            "#c4a000"
+        } else if $in < 3day {
+            "#4e9a05"
+        } else if $in < 1wk {
+            { fg: "#4e9a05" attr: "b" }
+        } else if $in < 6wk {
+            "#05989a"
+        } else if $in < 52wk {
+            "#3464a4"
+        } else { "dark_gray" }
     }
     range: "#d3d7cf"
     float: "#d3d7cf"

--- a/themes/themes/tango-light.nu
+++ b/themes/themes/tango-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#34e2e2" } else { "light_gray" } }
     int: "#d3d7cf"
     filesize: {|e|
-      if $e == 0b {
-        "#d3d7cf"
-      } else if $e < 1mb {
-        "#05989a"
-      } else {{ fg: "#3464a4" }}
+        if $e == 0b {
+            "#d3d7cf"
+        } else if $e < 1mb {
+            "#05989a"
+        } else {{ fg: "#3464a4" }}
     }
     duration: "#d3d7cf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc0000" attr: "b" }
-      } else if $in < 6hr {
-        "#cc0000"
-      } else if $in < 1day {
-        "#c4a000"
-      } else if $in < 3day {
-        "#4e9a05"
-      } else if $in < 1wk {
-        { fg: "#4e9a05" attr: "b" }
-      } else if $in < 6wk {
-        "#05989a"
-      } else if $in < 52wk {
-        "#3464a4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc0000" attr: "b" }
+        } else if $in < 6hr {
+            "#cc0000"
+        } else if $in < 1day {
+            "#c4a000"
+        } else if $in < 3day {
+            "#4e9a05"
+        } else if $in < 1wk {
+            { fg: "#4e9a05" attr: "b" }
+        } else if $in < 6wk {
+            "#05989a"
+        } else if $in < 52wk {
+            "#3464a4"
+        } else { "dark_gray" }
     }
     range: "#d3d7cf"
     float: "#d3d7cf"

--- a/themes/themes/tango.nu
+++ b/themes/themes/tango.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#06989a" } else { "light_gray" } }
     int: "#d3d7cf"
     filesize: {|e|
-      if $e == 0b {
-        "#d3d7cf"
-      } else if $e < 1mb {
-        "#06989a"
-      } else {{ fg: "#3465a4" }}
+        if $e == 0b {
+            "#d3d7cf"
+        } else if $e < 1mb {
+            "#06989a"
+        } else {{ fg: "#3465a4" }}
     }
     duration: "#d3d7cf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc0000" attr: "b" }
-      } else if $in < 6hr {
-        "#cc0000"
-      } else if $in < 1day {
-        "#c4a000"
-      } else if $in < 3day {
-        "#4e9a06"
-      } else if $in < 1wk {
-        { fg: "#4e9a06" attr: "b" }
-      } else if $in < 6wk {
-        "#06989a"
-      } else if $in < 52wk {
-        "#3465a4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc0000" attr: "b" }
+        } else if $in < 6hr {
+            "#cc0000"
+        } else if $in < 1day {
+            "#c4a000"
+        } else if $in < 3day {
+            "#4e9a06"
+        } else if $in < 1wk {
+            { fg: "#4e9a06" attr: "b" }
+        } else if $in < 6wk {
+            "#06989a"
+        } else if $in < 52wk {
+            "#3465a4"
+        } else { "dark_gray" }
     }
     range: "#d3d7cf"
     float: "#d3d7cf"

--- a/themes/themes/teerb.nu
+++ b/themes/themes/teerb.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b1e7dd" } else { "light_gray" } }
     int: "#d0d0d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d0d0d0"
-      } else if $e < 1mb {
-        "#8adbb4"
-      } else {{ fg: "#86aed6" }}
+        if $e == 0b {
+            "#d0d0d0"
+        } else if $e < 1mb {
+            "#8adbb4"
+        } else {{ fg: "#86aed6" }}
     }
     duration: "#d0d0d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d68686" attr: "b" }
-      } else if $in < 6hr {
-        "#d68686"
-      } else if $in < 1day {
-        "#d7af87"
-      } else if $in < 3day {
-        "#aed686"
-      } else if $in < 1wk {
-        { fg: "#aed686" attr: "b" }
-      } else if $in < 6wk {
-        "#8adbb4"
-      } else if $in < 52wk {
-        "#86aed6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d68686" attr: "b" }
+        } else if $in < 6hr {
+            "#d68686"
+        } else if $in < 1day {
+            "#d7af87"
+        } else if $in < 3day {
+            "#aed686"
+        } else if $in < 1wk {
+            { fg: "#aed686" attr: "b" }
+        } else if $in < 6wk {
+            "#8adbb4"
+        } else if $in < 52wk {
+            "#86aed6"
+        } else { "dark_gray" }
     }
     range: "#d0d0d0"
     float: "#d0d0d0"

--- a/themes/themes/tempus-autumn.nu
+++ b/themes/themes/tempus-autumn.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2aa4ad" } else { "light_gray" } }
     int: "#a5918a"
     filesize: {|e|
-      if $e == 0b {
-        "#a5918a"
-      } else if $e < 1mb {
-        "#52a485"
-      } else {{ fg: "#7897c2" }}
+        if $e == 0b {
+            "#a5918a"
+        } else if $e < 1mb {
+            "#52a485"
+        } else {{ fg: "#7897c2" }}
     }
     duration: "#a5918a"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f16c50" attr: "b" }
-      } else if $in < 6hr {
-        "#f16c50"
-      } else if $in < 1day {
-        "#ac9440"
-      } else if $in < 3day {
-        "#80a100"
-      } else if $in < 1wk {
-        { fg: "#80a100" attr: "b" }
-      } else if $in < 6wk {
-        "#52a485"
-      } else if $in < 52wk {
-        "#7897c2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f16c50" attr: "b" }
+        } else if $in < 6hr {
+            "#f16c50"
+        } else if $in < 1day {
+            "#ac9440"
+        } else if $in < 3day {
+            "#80a100"
+        } else if $in < 1wk {
+            { fg: "#80a100" attr: "b" }
+        } else if $in < 6wk {
+            "#52a485"
+        } else if $in < 52wk {
+            "#7897c2"
+        } else { "dark_gray" }
     }
     range: "#a5918a"
     float: "#a5918a"

--- a/themes/themes/tempus-classic.nu
+++ b/themes/themes/tempus-classic.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7aa880" } else { "light_gray" } }
     int: "#949d9f"
     filesize: {|e|
-      if $e == 0b {
-        "#949d9f"
-      } else if $e < 1mb {
-        "#6da280"
-      } else {{ fg: "#6e9cb0" }}
+        if $e == 0b {
+            "#949d9f"
+        } else if $e < 1mb {
+            "#6da280"
+        } else {{ fg: "#6e9cb0" }}
     }
     duration: "#949d9f"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d2813d" attr: "b" }
-      } else if $in < 6hr {
-        "#d2813d"
-      } else if $in < 1day {
-        "#b1942b"
-      } else if $in < 3day {
-        "#8c9e3d"
-      } else if $in < 1wk {
-        { fg: "#8c9e3d" attr: "b" }
-      } else if $in < 6wk {
-        "#6da280"
-      } else if $in < 52wk {
-        "#6e9cb0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d2813d" attr: "b" }
+        } else if $in < 6hr {
+            "#d2813d"
+        } else if $in < 1day {
+            "#b1942b"
+        } else if $in < 3day {
+            "#8c9e3d"
+        } else if $in < 1wk {
+            { fg: "#8c9e3d" attr: "b" }
+        } else if $in < 6wk {
+            "#6da280"
+        } else if $in < 52wk {
+            "#6e9cb0"
+        } else { "dark_gray" }
     }
     range: "#949d9f"
     float: "#949d9f"

--- a/themes/themes/tempus-dawn.nu
+++ b/themes/themes/tempus-dawn.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#106e8c" } else { "light_gray" } }
     int: "#e2e4e1"
     filesize: {|e|
-      if $e == 0b {
-        "#e2e4e1"
-      } else if $e < 1mb {
-        "#086784"
-      } else {{ fg: "#4b529a" }}
+        if $e == 0b {
+            "#e2e4e1"
+        } else if $e < 1mb {
+            "#086784"
+        } else {{ fg: "#4b529a" }}
     }
     duration: "#e2e4e1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a32a3a" attr: "b" }
-      } else if $in < 6hr {
-        "#a32a3a"
-      } else if $in < 1day {
-        "#745300"
-      } else if $in < 3day {
-        "#206620"
-      } else if $in < 1wk {
-        { fg: "#206620" attr: "b" }
-      } else if $in < 6wk {
-        "#086784"
-      } else if $in < 52wk {
-        "#4b529a"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a32a3a" attr: "b" }
+        } else if $in < 6hr {
+            "#a32a3a"
+        } else if $in < 1day {
+            "#745300"
+        } else if $in < 3day {
+            "#206620"
+        } else if $in < 1wk {
+            { fg: "#206620" attr: "b" }
+        } else if $in < 6wk {
+            "#086784"
+        } else if $in < 52wk {
+            "#4b529a"
+        } else { "dark_gray" }
     }
     range: "#e2e4e1"
     float: "#e2e4e1"

--- a/themes/themes/tempus-day.nu
+++ b/themes/themes/tempus-day.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#337087" } else { "light_gray" } }
     int: "#eae9dd"
     filesize: {|e|
-      if $e == 0b {
-        "#eae9dd"
-      } else if $e < 1mb {
-        "#007070"
-      } else {{ fg: "#385dc4" }}
+        if $e == 0b {
+            "#eae9dd"
+        } else if $e < 1mb {
+            "#007070"
+        } else {{ fg: "#385dc4" }}
     }
     duration: "#eae9dd"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c81000" attr: "b" }
-      } else if $in < 6hr {
-        "#c81000"
-      } else if $in < 1day {
-        "#806000"
-      } else if $in < 3day {
-        "#107410"
-      } else if $in < 1wk {
-        { fg: "#107410" attr: "b" }
-      } else if $in < 6wk {
-        "#007070"
-      } else if $in < 52wk {
-        "#385dc4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c81000" attr: "b" }
+        } else if $in < 6hr {
+            "#c81000"
+        } else if $in < 1day {
+            "#806000"
+        } else if $in < 3day {
+            "#107410"
+        } else if $in < 1wk {
+            { fg: "#107410" attr: "b" }
+        } else if $in < 6wk {
+            "#007070"
+        } else if $in < 52wk {
+            "#385dc4"
+        } else { "dark_gray" }
     }
     range: "#eae9dd"
     float: "#eae9dd"

--- a/themes/themes/tempus-dusk.nu
+++ b/themes/themes/tempus-dusk.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8caeb6" } else { "light_gray" } }
     int: "#a29899"
     filesize: {|e|
-      if $e == 0b {
-        "#a29899"
-      } else if $e < 1mb {
-        "#8e9aba"
-      } else {{ fg: "#8c9abe" }}
+        if $e == 0b {
+            "#a29899"
+        } else if $e < 1mb {
+            "#8e9aba"
+        } else {{ fg: "#8c9abe" }}
     }
     duration: "#a29899"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cb8d56" attr: "b" }
-      } else if $in < 6hr {
-        "#cb8d56"
-      } else if $in < 1day {
-        "#a79c46"
-      } else if $in < 3day {
-        "#8ba089"
-      } else if $in < 1wk {
-        { fg: "#8ba089" attr: "b" }
-      } else if $in < 6wk {
-        "#8e9aba"
-      } else if $in < 52wk {
-        "#8c9abe"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cb8d56" attr: "b" }
+        } else if $in < 6hr {
+            "#cb8d56"
+        } else if $in < 1day {
+            "#a79c46"
+        } else if $in < 3day {
+            "#8ba089"
+        } else if $in < 1wk {
+            { fg: "#8ba089" attr: "b" }
+        } else if $in < 6wk {
+            "#8e9aba"
+        } else if $in < 52wk {
+            "#8c9abe"
+        } else { "dark_gray" }
     }
     range: "#a29899"
     float: "#a29899"

--- a/themes/themes/tempus-fugit.nu
+++ b/themes/themes/tempus-fugit.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00786a" } else { "light_gray" } }
     int: "#f2ebe9"
     filesize: {|e|
-      if $e == 0b {
-        "#f2ebe9"
-      } else if $e < 1mb {
-        "#007072"
-      } else {{ fg: "#1666b0" }}
+        if $e == 0b {
+            "#f2ebe9"
+        } else if $e < 1mb {
+            "#007072"
+        } else {{ fg: "#1666b0" }}
     }
     duration: "#f2ebe9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c61a14" attr: "b" }
-      } else if $in < 6hr {
-        "#c61a14"
-      } else if $in < 1day {
-        "#825e00"
-      } else if $in < 3day {
-        "#357200"
-      } else if $in < 1wk {
-        { fg: "#357200" attr: "b" }
-      } else if $in < 6wk {
-        "#007072"
-      } else if $in < 52wk {
-        "#1666b0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c61a14" attr: "b" }
+        } else if $in < 6hr {
+            "#c61a14"
+        } else if $in < 1day {
+            "#825e00"
+        } else if $in < 3day {
+            "#357200"
+        } else if $in < 1wk {
+            { fg: "#357200" attr: "b" }
+        } else if $in < 6wk {
+            "#007072"
+        } else if $in < 52wk {
+            "#1666b0"
+        } else { "dark_gray" }
     }
     range: "#f2ebe9"
     float: "#f2ebe9"

--- a/themes/themes/tempus-future.nu
+++ b/themes/themes/tempus-future.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2cbab6" } else { "light_gray" } }
     int: "#a59ebd"
     filesize: {|e|
-      if $e == 0b {
-        "#a59ebd"
-      } else if $e < 1mb {
-        "#29b3bb"
-      } else {{ fg: "#4aaed3" }}
+        if $e == 0b {
+            "#a59ebd"
+        } else if $e < 1mb {
+            "#29b3bb"
+        } else {{ fg: "#4aaed3" }}
     }
     duration: "#a59ebd"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff778a" attr: "b" }
-      } else if $in < 6hr {
-        "#ff778a"
-      } else if $in < 1day {
-        "#bfa01a"
-      } else if $in < 3day {
-        "#6ab539"
-      } else if $in < 1wk {
-        { fg: "#6ab539" attr: "b" }
-      } else if $in < 6wk {
-        "#29b3bb"
-      } else if $in < 52wk {
-        "#4aaed3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff778a" attr: "b" }
+        } else if $in < 6hr {
+            "#ff778a"
+        } else if $in < 1day {
+            "#bfa01a"
+        } else if $in < 3day {
+            "#6ab539"
+        } else if $in < 1wk {
+            { fg: "#6ab539" attr: "b" }
+        } else if $in < 6wk {
+            "#29b3bb"
+        } else if $in < 52wk {
+            "#4aaed3"
+        } else { "dark_gray" }
     }
     range: "#a59ebd"
     float: "#a59ebd"

--- a/themes/themes/tempus-night.nu
+++ b/themes/themes/tempus-night.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00ca9a" } else { "light_gray" } }
     int: "#c4bdaf"
     filesize: {|e|
-      if $e == 0b {
-        "#c4bdaf"
-      } else if $e < 1mb {
-        "#1db5c3"
-      } else {{ fg: "#5aaaf2" }}
+        if $e == 0b {
+            "#c4bdaf"
+        } else if $e < 1mb {
+            "#1db5c3"
+        } else {{ fg: "#5aaaf2" }}
     }
     duration: "#c4bdaf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fb7e8e" attr: "b" }
-      } else if $in < 6hr {
-        "#fb7e8e"
-      } else if $in < 1day {
-        "#b0a800"
-      } else if $in < 3day {
-        "#52ba40"
-      } else if $in < 1wk {
-        { fg: "#52ba40" attr: "b" }
-      } else if $in < 6wk {
-        "#1db5c3"
-      } else if $in < 52wk {
-        "#5aaaf2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fb7e8e" attr: "b" }
+        } else if $in < 6hr {
+            "#fb7e8e"
+        } else if $in < 1day {
+            "#b0a800"
+        } else if $in < 3day {
+            "#52ba40"
+        } else if $in < 1wk {
+            { fg: "#52ba40" attr: "b" }
+        } else if $in < 6wk {
+            "#1db5c3"
+        } else if $in < 52wk {
+            "#5aaaf2"
+        } else { "dark_gray" }
     }
     range: "#c4bdaf"
     float: "#c4bdaf"

--- a/themes/themes/tempus-past.nu
+++ b/themes/themes/tempus-past.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#07737a" } else { "light_gray" } }
     int: "#ece6de"
     filesize: {|e|
-      if $e == 0b {
-        "#ece6de"
-      } else if $e < 1mb {
-        "#096a83"
-      } else {{ fg: "#1763aa" }}
+        if $e == 0b {
+            "#ece6de"
+        } else if $e < 1mb {
+            "#096a83"
+        } else {{ fg: "#1763aa" }}
     }
     duration: "#ece6de"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c00c50" attr: "b" }
-      } else if $in < 6hr {
-        "#c00c50"
-      } else if $in < 1day {
-        "#a6403a"
-      } else if $in < 3day {
-        "#0a7040"
-      } else if $in < 1wk {
-        { fg: "#0a7040" attr: "b" }
-      } else if $in < 6wk {
-        "#096a83"
-      } else if $in < 52wk {
-        "#1763aa"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c00c50" attr: "b" }
+        } else if $in < 6hr {
+            "#c00c50"
+        } else if $in < 1day {
+            "#a6403a"
+        } else if $in < 3day {
+            "#0a7040"
+        } else if $in < 1wk {
+            { fg: "#0a7040" attr: "b" }
+        } else if $in < 6wk {
+            "#096a83"
+        } else if $in < 52wk {
+            "#1763aa"
+        } else { "dark_gray" }
     }
     range: "#ece6de"
     float: "#ece6de"

--- a/themes/themes/tempus-rift.nu
+++ b/themes/themes/tempus-rift.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#10c480" } else { "light_gray" } }
     int: "#ab9aa9"
     filesize: {|e|
-      if $e == 0b {
-        "#ab9aa9"
-      } else if $e < 1mb {
-        "#5fad8f"
-      } else {{ fg: "#30aeb0" }}
+        if $e == 0b {
+            "#ab9aa9"
+        } else if $e < 1mb {
+            "#5fad8f"
+        } else {{ fg: "#30aeb0" }}
     }
     duration: "#ab9aa9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c19904" attr: "b" }
-      } else if $in < 6hr {
-        "#c19904"
-      } else if $in < 1day {
-        "#7fad00"
-      } else if $in < 3day {
-        "#34b534"
-      } else if $in < 1wk {
-        { fg: "#34b534" attr: "b" }
-      } else if $in < 6wk {
-        "#5fad8f"
-      } else if $in < 52wk {
-        "#30aeb0"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c19904" attr: "b" }
+        } else if $in < 6hr {
+            "#c19904"
+        } else if $in < 1day {
+            "#7fad00"
+        } else if $in < 3day {
+            "#34b534"
+        } else if $in < 1wk {
+            { fg: "#34b534" attr: "b" }
+        } else if $in < 6wk {
+            "#5fad8f"
+        } else if $in < 52wk {
+            "#30aeb0"
+        } else { "dark_gray" }
     }
     range: "#ab9aa9"
     float: "#ab9aa9"

--- a/themes/themes/tempus-spring.nu
+++ b/themes/themes/tempus-spring.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3cbaa6" } else { "light_gray" } }
     int: "#96aca7"
     filesize: {|e|
-      if $e == 0b {
-        "#96aca7"
-      } else if $e < 1mb {
-        "#36bd84"
-      } else {{ fg: "#39b6ce" }}
+        if $e == 0b {
+            "#96aca7"
+        } else if $e < 1mb {
+            "#36bd84"
+        } else {{ fg: "#39b6ce" }}
     }
     duration: "#96aca7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff855a" attr: "b" }
-      } else if $in < 6hr {
-        "#ff855a"
-      } else if $in < 1day {
-        "#a6af1a"
-      } else if $in < 3day {
-        "#5cbc4d"
-      } else if $in < 1wk {
-        { fg: "#5cbc4d" attr: "b" }
-      } else if $in < 6wk {
-        "#36bd84"
-      } else if $in < 52wk {
-        "#39b6ce"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff855a" attr: "b" }
+        } else if $in < 6hr {
+            "#ff855a"
+        } else if $in < 1day {
+            "#a6af1a"
+        } else if $in < 3day {
+            "#5cbc4d"
+        } else if $in < 1wk {
+            { fg: "#5cbc4d" attr: "b" }
+        } else if $in < 6wk {
+            "#36bd84"
+        } else if $in < 52wk {
+            "#39b6ce"
+        } else { "dark_gray" }
     }
     range: "#96aca7"
     float: "#96aca7"

--- a/themes/themes/tempus-summer.nu
+++ b/themes/themes/tempus-summer.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#2aa9b6" } else { "light_gray" } }
     int: "#919ab9"
     filesize: {|e|
-      if $e == 0b {
-        "#919ab9"
-      } else if $e < 1mb {
-        "#3dab95"
-      } else {{ fg: "#609fda" }}
+        if $e == 0b {
+            "#919ab9"
+        } else if $e < 1mb {
+            "#3dab95"
+        } else {{ fg: "#609fda" }}
     }
     duration: "#919ab9"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f76f6e" attr: "b" }
-      } else if $in < 6hr {
-        "#f76f6e"
-      } else if $in < 1day {
-        "#af9a0a"
-      } else if $in < 3day {
-        "#4eac6d"
-      } else if $in < 1wk {
-        { fg: "#4eac6d" attr: "b" }
-      } else if $in < 6wk {
-        "#3dab95"
-      } else if $in < 52wk {
-        "#609fda"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f76f6e" attr: "b" }
+        } else if $in < 6hr {
+            "#f76f6e"
+        } else if $in < 1day {
+            "#af9a0a"
+        } else if $in < 3day {
+            "#4eac6d"
+        } else if $in < 1wk {
+            { fg: "#4eac6d" attr: "b" }
+        } else if $in < 6wk {
+            "#3dab95"
+        } else if $in < 52wk {
+            "#609fda"
+        } else { "dark_gray" }
     }
     range: "#919ab9"
     float: "#919ab9"

--- a/themes/themes/tempus-tempest.nu
+++ b/themes/themes/tempus-tempest.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#9bdfc4" } else { "light_gray" } }
     int: "#b0c8ca"
     filesize: {|e|
-      if $e == 0b {
-        "#b0c8ca"
-      } else if $e < 1mb {
-        "#8ad0b0"
-      } else {{ fg: "#60d4cd" }}
+        if $e == 0b {
+            "#b0c8ca"
+        } else if $e < 1mb {
+            "#8ad0b0"
+        } else {{ fg: "#60d4cd" }}
     }
     duration: "#b0c8ca"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c6c80a" attr: "b" }
-      } else if $in < 6hr {
-        "#c6c80a"
-      } else if $in < 1day {
-        "#bfc94a"
-      } else if $in < 3day {
-        "#7ad67a"
-      } else if $in < 1wk {
-        { fg: "#7ad67a" attr: "b" }
-      } else if $in < 6wk {
-        "#8ad0b0"
-      } else if $in < 52wk {
-        "#60d4cd"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c6c80a" attr: "b" }
+        } else if $in < 6hr {
+            "#c6c80a"
+        } else if $in < 1day {
+            "#bfc94a"
+        } else if $in < 3day {
+            "#7ad67a"
+        } else if $in < 1wk {
+            { fg: "#7ad67a" attr: "b" }
+        } else if $in < 6wk {
+            "#8ad0b0"
+        } else if $in < 52wk {
+            "#60d4cd"
+        } else { "dark_gray" }
     }
     range: "#b0c8ca"
     float: "#b0c8ca"

--- a/themes/themes/tempus-totus.nu
+++ b/themes/themes/tempus-totus.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#005589" } else { "light_gray" } }
     int: "#f3f1f3"
     filesize: {|e|
-      if $e == 0b {
-        "#f3f1f3"
-      } else if $e < 1mb {
-        "#185870"
-      } else {{ fg: "#1d3fcf" }}
+        if $e == 0b {
+            "#f3f1f3"
+        } else if $e < 1mb {
+            "#185870"
+        } else {{ fg: "#1d3fcf" }}
     }
     duration: "#f3f1f3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a80000" attr: "b" }
-      } else if $in < 6hr {
-        "#a80000"
-      } else if $in < 1day {
-        "#714900"
-      } else if $in < 3day {
-        "#005f26"
-      } else if $in < 1wk {
-        { fg: "#005f26" attr: "b" }
-      } else if $in < 6wk {
-        "#185870"
-      } else if $in < 52wk {
-        "#1d3fcf"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a80000" attr: "b" }
+        } else if $in < 6hr {
+            "#a80000"
+        } else if $in < 1day {
+            "#714900"
+        } else if $in < 3day {
+            "#005f26"
+        } else if $in < 1wk {
+            { fg: "#005f26" attr: "b" }
+        } else if $in < 6wk {
+            "#185870"
+        } else if $in < 52wk {
+            "#1d3fcf"
+        } else { "dark_gray" }
     }
     range: "#f3f1f3"
     float: "#f3f1f3"

--- a/themes/themes/tempus-warp.nu
+++ b/themes/themes/tempus-warp.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1da1af" } else { "light_gray" } }
     int: "#928080"
     filesize: {|e|
-      if $e == 0b {
-        "#928080"
-      } else if $e < 1mb {
-        "#009580"
-      } else {{ fg: "#557feb" }}
+        if $e == 0b {
+            "#928080"
+        } else if $e < 1mb {
+            "#009580"
+        } else {{ fg: "#557feb" }}
     }
     duration: "#928080"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fa3333" attr: "b" }
-      } else if $in < 6hr {
-        "#fa3333"
-      } else if $in < 1day {
-        "#9e8100"
-      } else if $in < 3day {
-        "#139913"
-      } else if $in < 1wk {
-        { fg: "#139913" attr: "b" }
-      } else if $in < 6wk {
-        "#009580"
-      } else if $in < 52wk {
-        "#557feb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fa3333" attr: "b" }
+        } else if $in < 6hr {
+            "#fa3333"
+        } else if $in < 1day {
+            "#9e8100"
+        } else if $in < 3day {
+            "#139913"
+        } else if $in < 1wk {
+            { fg: "#139913" attr: "b" }
+        } else if $in < 6wk {
+            "#009580"
+        } else if $in < 52wk {
+            "#557feb"
+        } else { "dark_gray" }
     }
     range: "#928080"
     float: "#928080"

--- a/themes/themes/tempus-winter.nu
+++ b/themes/themes/tempus-winter.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#1ba2a0" } else { "light_gray" } }
     int: "#909294"
     filesize: {|e|
-      if $e == 0b {
-        "#909294"
-      } else if $e < 1mb {
-        "#4fa090"
-      } else {{ fg: "#798fd7" }}
+        if $e == 0b {
+            "#909294"
+        } else if $e < 1mb {
+            "#4fa090"
+        } else {{ fg: "#798fd7" }}
     }
     duration: "#909294"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#eb6a58" attr: "b" }
-      } else if $in < 6hr {
-        "#eb6a58"
-      } else if $in < 1day {
-        "#959721"
-      } else if $in < 3day {
-        "#49a61d"
-      } else if $in < 1wk {
-        { fg: "#49a61d" attr: "b" }
-      } else if $in < 6wk {
-        "#4fa090"
-      } else if $in < 52wk {
-        "#798fd7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#eb6a58" attr: "b" }
+        } else if $in < 6hr {
+            "#eb6a58"
+        } else if $in < 1day {
+            "#959721"
+        } else if $in < 3day {
+            "#49a61d"
+        } else if $in < 1wk {
+            { fg: "#49a61d" attr: "b" }
+        } else if $in < 6wk {
+            "#4fa090"
+        } else if $in < 52wk {
+            "#798fd7"
+        } else { "dark_gray" }
     }
     range: "#909294"
     float: "#909294"

--- a/themes/themes/tender.nu
+++ b/themes/themes/tender.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#73cef4" } else { "light_gray" } }
     int: "#eeeeee"
     filesize: {|e|
-      if $e == 0b {
-        "#eeeeee"
-      } else if $e < 1mb {
-        "#73cef4"
-      } else {{ fg: "#b3deef" }}
+        if $e == 0b {
+            "#eeeeee"
+        } else if $e < 1mb {
+            "#73cef4"
+        } else {{ fg: "#b3deef" }}
     }
     duration: "#eeeeee"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f43753" attr: "b" }
-      } else if $in < 6hr {
-        "#f43753"
-      } else if $in < 1day {
-        "#ffc24b"
-      } else if $in < 3day {
-        "#c9d05c"
-      } else if $in < 1wk {
-        { fg: "#c9d05c" attr: "b" }
-      } else if $in < 6wk {
-        "#73cef4"
-      } else if $in < 52wk {
-        "#b3deef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f43753" attr: "b" }
+        } else if $in < 6hr {
+            "#f43753"
+        } else if $in < 1day {
+            "#ffc24b"
+        } else if $in < 3day {
+            "#c9d05c"
+        } else if $in < 1wk {
+            { fg: "#c9d05c" attr: "b" }
+        } else if $in < 6wk {
+            "#73cef4"
+        } else if $in < 52wk {
+            "#b3deef"
+        } else { "dark_gray" }
     }
     range: "#eeeeee"
     float: "#eeeeee"

--- a/themes/themes/terminal-basic.nu
+++ b/themes/themes/terminal-basic.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00e5e5" } else { "light_gray" } }
     int: "#bfbfbf"
     filesize: {|e|
-      if $e == 0b {
-        "#bfbfbf"
-      } else if $e < 1mb {
-        "#00a6b2"
-      } else {{ fg: "#0000b2" }}
+        if $e == 0b {
+            "#bfbfbf"
+        } else if $e < 1mb {
+            "#00a6b2"
+        } else {{ fg: "#0000b2" }}
     }
     duration: "#bfbfbf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#990000" attr: "b" }
-      } else if $in < 6hr {
-        "#990000"
-      } else if $in < 1day {
-        "#999900"
-      } else if $in < 3day {
-        "#00a600"
-      } else if $in < 1wk {
-        { fg: "#00a600" attr: "b" }
-      } else if $in < 6wk {
-        "#00a6b2"
-      } else if $in < 52wk {
-        "#0000b2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#990000" attr: "b" }
+        } else if $in < 6hr {
+            "#990000"
+        } else if $in < 1day {
+            "#999900"
+        } else if $in < 3day {
+            "#00a600"
+        } else if $in < 1wk {
+            { fg: "#00a600" attr: "b" }
+        } else if $in < 6wk {
+            "#00a6b2"
+        } else if $in < 52wk {
+            "#0000b2"
+        } else { "dark_gray" }
     }
     range: "#bfbfbf"
     float: "#bfbfbf"

--- a/themes/themes/terminix-dark.nu
+++ b/themes/themes/terminix-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#86c1b9" } else { "light_gray" } }
     int: "#777777"
     filesize: {|e|
-      if $e == 0b {
-        "#777777"
-      } else if $e < 1mb {
-        "#5e8d87"
-      } else {{ fg: "#225555" }}
+        if $e == 0b {
+            "#777777"
+        } else if $e < 1mb {
+            "#5e8d87"
+        } else {{ fg: "#225555" }}
     }
     duration: "#777777"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a54242" attr: "b" }
-      } else if $in < 6hr {
-        "#a54242"
-      } else if $in < 1day {
-        "#de935f"
-      } else if $in < 3day {
-        "#a1b56c"
-      } else if $in < 1wk {
-        { fg: "#a1b56c" attr: "b" }
-      } else if $in < 6wk {
-        "#5e8d87"
-      } else if $in < 52wk {
-        "#225555"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a54242" attr: "b" }
+        } else if $in < 6hr {
+            "#a54242"
+        } else if $in < 1day {
+            "#de935f"
+        } else if $in < 3day {
+            "#a1b56c"
+        } else if $in < 1wk {
+            { fg: "#a1b56c" attr: "b" }
+        } else if $in < 6wk {
+            "#5e8d87"
+        } else if $in < 52wk {
+            "#225555"
+        } else { "dark_gray" }
     }
     range: "#777777"
     float: "#777777"

--- a/themes/themes/thayer-bright.nu
+++ b/themes/themes/thayer-bright.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#23cfd5" } else { "light_gray" } }
     int: "#ccccc6"
     filesize: {|e|
-      if $e == 0b {
-        "#ccccc6"
-      } else if $e < 1mb {
-        "#38c8b5"
-      } else {{ fg: "#2757d6" }}
+        if $e == 0b {
+            "#ccccc6"
+        } else if $e < 1mb {
+            "#38c8b5"
+        } else {{ fg: "#2757d6" }}
     }
     duration: "#ccccc6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f92672" attr: "b" }
-      } else if $in < 6hr {
-        "#f92672"
-      } else if $in < 1day {
-        "#f4fd22"
-      } else if $in < 3day {
-        "#4df840"
-      } else if $in < 1wk {
-        { fg: "#4df840" attr: "b" }
-      } else if $in < 6wk {
-        "#38c8b5"
-      } else if $in < 52wk {
-        "#2757d6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f92672" attr: "b" }
+        } else if $in < 6hr {
+            "#f92672"
+        } else if $in < 1day {
+            "#f4fd22"
+        } else if $in < 3day {
+            "#4df840"
+        } else if $in < 1wk {
+            { fg: "#4df840" attr: "b" }
+        } else if $in < 6wk {
+            "#38c8b5"
+        } else if $in < 52wk {
+            "#2757d6"
+        } else { "dark_gray" }
     }
     range: "#ccccc6"
     float: "#ccccc6"

--- a/themes/themes/the-hulk.nu
+++ b/themes/themes/the-hulk.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3f85a5" } else { "light_gray" } }
     int: "#d8d8d0"
     filesize: {|e|
-      if $e == 0b {
-        "#d8d8d0"
-      } else if $e < 1mb {
-        "#378ca9"
-      } else {{ fg: "#2424f4" }}
+        if $e == 0b {
+            "#d8d8d0"
+        } else if $e < 1mb {
+            "#378ca9"
+        } else {{ fg: "#2424f4" }}
     }
     duration: "#d8d8d0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#259d1a" attr: "b" }
-      } else if $in < 6hr {
-        "#259d1a"
-      } else if $in < 1day {
-        "#62e456"
-      } else if $in < 3day {
-        "#13ce2f"
-      } else if $in < 1wk {
-        { fg: "#13ce2f" attr: "b" }
-      } else if $in < 6wk {
-        "#378ca9"
-      } else if $in < 52wk {
-        "#2424f4"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#259d1a" attr: "b" }
+        } else if $in < 6hr {
+            "#259d1a"
+        } else if $in < 1day {
+            "#62e456"
+        } else if $in < 3day {
+            "#13ce2f"
+        } else if $in < 1wk {
+            { fg: "#13ce2f" attr: "b" }
+        } else if $in < 6wk {
+            "#378ca9"
+        } else if $in < 52wk {
+            "#2424f4"
+        } else { "dark_gray" }
     }
     range: "#d8d8d0"
     float: "#d8d8d0"

--- a/themes/themes/tin.nu
+++ b/themes/themes/tin.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#78b0b5" } else { "light_gray" } }
     int: "#ffffff"
     filesize: {|e|
-      if $e == 0b {
-        "#ffffff"
-      } else if $e < 1mb {
-        "#4e888d"
-      } else {{ fg: "#534e8d" }}
+        if $e == 0b {
+            "#ffffff"
+        } else if $e < 1mb {
+            "#4e888d"
+        } else {{ fg: "#534e8d" }}
     }
     duration: "#ffffff"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#8d534e" attr: "b" }
-      } else if $in < 6hr {
-        "#8d534e"
-      } else if $in < 1day {
-        "#888d4e"
-      } else if $in < 3day {
-        "#4e8d53"
-      } else if $in < 1wk {
-        { fg: "#4e8d53" attr: "b" }
-      } else if $in < 6wk {
-        "#4e888d"
-      } else if $in < 52wk {
-        "#534e8d"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#8d534e" attr: "b" }
+        } else if $in < 6hr {
+            "#8d534e"
+        } else if $in < 1day {
+            "#888d4e"
+        } else if $in < 3day {
+            "#4e8d53"
+        } else if $in < 1wk {
+            { fg: "#4e8d53" attr: "b" }
+        } else if $in < 6wk {
+            "#4e888d"
+        } else if $in < 52wk {
+            "#534e8d"
+        } else { "dark_gray" }
     }
     range: "#ffffff"
     float: "#ffffff"

--- a/themes/themes/tokyo-day.nu
+++ b/themes/themes/tokyo-day.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#007197" } else { "light_gray" } }
     int: "#6172b0"
     filesize: {|e|
-      if $e == 0b {
-        "#6172b0"
-      } else if $e < 1mb {
-        "#007197"
-      } else {{ fg: "#2e7de9" }}
+        if $e == 0b {
+            "#6172b0"
+        } else if $e < 1mb {
+            "#007197"
+        } else {{ fg: "#2e7de9" }}
     }
     duration: "#6172b0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f52a65" attr: "b" }
-      } else if $in < 6hr {
-        "#f52a65"
-      } else if $in < 1day {
-        "#8c6c3e"
-      } else if $in < 3day {
-        "#587539"
-      } else if $in < 1wk {
-        { fg: "#587539" attr: "b" }
-      } else if $in < 6wk {
-        "#007197"
-      } else if $in < 52wk {
-        "#2e7de9"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f52a65" attr: "b" }
+        } else if $in < 6hr {
+            "#f52a65"
+        } else if $in < 1day {
+            "#8c6c3e"
+        } else if $in < 3day {
+            "#587539"
+        } else if $in < 1wk {
+            { fg: "#587539" attr: "b" }
+        } else if $in < 6wk {
+            "#007197"
+        } else if $in < 52wk {
+            "#2e7de9"
+        } else { "dark_gray" }
     }
     range: "#6172b0"
     float: "#6172b0"

--- a/themes/themes/tokyo-night.nu
+++ b/themes/themes/tokyo-night.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7dcfff" } else { "light_gray" } }
     int: "#a9b1d6"
     filesize: {|e|
-      if $e == 0b {
-        "#a9b1d6"
-      } else if $e < 1mb {
-        "#7dcfff"
-      } else {{ fg: "#7aa2f7" }}
+        if $e == 0b {
+            "#a9b1d6"
+        } else if $e < 1mb {
+            "#7dcfff"
+        } else {{ fg: "#7aa2f7" }}
     }
     duration: "#a9b1d6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f7768e" attr: "b" }
-      } else if $in < 6hr {
-        "#f7768e"
-      } else if $in < 1day {
-        "#e0af68"
-      } else if $in < 3day {
-        "#9ece6a"
-      } else if $in < 1wk {
-        { fg: "#9ece6a" attr: "b" }
-      } else if $in < 6wk {
-        "#7dcfff"
-      } else if $in < 52wk {
-        "#7aa2f7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f7768e" attr: "b" }
+        } else if $in < 6hr {
+            "#f7768e"
+        } else if $in < 1day {
+            "#e0af68"
+        } else if $in < 3day {
+            "#9ece6a"
+        } else if $in < 1wk {
+            { fg: "#9ece6a" attr: "b" }
+        } else if $in < 6wk {
+            "#7dcfff"
+        } else if $in < 52wk {
+            "#7aa2f7"
+        } else { "dark_gray" }
     }
     range: "#a9b1d6"
     float: "#a9b1d6"

--- a/themes/themes/tokyo-storm.nu
+++ b/themes/themes/tokyo-storm.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#7dcfff" } else { "light_gray" } }
     int: "#a9b1d6"
     filesize: {|e|
-      if $e == 0b {
-        "#a9b1d6"
-      } else if $e < 1mb {
-        "#7dcfff"
-      } else {{ fg: "#7aa2f7" }}
+        if $e == 0b {
+            "#a9b1d6"
+        } else if $e < 1mb {
+            "#7dcfff"
+        } else {{ fg: "#7aa2f7" }}
     }
     duration: "#a9b1d6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f7768e" attr: "b" }
-      } else if $in < 6hr {
-        "#f7768e"
-      } else if $in < 1day {
-        "#e0af68"
-      } else if $in < 3day {
-        "#9ece6a"
-      } else if $in < 1wk {
-        { fg: "#9ece6a" attr: "b" }
-      } else if $in < 6wk {
-        "#7dcfff"
-      } else if $in < 52wk {
-        "#7aa2f7"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f7768e" attr: "b" }
+        } else if $in < 6hr {
+            "#f7768e"
+        } else if $in < 1day {
+            "#e0af68"
+        } else if $in < 3day {
+            "#9ece6a"
+        } else if $in < 1wk {
+            { fg: "#9ece6a" attr: "b" }
+        } else if $in < 6wk {
+            "#7dcfff"
+        } else if $in < 52wk {
+            "#7aa2f7"
+        } else { "dark_gray" }
     }
     range: "#a9b1d6"
     float: "#a9b1d6"

--- a/themes/themes/tomorrow-night-blue.nu
+++ b/themes/themes/tomorrow-night-blue.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#99ffff" } else { "light_gray" } }
     int: "#fffefe"
     filesize: {|e|
-      if $e == 0b {
-        "#fffefe"
-      } else if $e < 1mb {
-        "#99ffff"
-      } else {{ fg: "#bbdaff" }}
+        if $e == 0b {
+            "#fffefe"
+        } else if $e < 1mb {
+            "#99ffff"
+        } else {{ fg: "#bbdaff" }}
     }
     duration: "#fffefe"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff9da3" attr: "b" }
-      } else if $in < 6hr {
-        "#ff9da3"
-      } else if $in < 1day {
-        "#ffeead"
-      } else if $in < 3day {
-        "#d1f1a9"
-      } else if $in < 1wk {
-        { fg: "#d1f1a9" attr: "b" }
-      } else if $in < 6wk {
-        "#99ffff"
-      } else if $in < 52wk {
-        "#bbdaff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff9da3" attr: "b" }
+        } else if $in < 6hr {
+            "#ff9da3"
+        } else if $in < 1day {
+            "#ffeead"
+        } else if $in < 3day {
+            "#d1f1a9"
+        } else if $in < 1wk {
+            { fg: "#d1f1a9" attr: "b" }
+        } else if $in < 6wk {
+            "#99ffff"
+        } else if $in < 52wk {
+            "#bbdaff"
+        } else { "dark_gray" }
     }
     range: "#fffefe"
     float: "#fffefe"

--- a/themes/themes/tomorrow-night-bright.nu
+++ b/themes/themes/tomorrow-night-bright.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#70c0b1" } else { "light_gray" } }
     int: "#fffefe"
     filesize: {|e|
-      if $e == 0b {
-        "#fffefe"
-      } else if $e < 1mb {
-        "#70c0b1"
-      } else {{ fg: "#79a6da" }}
+        if $e == 0b {
+            "#fffefe"
+        } else if $e < 1mb {
+            "#70c0b1"
+        } else {{ fg: "#79a6da" }}
     }
     duration: "#fffefe"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d54e53" attr: "b" }
-      } else if $in < 6hr {
-        "#d54e53"
-      } else if $in < 1day {
-        "#e7c547"
-      } else if $in < 3day {
-        "#b9ca49"
-      } else if $in < 1wk {
-        { fg: "#b9ca49" attr: "b" }
-      } else if $in < 6wk {
-        "#70c0b1"
-      } else if $in < 52wk {
-        "#79a6da"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d54e53" attr: "b" }
+        } else if $in < 6hr {
+            "#d54e53"
+        } else if $in < 1day {
+            "#e7c547"
+        } else if $in < 3day {
+            "#b9ca49"
+        } else if $in < 1wk {
+            { fg: "#b9ca49" attr: "b" }
+        } else if $in < 6wk {
+            "#70c0b1"
+        } else if $in < 52wk {
+            "#79a6da"
+        } else { "dark_gray" }
     }
     range: "#fffefe"
     float: "#fffefe"

--- a/themes/themes/tomorrow-night-eighties.nu
+++ b/themes/themes/tomorrow-night-eighties.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#66cccc" } else { "light_gray" } }
     int: "#cccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#cccccc"
-      } else if $e < 1mb {
-        "#66cccc"
-      } else {{ fg: "#6699cc" }}
+        if $e == 0b {
+            "#cccccc"
+        } else if $e < 1mb {
+            "#66cccc"
+        } else {{ fg: "#6699cc" }}
     }
     duration: "#cccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#f2777a" attr: "b" }
-      } else if $in < 6hr {
-        "#f2777a"
-      } else if $in < 1day {
-        "#ffcc66"
-      } else if $in < 3day {
-        "#99cc99"
-      } else if $in < 1wk {
-        { fg: "#99cc99" attr: "b" }
-      } else if $in < 6wk {
-        "#66cccc"
-      } else if $in < 52wk {
-        "#6699cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#f2777a" attr: "b" }
+        } else if $in < 6hr {
+            "#f2777a"
+        } else if $in < 1day {
+            "#ffcc66"
+        } else if $in < 3day {
+            "#99cc99"
+        } else if $in < 1wk {
+            { fg: "#99cc99" attr: "b" }
+        } else if $in < 6wk {
+            "#66cccc"
+        } else if $in < 52wk {
+            "#6699cc"
+        } else { "dark_gray" }
     }
     range: "#cccccc"
     float: "#cccccc"

--- a/themes/themes/tomorrow-night.nu
+++ b/themes/themes/tomorrow-night.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#8abeb7" } else { "light_gray" } }
     int: "#c5c8c6"
     filesize: {|e|
-      if $e == 0b {
-        "#c5c8c6"
-      } else if $e < 1mb {
-        "#8abeb7"
-      } else {{ fg: "#81a2be" }}
+        if $e == 0b {
+            "#c5c8c6"
+        } else if $e < 1mb {
+            "#8abeb7"
+        } else {{ fg: "#81a2be" }}
     }
     duration: "#c5c8c6"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc6666" attr: "b" }
-      } else if $in < 6hr {
-        "#cc6666"
-      } else if $in < 1day {
-        "#f0c674"
-      } else if $in < 3day {
-        "#b5bd68"
-      } else if $in < 1wk {
-        { fg: "#b5bd68" attr: "b" }
-      } else if $in < 6wk {
-        "#8abeb7"
-      } else if $in < 52wk {
-        "#81a2be"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc6666" attr: "b" }
+        } else if $in < 6hr {
+            "#cc6666"
+        } else if $in < 1day {
+            "#f0c674"
+        } else if $in < 3day {
+            "#b5bd68"
+        } else if $in < 1wk {
+            { fg: "#b5bd68" attr: "b" }
+        } else if $in < 6wk {
+            "#8abeb7"
+        } else if $in < 52wk {
+            "#81a2be"
+        } else { "dark_gray" }
     }
     range: "#c5c8c6"
     float: "#c5c8c6"

--- a/themes/themes/tomorrow.nu
+++ b/themes/themes/tomorrow.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3e999f" } else { "light_gray" } }
     int: "#4d4d4c"
     filesize: {|e|
-      if $e == 0b {
-        "#4d4d4c"
-      } else if $e < 1mb {
-        "#3e999f"
-      } else {{ fg: "#4271ae" }}
+        if $e == 0b {
+            "#4d4d4c"
+        } else if $e < 1mb {
+            "#3e999f"
+        } else {{ fg: "#4271ae" }}
     }
     duration: "#4d4d4c"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c82829" attr: "b" }
-      } else if $in < 6hr {
-        "#c82829"
-      } else if $in < 1day {
-        "#eab700"
-      } else if $in < 3day {
-        "#718c00"
-      } else if $in < 1wk {
-        { fg: "#718c00" attr: "b" }
-      } else if $in < 6wk {
-        "#3e999f"
-      } else if $in < 52wk {
-        "#4271ae"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c82829" attr: "b" }
+        } else if $in < 6hr {
+            "#c82829"
+        } else if $in < 1day {
+            "#eab700"
+        } else if $in < 3day {
+            "#718c00"
+        } else if $in < 1wk {
+            { fg: "#718c00" attr: "b" }
+        } else if $in < 6wk {
+            "#3e999f"
+        } else if $in < 52wk {
+            "#4271ae"
+        } else { "dark_gray" }
     }
     range: "#4d4d4c"
     float: "#4d4d4c"

--- a/themes/themes/toy-chest.nu
+++ b/themes/themes/toy-chest.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#42c3ae" } else { "light_gray" } }
     int: "#23d183"
     filesize: {|e|
-      if $e == 0b {
-        "#23d183"
-      } else if $e < 1mb {
-        "#35a08f"
-      } else {{ fg: "#325d96" }}
+        if $e == 0b {
+            "#23d183"
+        } else if $e < 1mb {
+            "#35a08f"
+        } else {{ fg: "#325d96" }}
     }
     duration: "#23d183"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#be2d26" attr: "b" }
-      } else if $in < 6hr {
-        "#be2d26"
-      } else if $in < 1day {
-        "#db8e27"
-      } else if $in < 3day {
-        "#1a9172"
-      } else if $in < 1wk {
-        { fg: "#1a9172" attr: "b" }
-      } else if $in < 6wk {
-        "#35a08f"
-      } else if $in < 52wk {
-        "#325d96"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#be2d26" attr: "b" }
+        } else if $in < 6hr {
+            "#be2d26"
+        } else if $in < 1day {
+            "#db8e27"
+        } else if $in < 3day {
+            "#1a9172"
+        } else if $in < 1wk {
+            { fg: "#1a9172" attr: "b" }
+        } else if $in < 6wk {
+            "#35a08f"
+        } else if $in < 52wk {
+            "#325d96"
+        } else { "dark_gray" }
     }
     range: "#23d183"
     float: "#23d183"

--- a/themes/themes/treehouse.nu
+++ b/themes/themes/treehouse.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#f07d14" } else { "light_gray" } }
     int: "#786b53"
     filesize: {|e|
-      if $e == 0b {
-        "#786b53"
-      } else if $e < 1mb {
-        "#b25a1e"
-      } else {{ fg: "#58859a" }}
+        if $e == 0b {
+            "#786b53"
+        } else if $e < 1mb {
+            "#b25a1e"
+        } else {{ fg: "#58859a" }}
     }
     duration: "#786b53"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b2270e" attr: "b" }
-      } else if $in < 6hr {
-        "#b2270e"
-      } else if $in < 1day {
-        "#aa820c"
-      } else if $in < 3day {
-        "#44a900"
-      } else if $in < 1wk {
-        { fg: "#44a900" attr: "b" }
-      } else if $in < 6wk {
-        "#b25a1e"
-      } else if $in < 52wk {
-        "#58859a"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b2270e" attr: "b" }
+        } else if $in < 6hr {
+            "#b2270e"
+        } else if $in < 1day {
+            "#aa820c"
+        } else if $in < 3day {
+            "#44a900"
+        } else if $in < 1wk {
+            { fg: "#44a900" attr: "b" }
+        } else if $in < 6wk {
+            "#b25a1e"
+        } else if $in < 52wk {
+            "#58859a"
+        } else { "dark_gray" }
     }
     range: "#786b53"
     float: "#786b53"

--- a/themes/themes/tube.nu
+++ b/themes/themes/tube.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#85cebc" } else { "light_gray" } }
     int: "#d9d8d8"
     filesize: {|e|
-      if $e == 0b {
-        "#d9d8d8"
-      } else if $e < 1mb {
-        "#85cebc"
-      } else {{ fg: "#009ddc" }}
+        if $e == 0b {
+            "#d9d8d8"
+        } else if $e < 1mb {
+            "#85cebc"
+        } else {{ fg: "#009ddc" }}
     }
     duration: "#d9d8d8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ee2e24" attr: "b" }
-      } else if $in < 6hr {
-        "#ee2e24"
-      } else if $in < 1day {
-        "#ffd204"
-      } else if $in < 3day {
-        "#00853e"
-      } else if $in < 1wk {
-        { fg: "#00853e" attr: "b" }
-      } else if $in < 6wk {
-        "#85cebc"
-      } else if $in < 52wk {
-        "#009ddc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ee2e24" attr: "b" }
+        } else if $in < 6hr {
+            "#ee2e24"
+        } else if $in < 1day {
+            "#ffd204"
+        } else if $in < 3day {
+            "#00853e"
+        } else if $in < 1wk {
+            { fg: "#00853e" attr: "b" }
+        } else if $in < 6wk {
+            "#85cebc"
+        } else if $in < 52wk {
+            "#009ddc"
+        } else { "dark_gray" }
     }
     range: "#d9d8d8"
     float: "#d9d8d8"

--- a/themes/themes/twilight.nu
+++ b/themes/themes/twilight.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#afc4db" } else { "light_gray" } }
     int: "#a7a7a7"
     filesize: {|e|
-      if $e == 0b {
-        "#a7a7a7"
-      } else if $e < 1mb {
-        "#afc4db"
-      } else {{ fg: "#7587a6" }}
+        if $e == 0b {
+            "#a7a7a7"
+        } else if $e < 1mb {
+            "#afc4db"
+        } else {{ fg: "#7587a6" }}
     }
     duration: "#a7a7a7"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cf6a4c" attr: "b" }
-      } else if $in < 6hr {
-        "#cf6a4c"
-      } else if $in < 1day {
-        "#f9ee98"
-      } else if $in < 3day {
-        "#8f9d6a"
-      } else if $in < 1wk {
-        { fg: "#8f9d6a" attr: "b" }
-      } else if $in < 6wk {
-        "#afc4db"
-      } else if $in < 52wk {
-        "#7587a6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cf6a4c" attr: "b" }
+        } else if $in < 6hr {
+            "#cf6a4c"
+        } else if $in < 1day {
+            "#f9ee98"
+        } else if $in < 3day {
+            "#8f9d6a"
+        } else if $in < 1wk {
+            { fg: "#8f9d6a" attr: "b" }
+        } else if $in < 6wk {
+            "#afc4db"
+        } else if $in < 52wk {
+            "#7587a6"
+        } else { "dark_gray" }
     }
     range: "#a7a7a7"
     float: "#a7a7a7"

--- a/themes/themes/two-firewatch.nu
+++ b/themes/themes/two-firewatch.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#56b6c2" } else { "light_gray" } }
     int: "#dcdfe4"
     filesize: {|e|
-      if $e == 0b {
-        "#dcdfe4"
-      } else if $e < 1mb {
-        "#56b6c2"
-      } else {{ fg: "#61afef" }}
+        if $e == 0b {
+            "#dcdfe4"
+        } else if $e < 1mb {
+            "#56b6c2"
+        } else {{ fg: "#61afef" }}
     }
     duration: "#dcdfe4"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e06c75" attr: "b" }
-      } else if $in < 6hr {
-        "#e06c75"
-      } else if $in < 1day {
-        "#e5c07b"
-      } else if $in < 3day {
-        "#98c379"
-      } else if $in < 1wk {
-        { fg: "#98c379" attr: "b" }
-      } else if $in < 6wk {
-        "#56b6c2"
-      } else if $in < 52wk {
-        "#61afef"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e06c75" attr: "b" }
+        } else if $in < 6hr {
+            "#e06c75"
+        } else if $in < 1day {
+            "#e5c07b"
+        } else if $in < 3day {
+            "#98c379"
+        } else if $in < 1wk {
+            { fg: "#98c379" attr: "b" }
+        } else if $in < 6wk {
+            "#56b6c2"
+        } else if $in < 52wk {
+            "#61afef"
+        } else { "dark_gray" }
     }
     range: "#dcdfe4"
     float: "#dcdfe4"

--- a/themes/themes/unikitty-dark.nu
+++ b/themes/themes/unikitty-dark.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#149bda" } else { "light_gray" } }
     int: "#bcbabe"
     filesize: {|e|
-      if $e == 0b {
-        "#bcbabe"
-      } else if $e < 1mb {
-        "#149bda"
-      } else {{ fg: "#796af5" }}
+        if $e == 0b {
+            "#bcbabe"
+        } else if $e < 1mb {
+            "#149bda"
+        } else {{ fg: "#796af5" }}
     }
     duration: "#bcbabe"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d8137f" attr: "b" }
-      } else if $in < 6hr {
-        "#d8137f"
-      } else if $in < 1day {
-        "#dc8a0e"
-      } else if $in < 3day {
-        "#17ad98"
-      } else if $in < 1wk {
-        { fg: "#17ad98" attr: "b" }
-      } else if $in < 6wk {
-        "#149bda"
-      } else if $in < 52wk {
-        "#796af5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d8137f" attr: "b" }
+        } else if $in < 6hr {
+            "#d8137f"
+        } else if $in < 1day {
+            "#dc8a0e"
+        } else if $in < 3day {
+            "#17ad98"
+        } else if $in < 1wk {
+            { fg: "#17ad98" attr: "b" }
+        } else if $in < 6wk {
+            "#149bda"
+        } else if $in < 52wk {
+            "#796af5"
+        } else { "dark_gray" }
     }
     range: "#bcbabe"
     float: "#bcbabe"

--- a/themes/themes/unikitty-light.nu
+++ b/themes/themes/unikitty-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#149bda" } else { "light_gray" } }
     int: "#6c696e"
     filesize: {|e|
-      if $e == 0b {
-        "#6c696e"
-      } else if $e < 1mb {
-        "#149bda"
-      } else {{ fg: "#775dff" }}
+        if $e == 0b {
+            "#6c696e"
+        } else if $e < 1mb {
+            "#149bda"
+        } else {{ fg: "#775dff" }}
     }
     duration: "#6c696e"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d8137f" attr: "b" }
-      } else if $in < 6hr {
-        "#d8137f"
-      } else if $in < 1day {
-        "#dc8a0e"
-      } else if $in < 3day {
-        "#17ad98"
-      } else if $in < 1wk {
-        { fg: "#17ad98" attr: "b" }
-      } else if $in < 6wk {
-        "#149bda"
-      } else if $in < 52wk {
-        "#775dff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d8137f" attr: "b" }
+        } else if $in < 6hr {
+            "#d8137f"
+        } else if $in < 1day {
+            "#dc8a0e"
+        } else if $in < 3day {
+            "#17ad98"
+        } else if $in < 1wk {
+            { fg: "#17ad98" attr: "b" }
+        } else if $in < 6wk {
+            "#149bda"
+        } else if $in < 52wk {
+            "#775dff"
+        } else { "dark_gray" }
     }
     range: "#6c696e"
     float: "#6c696e"

--- a/themes/themes/ura.nu
+++ b/themes/themes/ura.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#84eeb9" } else { "light_gray" } }
     int: "#808080"
     filesize: {|e|
-      if $e == 0b {
-        "#808080"
-      } else if $e < 1mb {
-        "#1bc26f"
-      } else {{ fg: "#1b6fc2" }}
+        if $e == 0b {
+            "#808080"
+        } else if $e < 1mb {
+            "#1bc26f"
+        } else {{ fg: "#1b6fc2" }}
     }
     duration: "#808080"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c21b6f" attr: "b" }
-      } else if $in < 6hr {
-        "#c21b6f"
-      } else if $in < 1day {
-        "#c26f1b"
-      } else if $in < 3day {
-        "#6fc21b"
-      } else if $in < 1wk {
-        { fg: "#6fc21b" attr: "b" }
-      } else if $in < 6wk {
-        "#1bc26f"
-      } else if $in < 52wk {
-        "#1b6fc2"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c21b6f" attr: "b" }
+        } else if $in < 6hr {
+            "#c21b6f"
+        } else if $in < 1day {
+            "#c26f1b"
+        } else if $in < 3day {
+            "#6fc21b"
+        } else if $in < 1wk {
+            { fg: "#6fc21b" attr: "b" }
+        } else if $in < 6wk {
+            "#1bc26f"
+        } else if $in < 52wk {
+            "#1b6fc2"
+        } else { "dark_gray" }
     }
     range: "#808080"
     float: "#808080"

--- a/themes/themes/urple.nu
+++ b/themes/themes/urple.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#eaeaea" } else { "light_gray" } }
     int: "#87799c"
     filesize: {|e|
-      if $e == 0b {
-        "#87799c"
-      } else if $e < 1mb {
-        "#808080"
-      } else {{ fg: "#564d9b" }}
+        if $e == 0b {
+            "#87799c"
+        } else if $e < 1mb {
+            "#808080"
+        } else {{ fg: "#564d9b" }}
     }
     duration: "#87799c"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b0425b" attr: "b" }
-      } else if $in < 6hr {
-        "#b0425b"
-      } else if $in < 1day {
-        "#ad5c42"
-      } else if $in < 3day {
-        "#37a415"
-      } else if $in < 1wk {
-        { fg: "#37a415" attr: "b" }
-      } else if $in < 6wk {
-        "#808080"
-      } else if $in < 52wk {
-        "#564d9b"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b0425b" attr: "b" }
+        } else if $in < 6hr {
+            "#b0425b"
+        } else if $in < 1day {
+            "#ad5c42"
+        } else if $in < 3day {
+            "#37a415"
+        } else if $in < 1wk {
+            { fg: "#37a415" attr: "b" }
+        } else if $in < 6wk {
+            "#808080"
+        } else if $in < 52wk {
+            "#564d9b"
+        } else { "dark_gray" }
     }
     range: "#87799c"
     float: "#87799c"

--- a/themes/themes/vag.nu
+++ b/themes/themes/vag.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3b76b0" } else { "light_gray" } }
     int: "#8a8a8a"
     filesize: {|e|
-      if $e == 0b {
-        "#8a8a8a"
-      } else if $e < 1mb {
-        "#3971a8"
-      } else {{ fg: "#7139a8" }}
+        if $e == 0b {
+            "#8a8a8a"
+        } else if $e < 1mb {
+            "#3971a8"
+        } else {{ fg: "#7139a8" }}
     }
     duration: "#8a8a8a"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a87139" attr: "b" }
-      } else if $in < 6hr {
-        "#a87139"
-      } else if $in < 1day {
-        "#71a839"
-      } else if $in < 3day {
-        "#39a871"
-      } else if $in < 1wk {
-        { fg: "#39a871" attr: "b" }
-      } else if $in < 6wk {
-        "#3971a8"
-      } else if $in < 52wk {
-        "#7139a8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a87139" attr: "b" }
+        } else if $in < 6hr {
+            "#a87139"
+        } else if $in < 1day {
+            "#71a839"
+        } else if $in < 3day {
+            "#39a871"
+        } else if $in < 1wk {
+            { fg: "#39a871" attr: "b" }
+        } else if $in < 6wk {
+            "#3971a8"
+        } else if $in < 52wk {
+            "#7139a8"
+        } else { "dark_gray" }
     }
     range: "#8a8a8a"
     float: "#8a8a8a"

--- a/themes/themes/vaughn.nu
+++ b/themes/themes/vaughn.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#93e0e3" } else { "light_gray" } }
     int: "#709080"
     filesize: {|e|
-      if $e == 0b {
-        "#709080"
-      } else if $e < 1mb {
-        "#8cd0d3"
-      } else {{ fg: "#5555ff" }}
+        if $e == 0b {
+            "#709080"
+        } else if $e < 1mb {
+            "#8cd0d3"
+        } else {{ fg: "#5555ff" }}
     }
     duration: "#709080"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#705050" attr: "b" }
-      } else if $in < 6hr {
-        "#705050"
-      } else if $in < 1day {
-        "#dfaf8f"
-      } else if $in < 3day {
-        "#60b48a"
-      } else if $in < 1wk {
-        { fg: "#60b48a" attr: "b" }
-      } else if $in < 6wk {
-        "#8cd0d3"
-      } else if $in < 52wk {
-        "#5555ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#705050" attr: "b" }
+        } else if $in < 6hr {
+            "#705050"
+        } else if $in < 1day {
+            "#dfaf8f"
+        } else if $in < 3day {
+            "#60b48a"
+        } else if $in < 1wk {
+            { fg: "#60b48a" attr: "b" }
+        } else if $in < 6wk {
+            "#8cd0d3"
+        } else if $in < 52wk {
+            "#5555ff"
+        } else { "dark_gray" }
     }
     range: "#709080"
     float: "#709080"

--- a/themes/themes/vibrant-ink.nu
+++ b/themes/themes/vibrant-ink.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00ffff" } else { "light_gray" } }
     int: "#f5f5f5"
     filesize: {|e|
-      if $e == 0b {
-        "#f5f5f5"
-      } else if $e < 1mb {
-        "#44b4cc"
-      } else {{ fg: "#44b4cc" }}
+        if $e == 0b {
+            "#f5f5f5"
+        } else if $e < 1mb {
+            "#44b4cc"
+        } else {{ fg: "#44b4cc" }}
     }
     duration: "#f5f5f5"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff6600" attr: "b" }
-      } else if $in < 6hr {
-        "#ff6600"
-      } else if $in < 1day {
-        "#ffcc00"
-      } else if $in < 3day {
-        "#ccff04"
-      } else if $in < 1wk {
-        { fg: "#ccff04" attr: "b" }
-      } else if $in < 6wk {
-        "#44b4cc"
-      } else if $in < 52wk {
-        "#44b4cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff6600" attr: "b" }
+        } else if $in < 6hr {
+            "#ff6600"
+        } else if $in < 1day {
+            "#ffcc00"
+        } else if $in < 3day {
+            "#ccff04"
+        } else if $in < 1wk {
+            { fg: "#ccff04" attr: "b" }
+        } else if $in < 6wk {
+            "#44b4cc"
+        } else if $in < 52wk {
+            "#44b4cc"
+        } else { "dark_gray" }
     }
     range: "#f5f5f5"
     float: "#f5f5f5"

--- a/themes/themes/vs-code-dark-plus.nu
+++ b/themes/themes/vs-code-dark-plus.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5fffff" } else { "light_gray" } }
     int: "#c3dde1"
     filesize: {|e|
-      if $e == 0b {
-        "#c3dde1"
-      } else if $e < 1mb {
-        "#3dd5e7"
-      } else {{ fg: "#44aae6" }}
+        if $e == 0b {
+            "#c3dde1"
+        } else if $e < 1mb {
+            "#3dd5e7"
+        } else {{ fg: "#44aae6" }}
     }
     duration: "#c3dde1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e9653b" attr: "b" }
-      } else if $in < 6hr {
-        "#e9653b"
-      } else if $in < 1day {
-        "#e5b684"
-      } else if $in < 3day {
-        "#39e9a8"
-      } else if $in < 1wk {
-        { fg: "#39e9a8" attr: "b" }
-      } else if $in < 6wk {
-        "#3dd5e7"
-      } else if $in < 52wk {
-        "#44aae6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e9653b" attr: "b" }
+        } else if $in < 6hr {
+            "#e9653b"
+        } else if $in < 1day {
+            "#e5b684"
+        } else if $in < 3day {
+            "#39e9a8"
+        } else if $in < 1wk {
+            { fg: "#39e9a8" attr: "b" }
+        } else if $in < 6wk {
+            "#3dd5e7"
+        } else if $in < 52wk {
+            "#44aae6"
+        } else { "dark_gray" }
     }
     range: "#c3dde1"
     float: "#c3dde1"

--- a/themes/themes/vulcan.nu
+++ b/themes/themes/vulcan.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#977d7c" } else { "light_gray" } }
     int: "#5b778c"
     filesize: {|e|
-      if $e == 0b {
-        "#5b778c"
-      } else if $e < 1mb {
-        "#977d7c"
-      } else {{ fg: "#977d7c" }}
+        if $e == 0b {
+            "#5b778c"
+        } else if $e < 1mb {
+            "#977d7c"
+        } else {{ fg: "#977d7c" }}
     }
     duration: "#5b778c"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#818591" attr: "b" }
-      } else if $in < 6hr {
-        "#818591"
-      } else if $in < 1day {
-        "#adb4b9"
-      } else if $in < 3day {
-        "#977d7c"
-      } else if $in < 1wk {
-        { fg: "#977d7c" attr: "b" }
-      } else if $in < 6wk {
-        "#977d7c"
-      } else if $in < 52wk {
-        "#977d7c"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#818591" attr: "b" }
+        } else if $in < 6hr {
+            "#818591"
+        } else if $in < 1day {
+            "#adb4b9"
+        } else if $in < 3day {
+            "#977d7c"
+        } else if $in < 1wk {
+            { fg: "#977d7c" attr: "b" }
+        } else if $in < 6wk {
+            "#977d7c"
+        } else if $in < 52wk {
+            "#977d7c"
+        } else { "dark_gray" }
     }
     range: "#5b778c"
     float: "#5b778c"

--- a/themes/themes/warm-neon.nu
+++ b/themes/themes/warm-neon.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#5ed1e5" } else { "light_gray" } }
     int: "#d0b8a3"
     filesize: {|e|
-      if $e == 0b {
-        "#d0b8a3"
-      } else if $e < 1mb {
-        "#2abbd4"
-      } else {{ fg: "#4261c5" }}
+        if $e == 0b {
+            "#d0b8a3"
+        } else if $e < 1mb {
+            "#2abbd4"
+        } else {{ fg: "#4261c5" }}
     }
     duration: "#d0b8a3"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e24346" attr: "b" }
-      } else if $in < 6hr {
-        "#e24346"
-      } else if $in < 1day {
-        "#dae145"
-      } else if $in < 3day {
-        "#39b13a"
-      } else if $in < 1wk {
-        { fg: "#39b13a" attr: "b" }
-      } else if $in < 6wk {
-        "#2abbd4"
-      } else if $in < 52wk {
-        "#4261c5"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e24346" attr: "b" }
+        } else if $in < 6hr {
+            "#e24346"
+        } else if $in < 1day {
+            "#dae145"
+        } else if $in < 3day {
+            "#39b13a"
+        } else if $in < 1wk {
+            { fg: "#39b13a" attr: "b" }
+        } else if $in < 6wk {
+            "#2abbd4"
+        } else if $in < 52wk {
+            "#4261c5"
+        } else { "dark_gray" }
     }
     range: "#d0b8a3"
     float: "#d0b8a3"

--- a/themes/themes/wez.nu
+++ b/themes/themes/wez.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#55ffff" } else { "light_gray" } }
     int: "#cccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#cccccc"
-      } else if $e < 1mb {
-        "#7acaca"
-      } else {{ fg: "#5555cc" }}
+        if $e == 0b {
+            "#cccccc"
+        } else if $e < 1mb {
+            "#7acaca"
+        } else {{ fg: "#5555cc" }}
     }
     duration: "#cccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#cc5555" attr: "b" }
-      } else if $in < 6hr {
-        "#cc5555"
-      } else if $in < 1day {
-        "#cdcd55"
-      } else if $in < 3day {
-        "#55cc55"
-      } else if $in < 1wk {
-        { fg: "#55cc55" attr: "b" }
-      } else if $in < 6wk {
-        "#7acaca"
-      } else if $in < 52wk {
-        "#5555cc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#cc5555" attr: "b" }
+        } else if $in < 6hr {
+            "#cc5555"
+        } else if $in < 1day {
+            "#cdcd55"
+        } else if $in < 3day {
+            "#55cc55"
+        } else if $in < 1wk {
+            { fg: "#55cc55" attr: "b" }
+        } else if $in < 6wk {
+            "#7acaca"
+        } else if $in < 52wk {
+            "#5555cc"
+        } else { "dark_gray" }
     }
     range: "#cccccc"
     float: "#cccccc"

--- a/themes/themes/wild-cherry.nu
+++ b/themes/themes/wild-cherry.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ff919d" } else { "light_gray" } }
     int: "#fff8de"
     filesize: {|e|
-      if $e == 0b {
-        "#fff8de"
-      } else if $e < 1mb {
-        "#c1b8b7"
-      } else {{ fg: "#883cdc" }}
+        if $e == 0b {
+            "#fff8de"
+        } else if $e < 1mb {
+            "#c1b8b7"
+        } else {{ fg: "#883cdc" }}
     }
     duration: "#fff8de"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d94085" attr: "b" }
-      } else if $in < 6hr {
-        "#d94085"
-      } else if $in < 1day {
-        "#ffd16f"
-      } else if $in < 3day {
-        "#2ab250"
-      } else if $in < 1wk {
-        { fg: "#2ab250" attr: "b" }
-      } else if $in < 6wk {
-        "#c1b8b7"
-      } else if $in < 52wk {
-        "#883cdc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d94085" attr: "b" }
+        } else if $in < 6hr {
+            "#d94085"
+        } else if $in < 1day {
+            "#ffd16f"
+        } else if $in < 3day {
+            "#2ab250"
+        } else if $in < 1wk {
+            { fg: "#2ab250" attr: "b" }
+        } else if $in < 6wk {
+            "#c1b8b7"
+        } else if $in < 52wk {
+            "#883cdc"
+        } else { "dark_gray" }
     }
     range: "#fff8de"
     float: "#fff8de"

--- a/themes/themes/windows-10-light.nu
+++ b/themes/themes/windows-10-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#3a96dd" } else { "light_gray" } }
     int: "#767676"
     filesize: {|e|
-      if $e == 0b {
-        "#767676"
-      } else if $e < 1mb {
-        "#3a96dd"
-      } else {{ fg: "#0037da" }}
+        if $e == 0b {
+            "#767676"
+        } else if $e < 1mb {
+            "#3a96dd"
+        } else {{ fg: "#0037da" }}
     }
     duration: "#767676"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#c50f1f" attr: "b" }
-      } else if $in < 6hr {
-        "#c50f1f"
-      } else if $in < 1day {
-        "#c19c00"
-      } else if $in < 3day {
-        "#13a10e"
-      } else if $in < 1wk {
-        { fg: "#13a10e" attr: "b" }
-      } else if $in < 6wk {
-        "#3a96dd"
-      } else if $in < 52wk {
-        "#0037da"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#c50f1f" attr: "b" }
+        } else if $in < 6hr {
+            "#c50f1f"
+        } else if $in < 1day {
+            "#c19c00"
+        } else if $in < 3day {
+            "#13a10e"
+        } else if $in < 1wk {
+            { fg: "#13a10e" attr: "b" }
+        } else if $in < 6wk {
+            "#3a96dd"
+        } else if $in < 52wk {
+            "#0037da"
+        } else { "dark_gray" }
     }
     range: "#767676"
     float: "#767676"

--- a/themes/themes/windows-10.nu
+++ b/themes/themes/windows-10.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#61d6d6" } else { "light_gray" } }
     int: "#cccccc"
     filesize: {|e|
-      if $e == 0b {
-        "#cccccc"
-      } else if $e < 1mb {
-        "#61d6d6"
-      } else {{ fg: "#3b78ff" }}
+        if $e == 0b {
+            "#cccccc"
+        } else if $e < 1mb {
+            "#61d6d6"
+        } else {{ fg: "#3b78ff" }}
     }
     duration: "#cccccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#e74856" attr: "b" }
-      } else if $in < 6hr {
-        "#e74856"
-      } else if $in < 1day {
-        "#f9f1a5"
-      } else if $in < 3day {
-        "#16c60c"
-      } else if $in < 1wk {
-        { fg: "#16c60c" attr: "b" }
-      } else if $in < 6wk {
-        "#61d6d6"
-      } else if $in < 52wk {
-        "#3b78ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#e74856" attr: "b" }
+        } else if $in < 6hr {
+            "#e74856"
+        } else if $in < 1day {
+            "#f9f1a5"
+        } else if $in < 3day {
+            "#16c60c"
+        } else if $in < 1wk {
+            { fg: "#16c60c" attr: "b" }
+        } else if $in < 6wk {
+            "#61d6d6"
+        } else if $in < 52wk {
+            "#3b78ff"
+        } else { "dark_gray" }
     }
     range: "#cccccc"
     float: "#cccccc"

--- a/themes/themes/windows-95-light.nu
+++ b/themes/themes/windows-95-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00a8a8" } else { "light_gray" } }
     int: "#545454"
     filesize: {|e|
-      if $e == 0b {
-        "#545454"
-      } else if $e < 1mb {
-        "#00a8a8"
-      } else {{ fg: "#0000a8" }}
+        if $e == 0b {
+            "#545454"
+        } else if $e < 1mb {
+            "#00a8a8"
+        } else {{ fg: "#0000a8" }}
     }
     duration: "#545454"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#a80000" attr: "b" }
-      } else if $in < 6hr {
-        "#a80000"
-      } else if $in < 1day {
-        "#a85400"
-      } else if $in < 3day {
-        "#00a800"
-      } else if $in < 1wk {
-        { fg: "#00a800" attr: "b" }
-      } else if $in < 6wk {
-        "#00a8a8"
-      } else if $in < 52wk {
-        "#0000a8"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#a80000" attr: "b" }
+        } else if $in < 6hr {
+            "#a80000"
+        } else if $in < 1day {
+            "#a85400"
+        } else if $in < 3day {
+            "#00a800"
+        } else if $in < 1wk {
+            { fg: "#00a800" attr: "b" }
+        } else if $in < 6wk {
+            "#00a8a8"
+        } else if $in < 52wk {
+            "#0000a8"
+        } else { "dark_gray" }
     }
     range: "#545454"
     float: "#545454"

--- a/themes/themes/windows-95.nu
+++ b/themes/themes/windows-95.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#54fcfc" } else { "light_gray" } }
     int: "#a8a8a8"
     filesize: {|e|
-      if $e == 0b {
-        "#a8a8a8"
-      } else if $e < 1mb {
-        "#54fcfc"
-      } else {{ fg: "#5454fc" }}
+        if $e == 0b {
+            "#a8a8a8"
+        } else if $e < 1mb {
+            "#54fcfc"
+        } else {{ fg: "#5454fc" }}
     }
     duration: "#a8a8a8"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fc5454" attr: "b" }
-      } else if $in < 6hr {
-        "#fc5454"
-      } else if $in < 1day {
-        "#fcfc54"
-      } else if $in < 3day {
-        "#54fc54"
-      } else if $in < 1wk {
-        { fg: "#54fc54" attr: "b" }
-      } else if $in < 6wk {
-        "#54fcfc"
-      } else if $in < 52wk {
-        "#5454fc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fc5454" attr: "b" }
+        } else if $in < 6hr {
+            "#fc5454"
+        } else if $in < 1day {
+            "#fcfc54"
+        } else if $in < 3day {
+            "#54fc54"
+        } else if $in < 1wk {
+            { fg: "#54fc54" attr: "b" }
+        } else if $in < 6wk {
+            "#54fcfc"
+        } else if $in < 52wk {
+            "#5454fc"
+        } else { "dark_gray" }
     }
     range: "#a8a8a8"
     float: "#a8a8a8"

--- a/themes/themes/windows-highcontrast-light.nu
+++ b/themes/themes/windows-highcontrast-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#008080" } else { "light_gray" } }
     int: "#545454"
     filesize: {|e|
-      if $e == 0b {
-        "#545454"
-      } else if $e < 1mb {
-        "#008080"
-      } else {{ fg: "#000080" }}
+        if $e == 0b {
+            "#545454"
+        } else if $e < 1mb {
+            "#008080"
+        } else {{ fg: "#000080" }}
     }
     duration: "#545454"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#800000" attr: "b" }
-      } else if $in < 6hr {
-        "#800000"
-      } else if $in < 1day {
-        "#808000"
-      } else if $in < 3day {
-        "#008000"
-      } else if $in < 1wk {
-        { fg: "#008000" attr: "b" }
-      } else if $in < 6wk {
-        "#008080"
-      } else if $in < 52wk {
-        "#000080"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#800000" attr: "b" }
+        } else if $in < 6hr {
+            "#800000"
+        } else if $in < 1day {
+            "#808000"
+        } else if $in < 3day {
+            "#008000"
+        } else if $in < 1wk {
+            { fg: "#008000" attr: "b" }
+        } else if $in < 6wk {
+            "#008080"
+        } else if $in < 52wk {
+            "#000080"
+        } else { "dark_gray" }
     }
     range: "#545454"
     float: "#545454"

--- a/themes/themes/windows-highcontrast.nu
+++ b/themes/themes/windows-highcontrast.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#54fcfc" } else { "light_gray" } }
     int: "#c0c0c0"
     filesize: {|e|
-      if $e == 0b {
-        "#c0c0c0"
-      } else if $e < 1mb {
-        "#54fcfc"
-      } else {{ fg: "#5454fc" }}
+        if $e == 0b {
+            "#c0c0c0"
+        } else if $e < 1mb {
+            "#54fcfc"
+        } else {{ fg: "#5454fc" }}
     }
     duration: "#c0c0c0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#fc5454" attr: "b" }
-      } else if $in < 6hr {
-        "#fc5454"
-      } else if $in < 1day {
-        "#fcfc54"
-      } else if $in < 3day {
-        "#54fc54"
-      } else if $in < 1wk {
-        { fg: "#54fc54" attr: "b" }
-      } else if $in < 6wk {
-        "#54fcfc"
-      } else if $in < 52wk {
-        "#5454fc"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#fc5454" attr: "b" }
+        } else if $in < 6hr {
+            "#fc5454"
+        } else if $in < 1day {
+            "#fcfc54"
+        } else if $in < 3day {
+            "#54fc54"
+        } else if $in < 1wk {
+            { fg: "#54fc54" attr: "b" }
+        } else if $in < 6wk {
+            "#54fcfc"
+        } else if $in < 52wk {
+            "#5454fc"
+        } else { "dark_gray" }
     }
     range: "#c0c0c0"
     float: "#c0c0c0"

--- a/themes/themes/windows-nt-light.nu
+++ b/themes/themes/windows-nt-light.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#008080" } else { "light_gray" } }
     int: "#808080"
     filesize: {|e|
-      if $e == 0b {
-        "#808080"
-      } else if $e < 1mb {
-        "#008080"
-      } else {{ fg: "#000080" }}
+        if $e == 0b {
+            "#808080"
+        } else if $e < 1mb {
+            "#008080"
+        } else {{ fg: "#000080" }}
     }
     duration: "#808080"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#800000" attr: "b" }
-      } else if $in < 6hr {
-        "#800000"
-      } else if $in < 1day {
-        "#808000"
-      } else if $in < 3day {
-        "#008000"
-      } else if $in < 1wk {
-        { fg: "#008000" attr: "b" }
-      } else if $in < 6wk {
-        "#008080"
-      } else if $in < 52wk {
-        "#000080"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#800000" attr: "b" }
+        } else if $in < 6hr {
+            "#800000"
+        } else if $in < 1day {
+            "#808000"
+        } else if $in < 3day {
+            "#008000"
+        } else if $in < 1wk {
+            { fg: "#008000" attr: "b" }
+        } else if $in < 6wk {
+            "#008080"
+        } else if $in < 52wk {
+            "#000080"
+        } else { "dark_gray" }
     }
     range: "#808080"
     float: "#808080"

--- a/themes/themes/windows-nt.nu
+++ b/themes/themes/windows-nt.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00ffff" } else { "light_gray" } }
     int: "#c0c0c0"
     filesize: {|e|
-      if $e == 0b {
-        "#c0c0c0"
-      } else if $e < 1mb {
-        "#00ffff"
-      } else {{ fg: "#0000ff" }}
+        if $e == 0b {
+            "#c0c0c0"
+        } else if $e < 1mb {
+            "#00ffff"
+        } else {{ fg: "#0000ff" }}
     }
     duration: "#c0c0c0"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff0000" attr: "b" }
-      } else if $in < 6hr {
-        "#ff0000"
-      } else if $in < 1day {
-        "#ffff00"
-      } else if $in < 3day {
-        "#00ff00"
-      } else if $in < 1wk {
-        { fg: "#00ff00" attr: "b" }
-      } else if $in < 6wk {
-        "#00ffff"
-      } else if $in < 52wk {
-        "#0000ff"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff0000" attr: "b" }
+        } else if $in < 6hr {
+            "#ff0000"
+        } else if $in < 1day {
+            "#ffff00"
+        } else if $in < 3day {
+            "#00ff00"
+        } else if $in < 1wk {
+            { fg: "#00ff00" attr: "b" }
+        } else if $in < 6wk {
+            "#00ffff"
+        } else if $in < 52wk {
+            "#0000ff"
+        } else { "dark_gray" }
     }
     range: "#c0c0c0"
     float: "#c0c0c0"

--- a/themes/themes/wombat.nu
+++ b/themes/themes/wombat.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#b7fff9" } else { "light_gray" } }
     int: "#dedacf"
     filesize: {|e|
-      if $e == 0b {
-        "#dedacf"
-      } else if $e < 1mb {
-        "#82fff7"
-      } else {{ fg: "#5da9f6" }}
+        if $e == 0b {
+            "#dedacf"
+        } else if $e < 1mb {
+            "#82fff7"
+        } else {{ fg: "#5da9f6" }}
     }
     duration: "#dedacf"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#ff615a" attr: "b" }
-      } else if $in < 6hr {
-        "#ff615a"
-      } else if $in < 1day {
-        "#ebd99c"
-      } else if $in < 3day {
-        "#b1e969"
-      } else if $in < 1wk {
-        { fg: "#b1e969" attr: "b" }
-      } else if $in < 6wk {
-        "#82fff7"
-      } else if $in < 52wk {
-        "#5da9f6"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#ff615a" attr: "b" }
+        } else if $in < 6hr {
+            "#ff615a"
+        } else if $in < 1day {
+            "#ebd99c"
+        } else if $in < 3day {
+            "#b1e969"
+        } else if $in < 1wk {
+            { fg: "#b1e969" attr: "b" }
+        } else if $in < 6wk {
+            "#82fff7"
+        } else if $in < 52wk {
+            "#5da9f6"
+        } else { "dark_gray" }
     }
     range: "#dedacf"
     float: "#dedacf"

--- a/themes/themes/woodland.nu
+++ b/themes/themes/woodland.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#6eb958" } else { "light_gray" } }
     int: "#cabcb1"
     filesize: {|e|
-      if $e == 0b {
-        "#cabcb1"
-      } else if $e < 1mb {
-        "#6eb958"
-      } else {{ fg: "#88a4d3" }}
+        if $e == 0b {
+            "#cabcb1"
+        } else if $e < 1mb {
+            "#6eb958"
+        } else {{ fg: "#88a4d3" }}
     }
     duration: "#cabcb1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#d35c5c" attr: "b" }
-      } else if $in < 6hr {
-        "#d35c5c"
-      } else if $in < 1day {
-        "#e0ac16"
-      } else if $in < 3day {
-        "#b7ba53"
-      } else if $in < 1wk {
-        { fg: "#b7ba53" attr: "b" }
-      } else if $in < 6wk {
-        "#6eb958"
-      } else if $in < 52wk {
-        "#88a4d3"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#d35c5c" attr: "b" }
+        } else if $in < 6hr {
+            "#d35c5c"
+        } else if $in < 1day {
+            "#e0ac16"
+        } else if $in < 3day {
+            "#b7ba53"
+        } else if $in < 1wk {
+            { fg: "#b7ba53" attr: "b" }
+        } else if $in < 6wk {
+            "#6eb958"
+        } else if $in < 52wk {
+            "#88a4d3"
+        } else { "dark_gray" }
     }
     range: "#cabcb1"
     float: "#cabcb1"

--- a/themes/themes/wryan.nu
+++ b/themes/themes/wryan.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#6096bf" } else { "light_gray" } }
     int: "#899ca1"
     filesize: {|e|
-      if $e == 0b {
-        "#899ca1"
-      } else if $e < 1mb {
-        "#31658c"
-      } else {{ fg: "#395573" }}
+        if $e == 0b {
+            "#899ca1"
+        } else if $e < 1mb {
+            "#31658c"
+        } else {{ fg: "#395573" }}
     }
     duration: "#899ca1"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#8c4665" attr: "b" }
-      } else if $in < 6hr {
-        "#8c4665"
-      } else if $in < 1day {
-        "#7c7c99"
-      } else if $in < 3day {
-        "#287373"
-      } else if $in < 1wk {
-        { fg: "#287373" attr: "b" }
-      } else if $in < 6wk {
-        "#31658c"
-      } else if $in < 52wk {
-        "#395573"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#8c4665" attr: "b" }
+        } else if $in < 6hr {
+            "#8c4665"
+        } else if $in < 1day {
+            "#7c7c99"
+        } else if $in < 3day {
+            "#287373"
+        } else if $in < 1wk {
+            { fg: "#287373" attr: "b" }
+        } else if $in < 6wk {
+            "#31658c"
+        } else if $in < 52wk {
+            "#395573"
+        } else { "dark_gray" }
     }
     range: "#899ca1"
     float: "#899ca1"

--- a/themes/themes/xcode-dusk.nu
+++ b/themes/themes/xcode-dusk.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#00a0be" } else { "light_gray" } }
     int: "#939599"
     filesize: {|e|
-      if $e == 0b {
-        "#939599"
-      } else if $e < 1mb {
-        "#00a0be"
-      } else {{ fg: "#790ead" }}
+        if $e == 0b {
+            "#939599"
+        } else if $e < 1mb {
+            "#00a0be"
+        } else {{ fg: "#790ead" }}
     }
     duration: "#939599"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#b21889" attr: "b" }
-      } else if $in < 6hr {
-        "#b21889"
-      } else if $in < 1day {
-        "#438288"
-      } else if $in < 3day {
-        "#df0002"
-      } else if $in < 1wk {
-        { fg: "#df0002" attr: "b" }
-      } else if $in < 6wk {
-        "#00a0be"
-      } else if $in < 52wk {
-        "#790ead"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#b21889" attr: "b" }
+        } else if $in < 6hr {
+            "#b21889"
+        } else if $in < 1day {
+            "#438288"
+        } else if $in < 3day {
+            "#df0002"
+        } else if $in < 1wk {
+            { fg: "#df0002" attr: "b" }
+        } else if $in < 6wk {
+            "#00a0be"
+        } else if $in < 52wk {
+            "#790ead"
+        } else { "dark_gray" }
     }
     range: "#939599"
     float: "#939599"

--- a/themes/themes/yachiyo.nu
+++ b/themes/themes/yachiyo.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#ff9c9c" } else { "light_gray" } }
     int: "#a0be99"
     filesize: {|e|
-      if $e == 0b {
-        "#a0be99"
-      } else if $e < 1mb {
-        "#ff9c9c"
-      } else {{ fg: "#ada883" }}
+        if $e == 0b {
+            "#a0be99"
+        } else if $e < 1mb {
+            "#ff9c9c"
+        } else {{ fg: "#ada883" }}
     }
     duration: "#a0be99"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#86b79b" attr: "b" }
-      } else if $in < 6hr {
-        "#86b79b"
-      } else if $in < 1day {
-        "#d4b34e"
-      } else if $in < 3day {
-        "#b9a9d7"
-      } else if $in < 1wk {
-        { fg: "#b9a9d7" attr: "b" }
-      } else if $in < 6wk {
-        "#ff9c9c"
-      } else if $in < 52wk {
-        "#ada883"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#86b79b" attr: "b" }
+        } else if $in < 6hr {
+            "#86b79b"
+        } else if $in < 1day {
+            "#d4b34e"
+        } else if $in < 3day {
+            "#b9a9d7"
+        } else if $in < 1wk {
+            { fg: "#b9a9d7" attr: "b" }
+        } else if $in < 6wk {
+            "#ff9c9c"
+        } else if $in < 52wk {
+            "#ada883"
+        } else { "dark_gray" }
     }
     range: "#a0be99"
     float: "#a0be99"

--- a/themes/themes/zenburn.nu
+++ b/themes/themes/zenburn.nu
@@ -6,29 +6,29 @@ export def main [] { return {
     bool: {|| if $in { "#93e0e3" } else { "light_gray" } }
     int: "#dcdccc"
     filesize: {|e|
-      if $e == 0b {
-        "#dcdccc"
-      } else if $e < 1mb {
-        "#93e0e3"
-      } else {{ fg: "#7cb8bb" }}
+        if $e == 0b {
+            "#dcdccc"
+        } else if $e < 1mb {
+            "#93e0e3"
+        } else {{ fg: "#7cb8bb" }}
     }
     duration: "#dcdccc"
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        { fg: "#dca3a3" attr: "b" }
-      } else if $in < 6hr {
-        "#dca3a3"
-      } else if $in < 1day {
-        "#e0cf9f"
-      } else if $in < 3day {
-        "#5f7f5f"
-      } else if $in < 1wk {
-        { fg: "#5f7f5f" attr: "b" }
-      } else if $in < 6wk {
-        "#93e0e3"
-      } else if $in < 52wk {
-        "#7cb8bb"
-      } else { "dark_gray" }
+        if $in < 1hr {
+            { fg: "#dca3a3" attr: "b" }
+        } else if $in < 6hr {
+            "#dca3a3"
+        } else if $in < 1day {
+            "#e0cf9f"
+        } else if $in < 3day {
+            "#5f7f5f"
+        } else if $in < 1wk {
+            { fg: "#5f7f5f" attr: "b" }
+        } else if $in < 6wk {
+            "#93e0e3"
+        } else if $in < 52wk {
+            "#7cb8bb"
+        } else { "dark_gray" }
     }
     range: "#dcdccc"
     float: "#dcdccc"


### PR DESCRIPTION
this PR might look like a lot but it's just
- a small change to `themes/make.nu`
- a (huge?) change when regenerating all the themes

:relieved: 

in this PR, i make the indentation 4 spaces in the whole theme :+1: 