### PR TITLE
auto-venv for python: update to be compatible with nu 0.80

### DIFF
--- a/modules/virtual_environments/auto-venv/README.md
+++ b/modules/virtual_environments/auto-venv/README.md
@@ -6,7 +6,7 @@ The scripts in this directory activate virtual environments whenever you cd into
 
 1. set `$env.AUTO_VENV_TRIGGER` as the preferred name of a trigger file
 1. import `auto-venv` into your environment
-1. `cp` the script file `./auto-venv/venvs/python-venv.nu` to a project as its trigger file at `/path/to/project/$AUTO_VENV_TRIGGER`
+1. Create a symlink via `ln -s` of the script file `./auto-venv/venvs/python-venv.nu` to a trigger file in project at `/path/to/project/$AUTO_VENV_TRIGGER`
 1. `cd` into `/path/to/project/`
 
 For example:

--- a/modules/virtual_environments/auto-venv/README.md
+++ b/modules/virtual_environments/auto-venv/README.md
@@ -4,21 +4,22 @@ The scripts in this directory activate virtual environments whenever you cd into
 
 ## Usage
 
-1. set `$env.AUTO_VENV_TRIGGER` to the name of a script file
+1. set `$env.AUTO_VENV_TRIGGER` as the preferred name of a trigger file
 1. import `auto-venv` into your environment
-1. cd into a folder that contains your trigger file
+1. `cp` the script file `./auto-venv/venvs/python-venv.nu` to a project as its trigger file at `/path/to/project/$AUTO_VENV_TRIGGER`
+1. `cd` into `/path/to/project/`
 
-ex.
+For example:
 ```nu
 # config.nu
 
 export-env {
     let-env AUTO_VENV_TRIGGER = '__auto-venv.nu'
 
-    source-env ~/path/to/nu_scripts/virtual_environments/auto-venv/auto-venv.nu
+    source-env ~/path/to/nu_scripts/modules/virtual_environments/auto-venv/auto-venv.nu
 }
 
-use ~/path/to/nu_scripts/virtual_environments/auto-venv/auto-venv.nu *
+use ~/path/to/nu_scripts/modules/virtual_environments/auto-venv/auto-venv.nu *
 ```
 
 When `auto-venv` detects that a file of that name exists in the folder you cd'ed into (or one of it's parents), it will automatically enable an overlay (as defined by the trigger file).

--- a/modules/virtual_environments/auto-venv/auto-venv.nu
+++ b/modules/virtual_environments/auto-venv/auto-venv.nu
@@ -35,7 +35,7 @@ def build-hooks [] {
         let _env = $env
         let pwd  = $_env.PWD
 
-        let trigger = (path_extensions path find-sub . __trigger__ --type "file")
+        let trigger = (path_extensions path find-sub . __trigger__ --type ["symlink", "file"])
 
         cd ($trigger | path dirname)
         overlay use __trigger__ as __auto_venv

--- a/modules/virtual_environments/auto-venv/auto-venv.nu
+++ b/modules/virtual_environments/auto-venv/auto-venv.nu
@@ -10,7 +10,7 @@ export-env {
     # this needs to be set somewhere
     # let-env AUTO_VENV_TRIGGER = '__auto-venv.nu'
 
-    let hooks = default-hooks
+    let hooks = (default-hooks)
 
     let hooks = ($hooks | append (build-hooks))
 
@@ -20,7 +20,7 @@ export-env {
 
 def default-hooks [] {
     (if ($env.config.hooks.env_change.PWD != $nothing) {
-        $env.config.hooks.env_change.PWD
+        [$env.config.hooks.env_change.PWD]
     }
     else {
         []
@@ -35,7 +35,7 @@ def build-hooks [] {
         let _env = $env
         let pwd  = $_env.PWD
 
-        let trigger = path_extensions path find-sub . __trigger__ --type "file"
+        let trigger = (path_extensions path find-sub . __trigger__ --type "file")
 
         cd ($trigger | path dirname)
         overlay use __trigger__ as __auto_venv

--- a/modules/virtual_environments/auto-venv/path_extensions.nu
+++ b/modules/virtual_environments/auto-venv/path_extensions.nu
@@ -14,7 +14,7 @@ export def "path walk" [
 ] {
     let list = ($path | path expand | path split);
 
-    $list | each -n { |$part| (
+    $list | enumerate | each { |$part| (
         $list | first ($part.index + 1) | path join;
     )}
 
@@ -45,7 +45,7 @@ export def "path find-sub" [
     subfolder: string,
     --type:    string
 ] {
-    let paths = path walk $folder;
+    let paths = (path walk $folder);
 
     let paths = ( $paths 
         | where (
@@ -55,5 +55,5 @@ export def "path find-sub" [
 
     if ($paths != $nothing) and ($paths | length) > 0 {
         [ ($paths | first), $subfolder ] | path join
-    }
+    } else {[]}
 }

--- a/modules/virtual_environments/auto-venv/path_extensions.nu
+++ b/modules/virtual_environments/auto-venv/path_extensions.nu
@@ -24,12 +24,12 @@ export def "path walk" [
 export def "path check-sub" [
     folder:    any, 
     subfolder: string,
-    --type:    string
+    --type:    list
 ] {
 
     (ls -a $folder
         | where ( 
-            ($type == $nothing or $it.type == $type)
+            ($type == $nothing or $it.type in $type)
             and ($it.name | path basename) == $subfolder
         )
         | length 
@@ -43,7 +43,7 @@ export def "path check-sub" [
 export def "path find-sub" [
     folder:    any,
     subfolder: string,
-    --type:    string
+    --type:    list
 ] {
     let paths = (path walk $folder);
 

--- a/modules/virtual_environments/auto-venv/venv_helpers.nu
+++ b/modules/virtual_environments/auto-venv/venv_helpers.nu
@@ -28,7 +28,7 @@ export def has-entered-venv [
     after: path,
 ] {
 
-    let target = path find-sub $after $env.AUTO_VENV_TRIGGER
+    let target = (path find-sub $after $env.AUTO_VENV_TRIGGER)
     
     (if ($target | is-empty) {
         false
@@ -47,13 +47,17 @@ export def has-swapped-venv [
         false
     }
     else {
-        let target = path find-sub $after $env.AUTO_VENV_TRIGGER
+        let target = (path find-sub $after $env.AUTO_VENV_TRIGGER)
             
         (if ($target | is-empty) {
             false
         }
         else {
-            $env.VIRTUAL_ENV != $target
+            (if ('VIRTUAL_ENV' in $env) {
+		    $env.VIRTUAL_ENV != $target
+		    } else {
+		    false # should it default to `false`?
+		    })
         })
 
     })

--- a/modules/virtual_environments/auto-venv/venvs/python-venv.nu
+++ b/modules/virtual_environments/auto-venv/venvs/python-venv.nu
@@ -57,11 +57,12 @@ export def-env auto-venv-on-enter [
     )
 
     let venv_path = ([$virtual_env $bin] | path join)
-    let new_path = ($old_path | prepend $venv_path | str join $path_sep)
+    # let new_path = ($old_path | prepend $venv_path | str join $path_sep)
+    let new_path = ($old_path | prepend $venv_path)
 
     # Creating the new prompt for the session
     let virtual_prompt = if ($virtual_prompt == '') {
-        $'(char lparen)($virtual_env | path basename)(char rparen) '
+        $'(char lparen)($virtual_env | path split | drop 1 | path join | path basename)(char rparen) '
     } else {
         '(' + $virtual_prompt + ') '
     }
@@ -74,13 +75,13 @@ export def-env auto-venv-on-enter [
 
     # If there is no default prompt, then only the env is printed in the prompt
     let new_prompt = if (has-env 'PROMPT_COMMAND') {
-        if ($old_prompt_command | describe) == 'block' {
-            { $'($virtual_prompt)(do $old_prompt_command)' }
+        if (($old_prompt_command | describe) in ['block', 'closure']) {
+            $'($virtual_prompt)(do $old_prompt_command)'
         } else {
-            { $'($virtual_prompt)($old_prompt_command)' }
+            $'($virtual_prompt)($old_prompt_command)'
         }
     } else {
-        { $'($virtual_prompt)' }
+        $'($virtual_prompt)'
     }
 
     # Environment variables that will be batched loaded to the virtual env


### PR DESCRIPTION
It is throwing various syntax errors due to dependence on old syntax or deprecated behavior. Updated the scripts so they now run, but it does not work yet; some of the semantics are not correct (some variables are storing closures rather than the evaluated values of that closure etc.)

Some extra work is needed before we can merge a working script. I have never been able to get `auto-venv` working with previous `nu` versions. Need help from anyone who has experience with patching it up.