### PR TITLE
FEATURE: add the preview script for the themes

### DIFF
--- a/themes/preview-current.nu
+++ b/themes/preview-current.nu
@@ -1,0 +1,32 @@
+#!/usr/bin/env nu
+
+def main [] {
+    def preview [attr: string] {
+        let color = $in
+        $"(ansi -e {fg: $color attr: $attr})($color)(ansi reset)"
+    }
+
+    let colors = [
+        [normal   rgb];
+
+        [black   '#000000']
+        [red     '#FF0000']
+        [green   '#00FF00']
+        [yellow  '#FFFF00']
+        [blue    '#0000FF']
+        [magenta '#FF00FF']
+        [purple  '#FF00FF']
+        [cyan    '#00FFFF']
+        [white   '#FFFFFF']
+    ]
+
+    $colors | each {|color| {
+        dimmed: ($color.normal | preview d)
+        normal: ($color.normal | preview n)
+        bold: ($color.normal | preview b)
+
+        rgb_dimmed: ($color.rgb | preview d)
+        rgb_normal: ($color.rgb | preview n)
+        rgb_bold: ($color.rgb | preview b)
+    }}
+}


### PR DESCRIPTION
cc/ @fdncred 

Darren, this is actually greatly inspired from one of the scripts you shared on Discord, i made it a bit more general and thought it would be cool to share it :relieved: 

`./themes/preview-current.nu` would give an output like the following
![preview-current-theme](https://github.com/nushell/nu_scripts/assets/44101798/4f46169d-e7cb-4336-a73f-7a1815d3cbc2)
where the first three columns are the currently loaded theme and the three last are the pure colors printed in hex :+1: 