### PR TITLE
add a package file in NUON

### DIFF
--- a/package.nuon
+++ b/package.nuon
@@ -1,0 +1,6 @@
+{
+    name: "nu-scripts"
+    description: "A place to share Nushell scripts with each other"
+    documentation: "https://github.com/nushell/nu_scripts/blob/main/README.md"
+    license: "https://github.com/nushell/nu_scripts/blob/main/LICENSE"
+}


### PR DESCRIPTION
so i have this project of a [package manager for Nushell](https://github.com/amtoine/nupm) i'm trying to build to make installation of Nushell libraries easier :blush: 

the thing is
- i really want some things from the `nu_scripts`
- `nupm` requires a `package.nuon` file to consider a repository as a valid Nushell package

in this PR, i humbly ask the permission to add such a file to turn the `nu_scripts` into a *valid Nushell package* in the sense of `nupm` :relieved: 

> **Note**
> i tried this with my fork
> ```
> nupm install https://github.com/amtoine/nu_scripts --revision feature/add-package-file
> ```
> and then
> ```
> nupm activate nu-scripts/themes/themes/dracula.nu
> ```
> successfully brings the `dracula` theme from the `nu_scripts` inside the current scope :partying_face: 