### PR TITLE
add missing colors to the themes

### DIFF
--- a/themes/make.nu
+++ b/themes/make.nu
@@ -63,6 +63,7 @@ def make-theme [name: string] {
     list: "($colors.color7)"
     block: "($colors.color7)"
     hints: "dark_gray"
+    search_result: { fg: "($colors.color1)" bg: "($colors.color7)" }
 
     shape_and: { fg: "($colors.color5)" attr: "b" }
     shape_binary: { fg: "($colors.color5)" attr: "b" }

--- a/themes/themes/3024-day.nu
+++ b/themes/themes/3024-day.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a5a2a2"
     block: "#a5a2a2"
     hints: "dark_gray"
+    search_result: { fg: "#db2d20" bg: "#a5a2a2" }
 
     shape_and: { fg: "#a16a94" attr: "b" }
     shape_binary: { fg: "#a16a94" attr: "b" }

--- a/themes/themes/3024-night.nu
+++ b/themes/themes/3024-night.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a5a2a2"
     block: "#a5a2a2"
     hints: "dark_gray"
+    search_result: { fg: "#db2d20" bg: "#a5a2a2" }
 
     shape_and: { fg: "#a16a94" attr: "b" }
     shape_binary: { fg: "#a16a94" attr: "b" }

--- a/themes/themes/3024.nu
+++ b/themes/themes/3024.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a5a2a2"
     block: "#a5a2a2"
     hints: "dark_gray"
+    search_result: { fg: "#db2d20" bg: "#a5a2a2" }
 
     shape_and: { fg: "#a16a94" attr: "b" }
     shape_binary: { fg: "#a16a94" attr: "b" }

--- a/themes/themes/abyss.nu
+++ b/themes/themes/abyss.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a0cce2"
     block: "#a0cce2"
     hints: "dark_gray"
+    search_result: { fg: "#48697e" bg: "#a0cce2" }
 
     shape_and: { fg: "#4595bd" attr: "b" }
     shape_binary: { fg: "#4595bd" attr: "b" }

--- a/themes/themes/aci.nu
+++ b/themes/themes/aci.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b6b6b6"
     block: "#b6b6b6"
     hints: "dark_gray"
+    search_result: { fg: "#ff0883" bg: "#b6b6b6" }
 
     shape_and: { fg: "#8308ff" attr: "b" }
     shape_binary: { fg: "#8308ff" attr: "b" }

--- a/themes/themes/aco.nu
+++ b/themes/themes/aco.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bebebe"
     block: "#bebebe"
     hints: "dark_gray"
+    search_result: { fg: "#ff0883" bg: "#bebebe" }
 
     shape_and: { fg: "#8308ff" attr: "b" }
     shape_binary: { fg: "#8308ff" attr: "b" }

--- a/themes/themes/adventuretime.nu
+++ b/themes/themes/adventuretime.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f8dcc0"
     block: "#f8dcc0"
     hints: "dark_gray"
+    search_result: { fg: "#bd0013" bg: "#f8dcc0" }
 
     shape_and: { fg: "#665993" attr: "b" }
     shape_binary: { fg: "#665993" attr: "b" }

--- a/themes/themes/afterglow.nu
+++ b/themes/themes/afterglow.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#a53c23" bg: "#d0d0d0" }
 
     shape_and: { fg: "#9f4e85" attr: "b" }
     shape_binary: { fg: "#9f4e85" attr: "b" }

--- a/themes/themes/alien-blood.nu
+++ b/themes/themes/alien-blood.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#647d75"
     block: "#647d75"
     hints: "dark_gray"
+    search_result: { fg: "#7f2b27" bg: "#647d75" }
 
     shape_and: { fg: "#47587f" attr: "b" }
     shape_binary: { fg: "#47587f" attr: "b" }

--- a/themes/themes/alucard.nu
+++ b/themes/themes/alucard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#ff5555" bg: "#bbbbbb" }
 
     shape_and: { fg: "#1b3cff" attr: "b" }
     shape_binary: { fg: "#1b3cff" attr: "b" }

--- a/themes/themes/amora.nu
+++ b/themes/themes/amora.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dedbeb"
     block: "#dedbeb"
     hints: "dark_gray"
+    search_result: { fg: "#ed3f7f" bg: "#dedbeb" }
 
     shape_and: { fg: "#e68ac1" attr: "b" }
     shape_binary: { fg: "#e68ac1" attr: "b" }

--- a/themes/themes/apathy.nu
+++ b/themes/themes/apathy.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#81b5ac"
     block: "#81b5ac"
     hints: "dark_gray"
+    search_result: { fg: "#3e9688" bg: "#81b5ac" }
 
     shape_and: { fg: "#4c963e" attr: "b" }
     shape_binary: { fg: "#4c963e" attr: "b" }

--- a/themes/themes/apprentice.nu
+++ b/themes/themes/apprentice.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bcbcbc"
     block: "#bcbcbc"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#bcbcbc" }
 
     shape_and: { fg: "#87afd7" attr: "b" }
     shape_binary: { fg: "#87afd7" attr: "b" }

--- a/themes/themes/argonaut.nu
+++ b/themes/themes/argonaut.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#ff000f" bg: "#ffffff" }
 
     shape_and: { fg: "#6d43a6" attr: "b" }
     shape_binary: { fg: "#6d43a6" attr: "b" }

--- a/themes/themes/arthur.nu
+++ b/themes/themes/arthur.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbaa99"
     block: "#bbaa99"
     hints: "dark_gray"
+    search_result: { fg: "#cd5c5c" bg: "#bbaa99" }
 
     shape_and: { fg: "#deb887" attr: "b" }
     shape_binary: { fg: "#deb887" attr: "b" }

--- a/themes/themes/ashes.nu
+++ b/themes/themes/ashes.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c7ccd1"
     block: "#c7ccd1"
     hints: "dark_gray"
+    search_result: { fg: "#c7ae95" bg: "#c7ccd1" }
 
     shape_and: { fg: "#c795ae" attr: "b" }
     shape_binary: { fg: "#c795ae" attr: "b" }

--- a/themes/themes/atelier-cave-light.nu
+++ b/themes/themes/atelier-cave-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#585260"
     block: "#585260"
     hints: "dark_gray"
+    search_result: { fg: "#be4678" bg: "#585260" }
 
     shape_and: { fg: "#955ae7" attr: "b" }
     shape_binary: { fg: "#955ae7" attr: "b" }

--- a/themes/themes/atelier-cave.nu
+++ b/themes/themes/atelier-cave.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#8b8792"
     block: "#8b8792"
     hints: "dark_gray"
+    search_result: { fg: "#be4678" bg: "#8b8792" }
 
     shape_and: { fg: "#955ae7" attr: "b" }
     shape_binary: { fg: "#955ae7" attr: "b" }

--- a/themes/themes/atelier-dune-light.nu
+++ b/themes/themes/atelier-dune-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#6e6b5e"
     block: "#6e6b5e"
     hints: "dark_gray"
+    search_result: { fg: "#d73737" bg: "#6e6b5e" }
 
     shape_and: { fg: "#b854d4" attr: "b" }
     shape_binary: { fg: "#b854d4" attr: "b" }

--- a/themes/themes/atelier-dune.nu
+++ b/themes/themes/atelier-dune.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a6a28c"
     block: "#a6a28c"
     hints: "dark_gray"
+    search_result: { fg: "#d73737" bg: "#a6a28c" }
 
     shape_and: { fg: "#b854d4" attr: "b" }
     shape_binary: { fg: "#b854d4" attr: "b" }

--- a/themes/themes/atelier-estuary-light.nu
+++ b/themes/themes/atelier-estuary-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#5f5e4e"
     block: "#5f5e4e"
     hints: "dark_gray"
+    search_result: { fg: "#ba6236" bg: "#5f5e4e" }
 
     shape_and: { fg: "#5f9182" attr: "b" }
     shape_binary: { fg: "#5f9182" attr: "b" }

--- a/themes/themes/atelier-estuary.nu
+++ b/themes/themes/atelier-estuary.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#929181"
     block: "#929181"
     hints: "dark_gray"
+    search_result: { fg: "#ba6236" bg: "#929181" }
 
     shape_and: { fg: "#5f9182" attr: "b" }
     shape_binary: { fg: "#5f9182" attr: "b" }

--- a/themes/themes/atelier-forest-light.nu
+++ b/themes/themes/atelier-forest-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#68615e"
     block: "#68615e"
     hints: "dark_gray"
+    search_result: { fg: "#f22c40" bg: "#68615e" }
 
     shape_and: { fg: "#6666ea" attr: "b" }
     shape_binary: { fg: "#6666ea" attr: "b" }

--- a/themes/themes/atelier-forest.nu
+++ b/themes/themes/atelier-forest.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a8a19f"
     block: "#a8a19f"
     hints: "dark_gray"
+    search_result: { fg: "#f22c40" bg: "#a8a19f" }
 
     shape_and: { fg: "#6666ea" attr: "b" }
     shape_binary: { fg: "#6666ea" attr: "b" }

--- a/themes/themes/atelier-heath-light.nu
+++ b/themes/themes/atelier-heath-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#695d69"
     block: "#695d69"
     hints: "dark_gray"
+    search_result: { fg: "#ca402b" bg: "#695d69" }
 
     shape_and: { fg: "#7b59c0" attr: "b" }
     shape_binary: { fg: "#7b59c0" attr: "b" }

--- a/themes/themes/atelier-heath.nu
+++ b/themes/themes/atelier-heath.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ab9bab"
     block: "#ab9bab"
     hints: "dark_gray"
+    search_result: { fg: "#ca402b" bg: "#ab9bab" }
 
     shape_and: { fg: "#7b59c0" attr: "b" }
     shape_binary: { fg: "#7b59c0" attr: "b" }

--- a/themes/themes/atelier-lakeside-light.nu
+++ b/themes/themes/atelier-lakeside-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#516d7b"
     block: "#516d7b"
     hints: "dark_gray"
+    search_result: { fg: "#d22d72" bg: "#516d7b" }
 
     shape_and: { fg: "#6b6bb8" attr: "b" }
     shape_binary: { fg: "#6b6bb8" attr: "b" }

--- a/themes/themes/atelier-lakeside.nu
+++ b/themes/themes/atelier-lakeside.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#7ea2b4"
     block: "#7ea2b4"
     hints: "dark_gray"
+    search_result: { fg: "#d22d72" bg: "#7ea2b4" }
 
     shape_and: { fg: "#6b6bb8" attr: "b" }
     shape_binary: { fg: "#6b6bb8" attr: "b" }

--- a/themes/themes/atelier-plateau-light.nu
+++ b/themes/themes/atelier-plateau-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#585050"
     block: "#585050"
     hints: "dark_gray"
+    search_result: { fg: "#ca4949" bg: "#585050" }
 
     shape_and: { fg: "#8464c4" attr: "b" }
     shape_binary: { fg: "#8464c4" attr: "b" }

--- a/themes/themes/atelier-plateau.nu
+++ b/themes/themes/atelier-plateau.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#8a8585"
     block: "#8a8585"
     hints: "dark_gray"
+    search_result: { fg: "#ca4949" bg: "#8a8585" }
 
     shape_and: { fg: "#8464c4" attr: "b" }
     shape_binary: { fg: "#8464c4" attr: "b" }

--- a/themes/themes/atelier-savanna-light.nu
+++ b/themes/themes/atelier-savanna-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#526057"
     block: "#526057"
     hints: "dark_gray"
+    search_result: { fg: "#b16139" bg: "#526057" }
 
     shape_and: { fg: "#55859b" attr: "b" }
     shape_binary: { fg: "#55859b" attr: "b" }

--- a/themes/themes/atelier-savanna.nu
+++ b/themes/themes/atelier-savanna.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#87928a"
     block: "#87928a"
     hints: "dark_gray"
+    search_result: { fg: "#b16139" bg: "#87928a" }
 
     shape_and: { fg: "#55859b" attr: "b" }
     shape_binary: { fg: "#55859b" attr: "b" }

--- a/themes/themes/atelier-seaside-light.nu
+++ b/themes/themes/atelier-seaside-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#5e6e5e"
     block: "#5e6e5e"
     hints: "dark_gray"
+    search_result: { fg: "#e6193c" bg: "#5e6e5e" }
 
     shape_and: { fg: "#ad2bee" attr: "b" }
     shape_binary: { fg: "#ad2bee" attr: "b" }

--- a/themes/themes/atelier-seaside.nu
+++ b/themes/themes/atelier-seaside.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#8ca68c"
     block: "#8ca68c"
     hints: "dark_gray"
+    search_result: { fg: "#e6193c" bg: "#8ca68c" }
 
     shape_and: { fg: "#ad2bee" attr: "b" }
     shape_binary: { fg: "#ad2bee" attr: "b" }

--- a/themes/themes/atelier-sulphurpool-light.nu
+++ b/themes/themes/atelier-sulphurpool-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#5e6687"
     block: "#5e6687"
     hints: "dark_gray"
+    search_result: { fg: "#c94922" bg: "#5e6687" }
 
     shape_and: { fg: "#6679cc" attr: "b" }
     shape_binary: { fg: "#6679cc" attr: "b" }

--- a/themes/themes/atelier-sulphurpool.nu
+++ b/themes/themes/atelier-sulphurpool.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#979db4"
     block: "#979db4"
     hints: "dark_gray"
+    search_result: { fg: "#c94922" bg: "#979db4" }
 
     shape_and: { fg: "#6679cc" attr: "b" }
     shape_binary: { fg: "#6679cc" attr: "b" }

--- a/themes/themes/atlas.nu
+++ b/themes/themes/atlas.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a1a19a"
     block: "#a1a19a"
     hints: "dark_gray"
+    search_result: { fg: "#ff5a67" bg: "#a1a19a" }
 
     shape_and: { fg: "#9a70a4" attr: "b" }
     shape_binary: { fg: "#9a70a4" attr: "b" }

--- a/themes/themes/atom-one-light.nu
+++ b/themes/themes/atom-one-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#de3d35" bg: "#bbbbbb" }
 
     shape_and: { fg: "#950095" attr: "b" }
     shape_binary: { fg: "#950095" attr: "b" }

--- a/themes/themes/atom.nu
+++ b/themes/themes/atom.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0e0e0"
     block: "#e0e0e0"
     hints: "dark_gray"
+    search_result: { fg: "#fd5ff1" bg: "#e0e0e0" }
 
     shape_and: { fg: "#b9b6fc" attr: "b" }
     shape_binary: { fg: "#b9b6fc" attr: "b" }

--- a/themes/themes/ayu-light.nu
+++ b/themes/themes/ayu-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#ff3333" bg: "#ffffff" }
 
     shape_and: { fg: "#f07078" attr: "b" }
     shape_binary: { fg: "#f07078" attr: "b" }

--- a/themes/themes/ayu-mirage-simple-cursor.nu
+++ b/themes/themes/ayu-mirage-simple-cursor.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c7c7c7"
     block: "#c7c7c7"
     hints: "dark_gray"
+    search_result: { fg: "#ed8274" bg: "#c7c7c7" }
 
     shape_and: { fg: "#cfbafa" attr: "b" }
     shape_binary: { fg: "#cfbafa" attr: "b" }

--- a/themes/themes/ayu-mirage.nu
+++ b/themes/themes/ayu-mirage.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c7c7c7"
     block: "#c7c7c7"
     hints: "dark_gray"
+    search_result: { fg: "#ed8274" bg: "#c7c7c7" }
 
     shape_and: { fg: "#cfbafa" attr: "b" }
     shape_binary: { fg: "#cfbafa" attr: "b" }

--- a/themes/themes/ayu.nu
+++ b/themes/themes/ayu.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#ff3333" bg: "#ffffff" }
 
     shape_and: { fg: "#f07078" attr: "b" }
     shape_binary: { fg: "#f07078" attr: "b" }

--- a/themes/themes/azu.nu
+++ b/themes/themes/azu.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e6e6e6"
     block: "#e6e6e6"
     hints: "dark_gray"
+    search_result: { fg: "#ac6d74" bg: "#e6e6e6" }
 
     shape_and: { fg: "#a46dac" attr: "b" }
     shape_binary: { fg: "#a46dac" attr: "b" }

--- a/themes/themes/batman.nu
+++ b/themes/themes/batman.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c5c5be"
     block: "#c5c5be"
     hints: "dark_gray"
+    search_result: { fg: "#e6db43" bg: "#c5c5be" }
 
     shape_and: { fg: "#737271" attr: "b" }
     shape_binary: { fg: "#737271" attr: "b" }

--- a/themes/themes/belafonte-day.nu
+++ b/themes/themes/belafonte-day.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#968c83"
     block: "#968c83"
     hints: "dark_gray"
+    search_result: { fg: "#be100e" bg: "#968c83" }
 
     shape_and: { fg: "#97522c" attr: "b" }
     shape_binary: { fg: "#97522c" attr: "b" }

--- a/themes/themes/belafonte-night.nu
+++ b/themes/themes/belafonte-night.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#968c83"
     block: "#968c83"
     hints: "dark_gray"
+    search_result: { fg: "#be100e" bg: "#968c83" }
 
     shape_and: { fg: "#97522c" attr: "b" }
     shape_binary: { fg: "#97522c" attr: "b" }

--- a/themes/themes/bespin.nu
+++ b/themes/themes/bespin.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#8a8986"
     block: "#8a8986"
     hints: "dark_gray"
+    search_result: { fg: "#cf6a4c" bg: "#8a8986" }
 
     shape_and: { fg: "#9b859d" attr: "b" }
     shape_binary: { fg: "#9b859d" attr: "b" }

--- a/themes/themes/bim.nu
+++ b/themes/themes/bim.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#918988"
     block: "#918988"
     hints: "dark_gray"
+    search_result: { fg: "#f557a0" bg: "#918988" }
 
     shape_and: { fg: "#a957ec" attr: "b" }
     shape_binary: { fg: "#a957ec" attr: "b" }

--- a/themes/themes/birds-of-paradise.nu
+++ b/themes/themes/birds-of-paradise.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0dbb7"
     block: "#e0dbb7"
     hints: "dark_gray"
+    search_result: { fg: "#be2d26" bg: "#e0dbb7" }
 
     shape_and: { fg: "#ac80a6" attr: "b" }
     shape_binary: { fg: "#ac80a6" attr: "b" }

--- a/themes/themes/black-metal-bathory.nu
+++ b/themes/themes/black-metal-bathory.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal-burzum.nu
+++ b/themes/themes/black-metal-burzum.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal-dark-funeral.nu
+++ b/themes/themes/black-metal-dark-funeral.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal-gorgoroth.nu
+++ b/themes/themes/black-metal-gorgoroth.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal-immortal.nu
+++ b/themes/themes/black-metal-immortal.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal-khold.nu
+++ b/themes/themes/black-metal-khold.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal-marduk.nu
+++ b/themes/themes/black-metal-marduk.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal-mayhem.nu
+++ b/themes/themes/black-metal-mayhem.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal-nile.nu
+++ b/themes/themes/black-metal-nile.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal-venom.nu
+++ b/themes/themes/black-metal-venom.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/black-metal.nu
+++ b/themes/themes/black-metal.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c1c1"
     block: "#c1c1c1"
     hints: "dark_gray"
+    search_result: { fg: "#5f8787" bg: "#c1c1c1" }
 
     shape_and: { fg: "#999999" attr: "b" }
     shape_binary: { fg: "#999999" attr: "b" }

--- a/themes/themes/blazer.nu
+++ b/themes/themes/blazer.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d9d9d9"
     block: "#d9d9d9"
     hints: "dark_gray"
+    search_result: { fg: "#b87a7a" bg: "#d9d9d9" }
 
     shape_and: { fg: "#b87ab8" attr: "b" }
     shape_binary: { fg: "#b87ab8" attr: "b" }

--- a/themes/themes/borland.nu
+++ b/themes/themes/borland.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#eeeeee"
     block: "#eeeeee"
     hints: "dark_gray"
+    search_result: { fg: "#ff6c60" bg: "#eeeeee" }
 
     shape_and: { fg: "#ff73fd" attr: "b" }
     shape_binary: { fg: "#ff73fd" attr: "b" }

--- a/themes/themes/brewer.nu
+++ b/themes/themes/brewer.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b7b8b9"
     block: "#b7b8b9"
     hints: "dark_gray"
+    search_result: { fg: "#e31a1c" bg: "#b7b8b9" }
 
     shape_and: { fg: "#756bb1" attr: "b" }
     shape_binary: { fg: "#756bb1" attr: "b" }

--- a/themes/themes/bright-lights.nu
+++ b/themes/themes/bright-lights.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c8d6"
     block: "#c1c8d6"
     hints: "dark_gray"
+    search_result: { fg: "#ff355b" bg: "#c1c8d6" }
 
     shape_and: { fg: "#b975e6" attr: "b" }
     shape_binary: { fg: "#b975e6" attr: "b" }

--- a/themes/themes/bright.nu
+++ b/themes/themes/bright.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0e0e0"
     block: "#e0e0e0"
     hints: "dark_gray"
+    search_result: { fg: "#fb0120" bg: "#e0e0e0" }
 
     shape_and: { fg: "#d381c3" attr: "b" }
     shape_binary: { fg: "#d381c3" attr: "b" }

--- a/themes/themes/broadcast.nu
+++ b/themes/themes/broadcast.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#da4939" bg: "#ffffff" }
 
     shape_and: { fg: "#d0d0ff" attr: "b" }
     shape_binary: { fg: "#d0d0ff" attr: "b" }

--- a/themes/themes/brogrammer.nu
+++ b/themes/themes/brogrammer.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#4e5ab7"
     block: "#4e5ab7"
     hints: "dark_gray"
+    search_result: { fg: "#d6dbe5" bg: "#4e5ab7" }
 
     shape_and: { fg: "#0f7ddb" attr: "b" }
     shape_binary: { fg: "#0f7ddb" attr: "b" }

--- a/themes/themes/brushtrees-dark.nu
+++ b/themes/themes/brushtrees-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b0c5c8"
     block: "#b0c5c8"
     hints: "dark_gray"
+    search_result: { fg: "#b38686" bg: "#b0c5c8" }
 
     shape_and: { fg: "#b386b2" attr: "b" }
     shape_binary: { fg: "#b386b2" attr: "b" }

--- a/themes/themes/brushtrees.nu
+++ b/themes/themes/brushtrees.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#6d828e"
     block: "#6d828e"
     hints: "dark_gray"
+    search_result: { fg: "#b38686" bg: "#6d828e" }
 
     shape_and: { fg: "#b386b2" attr: "b" }
     shape_binary: { fg: "#b386b2" attr: "b" }

--- a/themes/themes/c64.nu
+++ b/themes/themes/c64.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#883932" bg: "#ffffff" }
 
     shape_and: { fg: "#8b3f96" attr: "b" }
     shape_binary: { fg: "#8b3f96" attr: "b" }

--- a/themes/themes/cai.nu
+++ b/themes/themes/cai.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#808080"
     block: "#808080"
     hints: "dark_gray"
+    search_result: { fg: "#ca274d" bg: "#808080" }
 
     shape_and: { fg: "#a427ca" attr: "b" }
     shape_binary: { fg: "#a427ca" attr: "b" }

--- a/themes/themes/chalk.nu
+++ b/themes/themes/chalk.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#fb9fb1" bg: "#d0d0d0" }
 
     shape_and: { fg: "#e1a3ee" attr: "b" }
     shape_binary: { fg: "#e1a3ee" attr: "b" }

--- a/themes/themes/chalkboard.nu
+++ b/themes/themes/chalkboard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d9d9d9"
     block: "#d9d9d9"
     hints: "dark_gray"
+    search_result: { fg: "#c37372" bg: "#d9d9d9" }
 
     shape_and: { fg: "#c372c2" attr: "b" }
     shape_binary: { fg: "#c372c2" attr: "b" }

--- a/themes/themes/challenger-deep.nu
+++ b/themes/themes/challenger-deep.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cbe3e7"
     block: "#cbe3e7"
     hints: "dark_gray"
+    search_result: { fg: "#ff8080" bg: "#cbe3e7" }
 
     shape_and: { fg: "#c991e1" attr: "b" }
     shape_binary: { fg: "#c991e1" attr: "b" }

--- a/themes/themes/ciapre.nu
+++ b/themes/themes/ciapre.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#aea47f"
     block: "#aea47f"
     hints: "dark_gray"
+    search_result: { fg: "#810009" bg: "#aea47f" }
 
     shape_and: { fg: "#724d7c" attr: "b" }
     shape_binary: { fg: "#724d7c" attr: "b" }

--- a/themes/themes/circus.nu
+++ b/themes/themes/circus.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a7a7a7"
     block: "#a7a7a7"
     hints: "dark_gray"
+    search_result: { fg: "#dc657d" bg: "#a7a7a7" }
 
     shape_and: { fg: "#b888e2" attr: "b" }
     shape_binary: { fg: "#b888e2" attr: "b" }

--- a/themes/themes/classic-dark.nu
+++ b/themes/themes/classic-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#ac4142" bg: "#d0d0d0" }
 
     shape_and: { fg: "#aa759f" attr: "b" }
     shape_binary: { fg: "#aa759f" attr: "b" }

--- a/themes/themes/classic-light.nu
+++ b/themes/themes/classic-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#303030"
     block: "#303030"
     hints: "dark_gray"
+    search_result: { fg: "#ac4142" bg: "#303030" }
 
     shape_and: { fg: "#aa759f" attr: "b" }
     shape_binary: { fg: "#aa759f" attr: "b" }

--- a/themes/themes/clone-of-ubuntu.nu
+++ b/themes/themes/clone-of-ubuntu.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d3d7cf"
     block: "#d3d7cf"
     hints: "dark_gray"
+    search_result: { fg: "#cc0000" bg: "#d3d7cf" }
 
     shape_and: { fg: "#75507b" attr: "b" }
     shape_binary: { fg: "#75507b" attr: "b" }

--- a/themes/themes/clrs.nu
+++ b/themes/themes/clrs.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b3b3b3"
     block: "#b3b3b3"
     hints: "dark_gray"
+    search_result: { fg: "#f8282a" bg: "#b3b3b3" }
 
     shape_and: { fg: "#9f00bd" attr: "b" }
     shape_binary: { fg: "#9f00bd" attr: "b" }

--- a/themes/themes/cobalt-neon.nu
+++ b/themes/themes/cobalt-neon.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ba46b2"
     block: "#ba46b2"
     hints: "dark_gray"
+    search_result: { fg: "#ff2320" bg: "#ba46b2" }
 
     shape_and: { fg: "#781aa0" attr: "b" }
     shape_binary: { fg: "#781aa0" attr: "b" }

--- a/themes/themes/cobalt2.nu
+++ b/themes/themes/cobalt2.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#ff0000" bg: "#bbbbbb" }
 
     shape_and: { fg: "#ff005d" attr: "b" }
     shape_binary: { fg: "#ff005d" attr: "b" }

--- a/themes/themes/codeschool.nu
+++ b/themes/themes/codeschool.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#9ea7a6"
     block: "#9ea7a6"
     hints: "dark_gray"
+    search_result: { fg: "#2a5491" bg: "#9ea7a6" }
 
     shape_and: { fg: "#c59820" attr: "b" }
     shape_binary: { fg: "#c59820" attr: "b" }

--- a/themes/themes/corvine.nu
+++ b/themes/themes/corvine.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c6c6c6"
     block: "#c6c6c6"
     hints: "dark_gray"
+    search_result: { fg: "#d78787" bg: "#c6c6c6" }
 
     shape_and: { fg: "#afafd7" attr: "b" }
     shape_binary: { fg: "#afafd7" attr: "b" }

--- a/themes/themes/crayon-pony-fish.nu
+++ b/themes/themes/crayon-pony-fish.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#68525a"
     block: "#68525a"
     hints: "dark_gray"
+    search_result: { fg: "#91002b" bg: "#68525a" }
 
     shape_and: { fg: "#692f50" attr: "b" }
     shape_binary: { fg: "#692f50" attr: "b" }

--- a/themes/themes/cupcake.nu
+++ b/themes/themes/cupcake.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#8b8198"
     block: "#8b8198"
     hints: "dark_gray"
+    search_result: { fg: "#d57e85" bg: "#8b8198" }
 
     shape_and: { fg: "#bb99b4" attr: "b" }
     shape_binary: { fg: "#bb99b4" attr: "b" }

--- a/themes/themes/cupertino.nu
+++ b/themes/themes/cupertino.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#404040"
     block: "#404040"
     hints: "dark_gray"
+    search_result: { fg: "#c41a15" bg: "#404040" }
 
     shape_and: { fg: "#a90d91" attr: "b" }
     shape_binary: { fg: "#a90d91" attr: "b" }

--- a/themes/themes/danqing.nu
+++ b/themes/themes/danqing.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0f0ef"
     block: "#e0f0ef"
     hints: "dark_gray"
+    search_result: { fg: "#f9906f" bg: "#e0f0ef" }
 
     shape_and: { fg: "#cca4e3" attr: "b" }
     shape_binary: { fg: "#cca4e3" attr: "b" }

--- a/themes/themes/darcula.nu
+++ b/themes/themes/darcula.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a9b7c6"
     block: "#a9b7c6"
     hints: "dark_gray"
+    search_result: { fg: "#4eade5" bg: "#a9b7c6" }
 
     shape_and: { fg: "#cc7832" attr: "b" }
     shape_binary: { fg: "#cc7832" attr: "b" }

--- a/themes/themes/dark-pastel.nu
+++ b/themes/themes/dark-pastel.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#ff5555" bg: "#bbbbbb" }
 
     shape_and: { fg: "#ff55ff" attr: "b" }
     shape_binary: { fg: "#ff55ff" attr: "b" }

--- a/themes/themes/darkmoss.nu
+++ b/themes/themes/darkmoss.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c7c7a5"
     block: "#c7c7a5"
     hints: "dark_gray"
+    search_result: { fg: "#ff4658" bg: "#c7c7a5" }
 
     shape_and: { fg: "#9bc0c8" attr: "b" }
     shape_binary: { fg: "#9bc0c8" attr: "b" }

--- a/themes/themes/darkside.nu
+++ b/themes/themes/darkside.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bababa"
     block: "#bababa"
     hints: "dark_gray"
+    search_result: { fg: "#e8341c" bg: "#bababa" }
 
     shape_and: { fg: "#8e69c9" attr: "b" }
     shape_binary: { fg: "#8e69c9" attr: "b" }

--- a/themes/themes/darktooth.nu
+++ b/themes/themes/darktooth.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a89984"
     block: "#a89984"
     hints: "dark_gray"
+    search_result: { fg: "#fb543f" bg: "#a89984" }
 
     shape_and: { fg: "#8f4673" attr: "b" }
     shape_binary: { fg: "#8f4673" attr: "b" }

--- a/themes/themes/darkviolet.nu
+++ b/themes/themes/darkviolet.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b08ae6"
     block: "#b08ae6"
     hints: "dark_gray"
+    search_result: { fg: "#a82ee6" bg: "#b08ae6" }
 
     shape_and: { fg: "#7e5ce6" attr: "b" }
     shape_binary: { fg: "#7e5ce6" attr: "b" }

--- a/themes/themes/decaf.nu
+++ b/themes/themes/decaf.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cccccc"
     block: "#cccccc"
     hints: "dark_gray"
+    search_result: { fg: "#ff7f7b" bg: "#cccccc" }
 
     shape_and: { fg: "#efb3f7" attr: "b" }
     shape_binary: { fg: "#efb3f7" attr: "b" }

--- a/themes/themes/default-dark.nu
+++ b/themes/themes/default-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d8d8d8"
     block: "#d8d8d8"
     hints: "dark_gray"
+    search_result: { fg: "#ab4642" bg: "#d8d8d8" }
 
     shape_and: { fg: "#ba8baf" attr: "b" }
     shape_binary: { fg: "#ba8baf" attr: "b" }

--- a/themes/themes/default-light.nu
+++ b/themes/themes/default-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#383838"
     block: "#383838"
     hints: "dark_gray"
+    search_result: { fg: "#ab4642" bg: "#383838" }
 
     shape_and: { fg: "#ba8baf" attr: "b" }
     shape_binary: { fg: "#ba8baf" attr: "b" }

--- a/themes/themes/desert-night.nu
+++ b/themes/themes/desert-night.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#87765d"
     block: "#87765d"
     hints: "dark_gray"
+    search_result: { fg: "#e56b55" bg: "#87765d" }
 
     shape_and: { fg: "#d261a5" attr: "b" }
     shape_binary: { fg: "#d261a5" attr: "b" }

--- a/themes/themes/desert.nu
+++ b/themes/themes/desert.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f5deb3"
     block: "#f5deb3"
     hints: "dark_gray"
+    search_result: { fg: "#ff2b2b" bg: "#f5deb3" }
 
     shape_and: { fg: "#ffdead" attr: "b" }
     shape_binary: { fg: "#ffdead" attr: "b" }

--- a/themes/themes/dimmed-monokai.nu
+++ b/themes/themes/dimmed-monokai.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b9bcba"
     block: "#b9bcba"
     hints: "dark_gray"
+    search_result: { fg: "#be3f48" bg: "#b9bcba" }
 
     shape_and: { fg: "#855c8d" attr: "b" }
     shape_binary: { fg: "#855c8d" attr: "b" }

--- a/themes/themes/dirtysea.nu
+++ b/themes/themes/dirtysea.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#000000"
     block: "#000000"
     hints: "dark_gray"
+    search_result: { fg: "#840000" bg: "#000000" }
 
     shape_and: { fg: "#000090" attr: "b" }
     shape_binary: { fg: "#000090" attr: "b" }

--- a/themes/themes/dot-gov.nu
+++ b/themes/themes/dot-gov.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#bf081d" bg: "#ffffff" }
 
     shape_and: { fg: "#772fb0" attr: "b" }
     shape_binary: { fg: "#772fb0" attr: "b" }

--- a/themes/themes/dracula.nu
+++ b/themes/themes/dracula.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e9e9f4"
     block: "#e9e9f4"
     hints: "dark_gray"
+    search_result: { fg: "#ea51b2" bg: "#e9e9f4" }
 
     shape_and: { fg: "#b45bcf" attr: "b" }
     shape_binary: { fg: "#b45bcf" attr: "b" }

--- a/themes/themes/dumbledore.nu
+++ b/themes/themes/dumbledore.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#850000"
     block: "#850000"
     hints: "dark_gray"
+    search_result: { fg: "#ae0000" bg: "#850000" }
 
     shape_and: { fg: "#9445ae" attr: "b" }
     shape_binary: { fg: "#9445ae" attr: "b" }

--- a/themes/themes/duotone-dark.nu
+++ b/themes/themes/duotone-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b6a0ff"
     block: "#b6a0ff"
     hints: "dark_gray"
+    search_result: { fg: "#d8393d" bg: "#b6a0ff" }
 
     shape_and: { fg: "#dd8d40" attr: "b" }
     shape_binary: { fg: "#dd8d40" attr: "b" }

--- a/themes/themes/e-n-c-o-m.nu
+++ b/themes/themes/e-n-c-o-m.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#9f0000" bg: "#bbbbbb" }
 
     shape_and: { fg: "#bc00ca" attr: "b" }
     shape_binary: { fg: "#bc00ca" attr: "b" }

--- a/themes/themes/earthsong.nu
+++ b/themes/themes/earthsong.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e5c6aa"
     block: "#e5c6aa"
     hints: "dark_gray"
+    search_result: { fg: "#c94234" bg: "#e5c6aa" }
 
     shape_and: { fg: "#d0633d" attr: "b" }
     shape_binary: { fg: "#d0633d" attr: "b" }

--- a/themes/themes/edge-dark.nu
+++ b/themes/themes/edge-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b7bec9"
     block: "#b7bec9"
     hints: "dark_gray"
+    search_result: { fg: "#e77171" bg: "#b7bec9" }
 
     shape_and: { fg: "#d390e7" attr: "b" }
     shape_binary: { fg: "#d390e7" attr: "b" }

--- a/themes/themes/edge-light.nu
+++ b/themes/themes/edge-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#5e646f"
     block: "#5e646f"
     hints: "dark_gray"
+    search_result: { fg: "#db7070" bg: "#5e646f" }
 
     shape_and: { fg: "#b870ce" attr: "b" }
     shape_binary: { fg: "#b870ce" attr: "b" }

--- a/themes/themes/eighties.nu
+++ b/themes/themes/eighties.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d3d0c8"
     block: "#d3d0c8"
     hints: "dark_gray"
+    search_result: { fg: "#f2777a" bg: "#d3d0c8" }
 
     shape_and: { fg: "#cc99cc" attr: "b" }
     shape_binary: { fg: "#cc99cc" attr: "b" }

--- a/themes/themes/elemental.nu
+++ b/themes/themes/elemental.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#807974"
     block: "#807974"
     hints: "dark_gray"
+    search_result: { fg: "#98290f" bg: "#807974" }
 
     shape_and: { fg: "#7f4e2f" attr: "b" }
     shape_binary: { fg: "#7f4e2f" attr: "b" }

--- a/themes/themes/elementary.nu
+++ b/themes/themes/elementary.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f2f2f2"
     block: "#f2f2f2"
     hints: "dark_gray"
+    search_result: { fg: "#e1321a" bg: "#f2f2f2" }
 
     shape_and: { fg: "#ec0048" attr: "b" }
     shape_binary: { fg: "#ec0048" attr: "b" }

--- a/themes/themes/elic.nu
+++ b/themes/themes/elic.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#2aa7e7"
     block: "#2aa7e7"
     hints: "dark_gray"
+    search_result: { fg: "#e1321a" bg: "#2aa7e7" }
 
     shape_and: { fg: "#ec0048" attr: "b" }
     shape_binary: { fg: "#ec0048" attr: "b" }

--- a/themes/themes/elio.nu
+++ b/themes/themes/elio.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f2f2f2"
     block: "#f2f2f2"
     hints: "dark_gray"
+    search_result: { fg: "#e1321a" bg: "#f2f2f2" }
 
     shape_and: { fg: "#ec0048" attr: "b" }
     shape_binary: { fg: "#ec0048" attr: "b" }

--- a/themes/themes/embark.nu
+++ b/themes/themes/embark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cbe3e7"
     block: "#cbe3e7"
     hints: "dark_gray"
+    search_result: { fg: "#f48fb1" bg: "#cbe3e7" }
 
     shape_and: { fg: "#d4bfff" attr: "b" }
     shape_binary: { fg: "#d4bfff" attr: "b" }

--- a/themes/themes/embers.nu
+++ b/themes/themes/embers.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a39a90"
     block: "#a39a90"
     hints: "dark_gray"
+    search_result: { fg: "#826d57" bg: "#a39a90" }
 
     shape_and: { fg: "#82576d" attr: "b" }
     shape_binary: { fg: "#82576d" attr: "b" }

--- a/themes/themes/equilibrium-dark.nu
+++ b/themes/themes/equilibrium-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#afaba2"
     block: "#afaba2"
     hints: "dark_gray"
+    search_result: { fg: "#f04339" bg: "#afaba2" }
 
     shape_and: { fg: "#6a7fd2" attr: "b" }
     shape_binary: { fg: "#6a7fd2" attr: "b" }

--- a/themes/themes/equilibrium-gray-dark.nu
+++ b/themes/themes/equilibrium-gray-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ababab"
     block: "#ababab"
     hints: "dark_gray"
+    search_result: { fg: "#f04339" bg: "#ababab" }
 
     shape_and: { fg: "#6a7fd2" attr: "b" }
     shape_binary: { fg: "#6a7fd2" attr: "b" }

--- a/themes/themes/equilibrium-gray-light.nu
+++ b/themes/themes/equilibrium-gray-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#474747"
     block: "#474747"
     hints: "dark_gray"
+    search_result: { fg: "#d02023" bg: "#474747" }
 
     shape_and: { fg: "#4e66b6" attr: "b" }
     shape_binary: { fg: "#4e66b6" attr: "b" }

--- a/themes/themes/equilibrium-light.nu
+++ b/themes/themes/equilibrium-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#43474e"
     block: "#43474e"
     hints: "dark_gray"
+    search_result: { fg: "#d02023" bg: "#43474e" }
 
     shape_and: { fg: "#4e66b6" attr: "b" }
     shape_binary: { fg: "#4e66b6" attr: "b" }

--- a/themes/themes/espresso-libre.nu
+++ b/themes/themes/espresso-libre.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d3d7cf"
     block: "#d3d7cf"
     hints: "dark_gray"
+    search_result: { fg: "#cc0000" bg: "#d3d7cf" }
 
     shape_and: { fg: "#c5656b" attr: "b" }
     shape_binary: { fg: "#c5656b" attr: "b" }

--- a/themes/themes/espresso.nu
+++ b/themes/themes/espresso.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cccccc"
     block: "#cccccc"
     hints: "dark_gray"
+    search_result: { fg: "#d25252" bg: "#cccccc" }
 
     shape_and: { fg: "#d197d9" attr: "b" }
     shape_binary: { fg: "#d197d9" attr: "b" }

--- a/themes/themes/eva-dim.nu
+++ b/themes/themes/eva-dim.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#9fa2a6"
     block: "#9fa2a6"
     hints: "dark_gray"
+    search_result: { fg: "#c4676c" bg: "#9fa2a6" }
 
     shape_and: { fg: "#9c6cd3" attr: "b" }
     shape_binary: { fg: "#9c6cd3" attr: "b" }

--- a/themes/themes/eva.nu
+++ b/themes/themes/eva.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#9fa2a6"
     block: "#9fa2a6"
     hints: "dark_gray"
+    search_result: { fg: "#c4676c" bg: "#9fa2a6" }
 
     shape_and: { fg: "#9c6cd3" attr: "b" }
     shape_binary: { fg: "#9c6cd3" attr: "b" }

--- a/themes/themes/everforest-light.nu
+++ b/themes/themes/everforest-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dfddc8"
     block: "#dfddc8"
     hints: "dark_gray"
+    search_result: { fg: "#f85552" bg: "#dfddc8" }
 
     shape_and: { fg: "#df69ba" attr: "b" }
     shape_binary: { fg: "#df69ba" attr: "b" }

--- a/themes/themes/everforest.nu
+++ b/themes/themes/everforest.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d3c6aa"
     block: "#d3c6aa"
     hints: "dark_gray"
+    search_result: { fg: "#e67e80" bg: "#d3c6aa" }
 
     shape_and: { fg: "#d699b6" attr: "b" }
     shape_binary: { fg: "#d699b6" attr: "b" }

--- a/themes/themes/falcon.nu
+++ b/themes/themes/falcon.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b4b4b9"
     block: "#b4b4b9"
     hints: "dark_gray"
+    search_result: { fg: "#ff3600" bg: "#b4b4b9" }
 
     shape_and: { fg: "#ff761a" attr: "b" }
     shape_binary: { fg: "#ff761a" attr: "b" }

--- a/themes/themes/farin.nu
+++ b/themes/themes/farin.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cccccc"
     block: "#cccccc"
     hints: "dark_gray"
+    search_result: { fg: "#ff1155" bg: "#cccccc" }
 
     shape_and: { fg: "#ed53c9" attr: "b" }
     shape_binary: { fg: "#ed53c9" attr: "b" }

--- a/themes/themes/ffive.nu
+++ b/themes/themes/ffive.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dadadb"
     block: "#dadadb"
     hints: "dark_gray"
+    search_result: { fg: "#ea2639" bg: "#dadadb" }
 
     shape_and: { fg: "#b035c0" attr: "b" }
     shape_binary: { fg: "#b035c0" attr: "b" }

--- a/themes/themes/fideloper.nu
+++ b/themes/themes/fideloper.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e9e2cd"
     block: "#e9e2cd"
     hints: "dark_gray"
+    search_result: { fg: "#ca1d2c" bg: "#e9e2cd" }
 
     shape_and: { fg: "#c0226e" attr: "b" }
     shape_binary: { fg: "#c0226e" attr: "b" }

--- a/themes/themes/fishtank.nu
+++ b/themes/themes/fishtank.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ecf0fc"
     block: "#ecf0fc"
     hints: "dark_gray"
+    search_result: { fg: "#c6004a" bg: "#ecf0fc" }
 
     shape_and: { fg: "#986f82" attr: "b" }
     shape_binary: { fg: "#986f82" attr: "b" }

--- a/themes/themes/flat.nu
+++ b/themes/themes/flat.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0e0e0"
     block: "#e0e0e0"
     hints: "dark_gray"
+    search_result: { fg: "#e74c3c" bg: "#e0e0e0" }
 
     shape_and: { fg: "#9b59b6" attr: "b" }
     shape_binary: { fg: "#9b59b6" attr: "b" }

--- a/themes/themes/flatland.nu
+++ b/themes/themes/flatland.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#f18339" bg: "#ffffff" }
 
     shape_and: { fg: "#695abc" attr: "b" }
     shape_binary: { fg: "#695abc" attr: "b" }

--- a/themes/themes/floraverse.nu
+++ b/themes/themes/floraverse.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f3e0b8"
     block: "#f3e0b8"
     hints: "dark_gray"
+    search_result: { fg: "#64002c" bg: "#f3e0b8" }
 
     shape_and: { fg: "#b7077e" attr: "b" }
     shape_binary: { fg: "#b7077e" attr: "b" }

--- a/themes/themes/forest-night.nu
+++ b/themes/themes/forest-night.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffebc3"
     block: "#ffebc3"
     hints: "dark_gray"
+    search_result: { fg: "#fd8489" bg: "#ffebc3" }
 
     shape_and: { fg: "#daccf0" attr: "b" }
     shape_binary: { fg: "#daccf0" attr: "b" }

--- a/themes/themes/foxnightly.nu
+++ b/themes/themes/foxnightly.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#b98eff" bg: "#ffffff" }
 
     shape_and: { fg: "#75507b" attr: "b" }
     shape_binary: { fg: "#75507b" attr: "b" }

--- a/themes/themes/framer.nu
+++ b/themes/themes/framer.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#fd886b" bg: "#d0d0d0" }
 
     shape_and: { fg: "#ba8cfc" attr: "b" }
     shape_binary: { fg: "#ba8cfc" attr: "b" }

--- a/themes/themes/freya.nu
+++ b/themes/themes/freya.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#94a3a5"
     block: "#94a3a5"
     hints: "dark_gray"
+    search_result: { fg: "#dc322f" bg: "#94a3a5" }
 
     shape_and: { fg: "#ec0048" attr: "b" }
     shape_binary: { fg: "#ec0048" attr: "b" }

--- a/themes/themes/frontend-delight.nu
+++ b/themes/themes/frontend-delight.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#adadad"
     block: "#adadad"
     hints: "dark_gray"
+    search_result: { fg: "#f8511b" bg: "#adadad" }
 
     shape_and: { fg: "#f02e4f" attr: "b" }
     shape_binary: { fg: "#f02e4f" attr: "b" }

--- a/themes/themes/frontend-fun-forrest.nu
+++ b/themes/themes/frontend-fun-forrest.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ddc265"
     block: "#ddc265"
     hints: "dark_gray"
+    search_result: { fg: "#d6262b" bg: "#ddc265" }
 
     shape_and: { fg: "#8d4331" attr: "b" }
     shape_binary: { fg: "#8d4331" attr: "b" }

--- a/themes/themes/frontend-galaxy.nu
+++ b/themes/themes/frontend-galaxy.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#f9555f" bg: "#bbbbbb" }
 
     shape_and: { fg: "#944d95" attr: "b" }
     shape_binary: { fg: "#944d95" attr: "b" }

--- a/themes/themes/fruit-soda.nu
+++ b/themes/themes/fruit-soda.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#515151"
     block: "#515151"
     hints: "dark_gray"
+    search_result: { fg: "#fe3e31" bg: "#515151" }
 
     shape_and: { fg: "#611fce" attr: "b" }
     shape_binary: { fg: "#611fce" attr: "b" }

--- a/themes/themes/gigavolt.nu
+++ b/themes/themes/gigavolt.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e9e7e1"
     block: "#e9e7e1"
     hints: "dark_gray"
+    search_result: { fg: "#ff661a" bg: "#e9e7e1" }
 
     shape_and: { fg: "#ae94f9" attr: "b" }
     shape_binary: { fg: "#ae94f9" attr: "b" }

--- a/themes/themes/github-dark-colorblind.nu
+++ b/themes/themes/github-dark-colorblind.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b1bac4"
     block: "#b1bac4"
     hints: "dark_gray"
+    search_result: { fg: "#ff7b72" bg: "#b1bac4" }
 
     shape_and: { fg: "#bc8cff" attr: "b" }
     shape_binary: { fg: "#bc8cff" attr: "b" }

--- a/themes/themes/github-dark-default.nu
+++ b/themes/themes/github-dark-default.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b1bac4"
     block: "#b1bac4"
     hints: "dark_gray"
+    search_result: { fg: "#ff7b72" bg: "#b1bac4" }
 
     shape_and: { fg: "#bc8cff" attr: "b" }
     shape_binary: { fg: "#bc8cff" attr: "b" }

--- a/themes/themes/github-dark.nu
+++ b/themes/themes/github-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d1d5da"
     block: "#d1d5da"
     hints: "dark_gray"
+    search_result: { fg: "#ea4a5a" bg: "#d1d5da" }
 
     shape_and: { fg: "#b392f0" attr: "b" }
     shape_binary: { fg: "#b392f0" attr: "b" }

--- a/themes/themes/github-dimmed.nu
+++ b/themes/themes/github-dimmed.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#909dab"
     block: "#909dab"
     hints: "dark_gray"
+    search_result: { fg: "#f47067" bg: "#909dab" }
 
     shape_and: { fg: "#b083f0" attr: "b" }
     shape_binary: { fg: "#b083f0" attr: "b" }

--- a/themes/themes/github-light-colorblind.nu
+++ b/themes/themes/github-light-colorblind.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#6e7781"
     block: "#6e7781"
     hints: "dark_gray"
+    search_result: { fg: "#cf222e" bg: "#6e7781" }
 
     shape_and: { fg: "#8250df" attr: "b" }
     shape_binary: { fg: "#8250df" attr: "b" }

--- a/themes/themes/github-light-default.nu
+++ b/themes/themes/github-light-default.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#6e7781"
     block: "#6e7781"
     hints: "dark_gray"
+    search_result: { fg: "#cf222e" bg: "#6e7781" }
 
     shape_and: { fg: "#8250df" attr: "b" }
     shape_binary: { fg: "#8250df" attr: "b" }

--- a/themes/themes/github-light.nu
+++ b/themes/themes/github-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#6a737d"
     block: "#6a737d"
     hints: "dark_gray"
+    search_result: { fg: "#d73a49" bg: "#6a737d" }
 
     shape_and: { fg: "#5a32a3" attr: "b" }
     shape_binary: { fg: "#5a32a3" attr: "b" }

--- a/themes/themes/github.nu
+++ b/themes/themes/github.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#333333"
     block: "#333333"
     hints: "dark_gray"
+    search_result: { fg: "#ed6a43" bg: "#333333" }
 
     shape_and: { fg: "#a71d5d" attr: "b" }
     shape_binary: { fg: "#a71d5d" attr: "b" }

--- a/themes/themes/glacier.nu
+++ b/themes/themes/glacier.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#bd0f2f" bg: "#ffffff" }
 
     shape_and: { fg: "#bd2523" attr: "b" }
     shape_binary: { fg: "#bd2523" attr: "b" }

--- a/themes/themes/goa-base.nu
+++ b/themes/themes/goa-base.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#000000"
     block: "#000000"
     hints: "dark_gray"
+    search_result: { fg: "#f78000" bg: "#000000" }
 
     shape_and: { fg: "#f43bff" attr: "b" }
     shape_binary: { fg: "#f43bff" attr: "b" }

--- a/themes/themes/gooey.nu
+++ b/themes/themes/gooey.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#858893"
     block: "#858893"
     hints: "dark_gray"
+    search_result: { fg: "#bb4f6c" bg: "#858893" }
 
     shape_and: { fg: "#6488c4" attr: "b" }
     shape_binary: { fg: "#6488c4" attr: "b" }

--- a/themes/themes/google-dark.nu
+++ b/themes/themes/google-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c5c8c6"
     block: "#c5c8c6"
     hints: "dark_gray"
+    search_result: { fg: "#cc342b" bg: "#c5c8c6" }
 
     shape_and: { fg: "#a36ac7" attr: "b" }
     shape_binary: { fg: "#a36ac7" attr: "b" }

--- a/themes/themes/google-light.nu
+++ b/themes/themes/google-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#373b41"
     block: "#373b41"
     hints: "dark_gray"
+    search_result: { fg: "#cc342b" bg: "#373b41" }
 
     shape_and: { fg: "#a36ac7" attr: "b" }
     shape_binary: { fg: "#a36ac7" attr: "b" }

--- a/themes/themes/grape.nu
+++ b/themes/themes/grape.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#9e9ea0"
     block: "#9e9ea0"
     hints: "dark_gray"
+    search_result: { fg: "#ed2261" bg: "#9e9ea0" }
 
     shape_and: { fg: "#8d35c9" attr: "b" }
     shape_binary: { fg: "#8d35c9" attr: "b" }

--- a/themes/themes/grass.nu
+++ b/themes/themes/grass.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#bb0000" bg: "#bbbbbb" }
 
     shape_and: { fg: "#950062" attr: "b" }
     shape_binary: { fg: "#950062" attr: "b" }

--- a/themes/themes/grayscale-dark.nu
+++ b/themes/themes/grayscale-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b9b9b9"
     block: "#b9b9b9"
     hints: "dark_gray"
+    search_result: { fg: "#7c7c7c" bg: "#b9b9b9" }
 
     shape_and: { fg: "#747474" attr: "b" }
     shape_binary: { fg: "#747474" attr: "b" }

--- a/themes/themes/grayscale-light.nu
+++ b/themes/themes/grayscale-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#464646"
     block: "#464646"
     hints: "dark_gray"
+    search_result: { fg: "#7c7c7c" bg: "#464646" }
 
     shape_and: { fg: "#747474" attr: "b" }
     shape_binary: { fg: "#747474" attr: "b" }

--- a/themes/themes/green-screen.nu
+++ b/themes/themes/green-screen.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#00bb00"
     block: "#00bb00"
     hints: "dark_gray"
+    search_result: { fg: "#007700" bg: "#00bb00" }
 
     shape_and: { fg: "#00bb00" attr: "b" }
     shape_binary: { fg: "#00bb00" attr: "b" }

--- a/themes/themes/greenscreen.nu
+++ b/themes/themes/greenscreen.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#00bb00"
     block: "#00bb00"
     hints: "dark_gray"
+    search_result: { fg: "#007700" bg: "#00bb00" }
 
     shape_and: { fg: "#00bb00" attr: "b" }
     shape_binary: { fg: "#00bb00" attr: "b" }

--- a/themes/themes/gruvbit.nu
+++ b/themes/themes/gruvbit.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#504945"
     block: "#504945"
     hints: "dark_gray"
+    search_result: { fg: "#fabd2f" bg: "#504945" }
 
     shape_and: { fg: "#fe8019" attr: "b" }
     shape_binary: { fg: "#fe8019" attr: "b" }

--- a/themes/themes/gruvbox-dark-hard.nu
+++ b/themes/themes/gruvbox-dark-hard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d5c4a1"
     block: "#d5c4a1"
     hints: "dark_gray"
+    search_result: { fg: "#fb4934" bg: "#d5c4a1" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-dark-medium.nu
+++ b/themes/themes/gruvbox-dark-medium.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d5c4a1"
     block: "#d5c4a1"
     hints: "dark_gray"
+    search_result: { fg: "#fb4934" bg: "#d5c4a1" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-dark-pale.nu
+++ b/themes/themes/gruvbox-dark-pale.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dab997"
     block: "#dab997"
     hints: "dark_gray"
+    search_result: { fg: "#d75f5f" bg: "#dab997" }
 
     shape_and: { fg: "#d485ad" attr: "b" }
     shape_binary: { fg: "#d485ad" attr: "b" }

--- a/themes/themes/gruvbox-dark-soft.nu
+++ b/themes/themes/gruvbox-dark-soft.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d5c4a1"
     block: "#d5c4a1"
     hints: "dark_gray"
+    search_result: { fg: "#fb4934" bg: "#d5c4a1" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-dark.nu
+++ b/themes/themes/gruvbox-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a89984"
     block: "#a89984"
     hints: "dark_gray"
+    search_result: { fg: "#cc241d" bg: "#a89984" }
 
     shape_and: { fg: "#b16286" attr: "b" }
     shape_binary: { fg: "#b16286" attr: "b" }

--- a/themes/themes/gruvbox-light-hard.nu
+++ b/themes/themes/gruvbox-light-hard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#504945"
     block: "#504945"
     hints: "dark_gray"
+    search_result: { fg: "#9d0006" bg: "#504945" }
 
     shape_and: { fg: "#8f3f71" attr: "b" }
     shape_binary: { fg: "#8f3f71" attr: "b" }

--- a/themes/themes/gruvbox-light-medium.nu
+++ b/themes/themes/gruvbox-light-medium.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#504945"
     block: "#504945"
     hints: "dark_gray"
+    search_result: { fg: "#9d0006" bg: "#504945" }
 
     shape_and: { fg: "#8f3f71" attr: "b" }
     shape_binary: { fg: "#8f3f71" attr: "b" }

--- a/themes/themes/gruvbox-light-soft.nu
+++ b/themes/themes/gruvbox-light-soft.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#504945"
     block: "#504945"
     hints: "dark_gray"
+    search_result: { fg: "#9d0006" bg: "#504945" }
 
     shape_and: { fg: "#8f3f71" attr: "b" }
     shape_binary: { fg: "#8f3f71" attr: "b" }

--- a/themes/themes/gruvbox-material-dark-hard.nu
+++ b/themes/themes/gruvbox-material-dark-hard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d4be98"
     block: "#d4be98"
     hints: "dark_gray"
+    search_result: { fg: "#ea6962" bg: "#d4be98" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-material-dark-medium.nu
+++ b/themes/themes/gruvbox-material-dark-medium.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d4be98"
     block: "#d4be98"
     hints: "dark_gray"
+    search_result: { fg: "#ea6962" bg: "#d4be98" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-material-dark-soft.nu
+++ b/themes/themes/gruvbox-material-dark-soft.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d4be98"
     block: "#d4be98"
     hints: "dark_gray"
+    search_result: { fg: "#ea6962" bg: "#d4be98" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-material-light-hard.nu
+++ b/themes/themes/gruvbox-material-light-hard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#654735"
     block: "#654735"
     hints: "dark_gray"
+    search_result: { fg: "#c14a4a" bg: "#654735" }
 
     shape_and: { fg: "#945e80" attr: "b" }
     shape_binary: { fg: "#945e80" attr: "b" }

--- a/themes/themes/gruvbox-material-light-medium.nu
+++ b/themes/themes/gruvbox-material-light-medium.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#654735"
     block: "#654735"
     hints: "dark_gray"
+    search_result: { fg: "#c14a4a" bg: "#654735" }
 
     shape_and: { fg: "#945e80" attr: "b" }
     shape_binary: { fg: "#945e80" attr: "b" }

--- a/themes/themes/gruvbox-material-light-soft.nu
+++ b/themes/themes/gruvbox-material-light-soft.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#654735"
     block: "#654735"
     hints: "dark_gray"
+    search_result: { fg: "#c14a4a" bg: "#654735" }
 
     shape_and: { fg: "#945e80" attr: "b" }
     shape_binary: { fg: "#945e80" attr: "b" }

--- a/themes/themes/gruvbox-mix-dark-hard.nu
+++ b/themes/themes/gruvbox-mix-dark-hard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e2cca9"
     block: "#e2cca9"
     hints: "dark_gray"
+    search_result: { fg: "#f2594b" bg: "#e2cca9" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-mix-dark-medium.nu
+++ b/themes/themes/gruvbox-mix-dark-medium.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e2cca9"
     block: "#e2cca9"
     hints: "dark_gray"
+    search_result: { fg: "#f2594b" bg: "#e2cca9" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-mix-dark-soft.nu
+++ b/themes/themes/gruvbox-mix-dark-soft.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e2cca9"
     block: "#e2cca9"
     hints: "dark_gray"
+    search_result: { fg: "#f2594b" bg: "#e2cca9" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-mix-light-hard.nu
+++ b/themes/themes/gruvbox-mix-light-hard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#514036"
     block: "#514036"
     hints: "dark_gray"
+    search_result: { fg: "#af2528" bg: "#514036" }
 
     shape_and: { fg: "#924f79" attr: "b" }
     shape_binary: { fg: "#924f79" attr: "b" }

--- a/themes/themes/gruvbox-mix-light-medium.nu
+++ b/themes/themes/gruvbox-mix-light-medium.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#514036"
     block: "#514036"
     hints: "dark_gray"
+    search_result: { fg: "#af2528" bg: "#514036" }
 
     shape_and: { fg: "#924f79" attr: "b" }
     shape_binary: { fg: "#924f79" attr: "b" }

--- a/themes/themes/gruvbox-mix-light-soft.nu
+++ b/themes/themes/gruvbox-mix-light-soft.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#514036"
     block: "#514036"
     hints: "dark_gray"
+    search_result: { fg: "#af2528" bg: "#514036" }
 
     shape_and: { fg: "#924f79" attr: "b" }
     shape_binary: { fg: "#924f79" attr: "b" }

--- a/themes/themes/gruvbox-original-dark-hard.nu
+++ b/themes/themes/gruvbox-original-dark-hard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ebdbb2"
     block: "#ebdbb2"
     hints: "dark_gray"
+    search_result: { fg: "#fb4934" bg: "#ebdbb2" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-original-dark-medium.nu
+++ b/themes/themes/gruvbox-original-dark-medium.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ebdbb2"
     block: "#ebdbb2"
     hints: "dark_gray"
+    search_result: { fg: "#fb4934" bg: "#ebdbb2" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-original-dark-soft.nu
+++ b/themes/themes/gruvbox-original-dark-soft.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ebdbb2"
     block: "#ebdbb2"
     hints: "dark_gray"
+    search_result: { fg: "#fb4934" bg: "#ebdbb2" }
 
     shape_and: { fg: "#d3869b" attr: "b" }
     shape_binary: { fg: "#d3869b" attr: "b" }

--- a/themes/themes/gruvbox-original-light-hard.nu
+++ b/themes/themes/gruvbox-original-light-hard.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#3c3836"
     block: "#3c3836"
     hints: "dark_gray"
+    search_result: { fg: "#9d0006" bg: "#3c3836" }
 
     shape_and: { fg: "#8f3f71" attr: "b" }
     shape_binary: { fg: "#8f3f71" attr: "b" }

--- a/themes/themes/gruvbox-original-light-medium.nu
+++ b/themes/themes/gruvbox-original-light-medium.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#3c3836"
     block: "#3c3836"
     hints: "dark_gray"
+    search_result: { fg: "#9d0006" bg: "#3c3836" }
 
     shape_and: { fg: "#8f3f71" attr: "b" }
     shape_binary: { fg: "#8f3f71" attr: "b" }

--- a/themes/themes/gruvbox-original-light-soft.nu
+++ b/themes/themes/gruvbox-original-light-soft.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#3c3836"
     block: "#3c3836"
     hints: "dark_gray"
+    search_result: { fg: "#9d0006" bg: "#3c3836" }
 
     shape_and: { fg: "#8f3f71" attr: "b" }
     shape_binary: { fg: "#8f3f71" attr: "b" }

--- a/themes/themes/gruvbox.nu
+++ b/themes/themes/gruvbox.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#7c6f64"
     block: "#7c6f64"
     hints: "dark_gray"
+    search_result: { fg: "#cc241d" bg: "#7c6f64" }
 
     shape_and: { fg: "#b16286" attr: "b" }
     shape_binary: { fg: "#b16286" attr: "b" }

--- a/themes/themes/hardcore.nu
+++ b/themes/themes/hardcore.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cdcdcd"
     block: "#cdcdcd"
     hints: "dark_gray"
+    search_result: { fg: "#f92672" bg: "#cdcdcd" }
 
     shape_and: { fg: "#9e6ffe" attr: "b" }
     shape_binary: { fg: "#9e6ffe" attr: "b" }

--- a/themes/themes/harmonic-dark.nu
+++ b/themes/themes/harmonic-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cbd6e2"
     block: "#cbd6e2"
     hints: "dark_gray"
+    search_result: { fg: "#bf8b56" bg: "#cbd6e2" }
 
     shape_and: { fg: "#bf568b" attr: "b" }
     shape_binary: { fg: "#bf568b" attr: "b" }

--- a/themes/themes/harmonic-light.nu
+++ b/themes/themes/harmonic-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#405c79"
     block: "#405c79"
     hints: "dark_gray"
+    search_result: { fg: "#bf8b56" bg: "#405c79" }
 
     shape_and: { fg: "#bf568b" attr: "b" }
     shape_binary: { fg: "#bf568b" attr: "b" }

--- a/themes/themes/harmonic16-dark.nu
+++ b/themes/themes/harmonic16-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cbd6e2"
     block: "#cbd6e2"
     hints: "dark_gray"
+    search_result: { fg: "#bf8b56" bg: "#cbd6e2" }
 
     shape_and: { fg: "#bf568b" attr: "b" }
     shape_binary: { fg: "#bf568b" attr: "b" }

--- a/themes/themes/harmonic16-light.nu
+++ b/themes/themes/harmonic16-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#405c79"
     block: "#405c79"
     hints: "dark_gray"
+    search_result: { fg: "#bf8b56" bg: "#405c79" }
 
     shape_and: { fg: "#bf568b" attr: "b" }
     shape_binary: { fg: "#bf568b" attr: "b" }

--- a/themes/themes/harper.nu
+++ b/themes/themes/harper.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a8a49d"
     block: "#a8a49d"
     hints: "dark_gray"
+    search_result: { fg: "#f8b63f" bg: "#a8a49d" }
 
     shape_and: { fg: "#b296c6" attr: "b" }
     shape_binary: { fg: "#b296c6" attr: "b" }

--- a/themes/themes/heetch-light.nu
+++ b/themes/themes/heetch-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#5a496e"
     block: "#5a496e"
     hints: "dark_gray"
+    search_result: { fg: "#27d9d5" bg: "#5a496e" }
 
     shape_and: { fg: "#bd0152" attr: "b" }
     shape_binary: { fg: "#bd0152" attr: "b" }

--- a/themes/themes/heetch.nu
+++ b/themes/themes/heetch.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bdb6c5"
     block: "#bdb6c5"
     hints: "dark_gray"
+    search_result: { fg: "#27d9d5" bg: "#bdb6c5" }
 
     shape_and: { fg: "#82034c" attr: "b" }
     shape_binary: { fg: "#82034c" attr: "b" }

--- a/themes/themes/helios.nu
+++ b/themes/themes/helios.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d5d5d5"
     block: "#d5d5d5"
     hints: "dark_gray"
+    search_result: { fg: "#d72638" bg: "#d5d5d5" }
 
     shape_and: { fg: "#be4264" attr: "b" }
     shape_binary: { fg: "#be4264" attr: "b" }

--- a/themes/themes/hemisu-dark.nu
+++ b/themes/themes/hemisu-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ededed"
     block: "#ededed"
     hints: "dark_gray"
+    search_result: { fg: "#ff0054" bg: "#ededed" }
 
     shape_and: { fg: "#b576bc" attr: "b" }
     shape_binary: { fg: "#b576bc" attr: "b" }

--- a/themes/themes/hemisu-light.nu
+++ b/themes/themes/hemisu-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#999999"
     block: "#999999"
     hints: "dark_gray"
+    search_result: { fg: "#ff0055" bg: "#999999" }
 
     shape_and: { fg: "#5b345e" attr: "b" }
     shape_binary: { fg: "#5b345e" attr: "b" }

--- a/themes/themes/highway.nu
+++ b/themes/themes/highway.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ededed"
     block: "#ededed"
     hints: "dark_gray"
+    search_result: { fg: "#d00e18" bg: "#ededed" }
 
     shape_and: { fg: "#6b2775" attr: "b" }
     shape_binary: { fg: "#6b2775" attr: "b" }

--- a/themes/themes/hipster-green.nu
+++ b/themes/themes/hipster-green.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bfbfbf"
     block: "#bfbfbf"
     hints: "dark_gray"
+    search_result: { fg: "#b6214a" bg: "#bfbfbf" }
 
     shape_and: { fg: "#b200b2" attr: "b" }
     shape_binary: { fg: "#b200b2" attr: "b" }

--- a/themes/themes/homebrew.nu
+++ b/themes/themes/homebrew.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bfbfbf"
     block: "#bfbfbf"
     hints: "dark_gray"
+    search_result: { fg: "#990000" bg: "#bfbfbf" }
 
     shape_and: { fg: "#b200b2" attr: "b" }
     shape_binary: { fg: "#b200b2" attr: "b" }

--- a/themes/themes/hopscotch.nu
+++ b/themes/themes/hopscotch.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b9b5b8"
     block: "#b9b5b8"
     hints: "dark_gray"
+    search_result: { fg: "#dd464c" bg: "#b9b5b8" }
 
     shape_and: { fg: "#c85e7c" attr: "b" }
     shape_binary: { fg: "#c85e7c" attr: "b" }

--- a/themes/themes/horizon-dark.nu
+++ b/themes/themes/horizon-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cbced0"
     block: "#cbced0"
     hints: "dark_gray"
+    search_result: { fg: "#e93c58" bg: "#cbced0" }
 
     shape_and: { fg: "#b072d1" attr: "b" }
     shape_binary: { fg: "#b072d1" attr: "b" }

--- a/themes/themes/horizon-light.nu
+++ b/themes/themes/horizon-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#403c3d"
     block: "#403c3d"
     hints: "dark_gray"
+    search_result: { fg: "#f7939b" bg: "#403c3d" }
 
     shape_and: { fg: "#1d8991" attr: "b" }
     shape_binary: { fg: "#1d8991" attr: "b" }

--- a/themes/themes/horizon-terminal-dark.nu
+++ b/themes/themes/horizon-terminal-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cbced0"
     block: "#cbced0"
     hints: "dark_gray"
+    search_result: { fg: "#e95678" bg: "#cbced0" }
 
     shape_and: { fg: "#ee64ac" attr: "b" }
     shape_binary: { fg: "#ee64ac" attr: "b" }

--- a/themes/themes/horizon-terminal-light.nu
+++ b/themes/themes/horizon-terminal-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#403c3d"
     block: "#403c3d"
     hints: "dark_gray"
+    search_result: { fg: "#e95678" bg: "#403c3d" }
 
     shape_and: { fg: "#ee64ac" attr: "b" }
     shape_binary: { fg: "#ee64ac" attr: "b" }

--- a/themes/themes/humanoid-dark.nu
+++ b/themes/themes/humanoid-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f8f8f2"
     block: "#f8f8f2"
     hints: "dark_gray"
+    search_result: { fg: "#f11235" bg: "#f8f8f2" }
 
     shape_and: { fg: "#f15ee3" attr: "b" }
     shape_binary: { fg: "#f15ee3" attr: "b" }

--- a/themes/themes/humanoid-light.nu
+++ b/themes/themes/humanoid-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#232629"
     block: "#232629"
     hints: "dark_gray"
+    search_result: { fg: "#b0151a" bg: "#232629" }
 
     shape_and: { fg: "#700f98" attr: "b" }
     shape_binary: { fg: "#700f98" attr: "b" }

--- a/themes/themes/hurtado.nu
+++ b/themes/themes/hurtado.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cbcccb"
     block: "#cbcccb"
     hints: "dark_gray"
+    search_result: { fg: "#ff1b00" bg: "#cbcccb" }
 
     shape_and: { fg: "#fd5ff1" attr: "b" }
     shape_binary: { fg: "#fd5ff1" attr: "b" }

--- a/themes/themes/hybrid.nu
+++ b/themes/themes/hybrid.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#969896"
     block: "#969896"
     hints: "dark_gray"
+    search_result: { fg: "#a54242" bg: "#969896" }
 
     shape_and: { fg: "#85678f" attr: "b" }
     shape_binary: { fg: "#85678f" attr: "b" }

--- a/themes/themes/ia-dark.nu
+++ b/themes/themes/ia-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cccccc"
     block: "#cccccc"
     hints: "dark_gray"
+    search_result: { fg: "#d88568" bg: "#cccccc" }
 
     shape_and: { fg: "#b98eb2" attr: "b" }
     shape_binary: { fg: "#b98eb2" attr: "b" }

--- a/themes/themes/ia-light.nu
+++ b/themes/themes/ia-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#181818"
     block: "#181818"
     hints: "dark_gray"
+    search_result: { fg: "#9c5a02" bg: "#181818" }
 
     shape_and: { fg: "#a94598" attr: "b" }
     shape_binary: { fg: "#a94598" attr: "b" }

--- a/themes/themes/ibm3270.nu
+++ b/themes/themes/ibm3270.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a5a5a5"
     block: "#a5a5a5"
     hints: "dark_gray"
+    search_result: { fg: "#f01818" bg: "#a5a5a5" }
 
     shape_and: { fg: "#f078d8" attr: "b" }
     shape_binary: { fg: "#f078d8" attr: "b" }

--- a/themes/themes/ic-green-ppl.nu
+++ b/themes/themes/ic-green-ppl.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0ffef"
     block: "#e0ffef"
     hints: "dark_gray"
+    search_result: { fg: "#fb002a" bg: "#e0ffef" }
 
     shape_and: { fg: "#53b82c" attr: "b" }
     shape_binary: { fg: "#53b82c" attr: "b" }

--- a/themes/themes/ic-orange-ppl.nu
+++ b/themes/themes/ic-orange-ppl.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffc88a"
     block: "#ffc88a"
     hints: "dark_gray"
+    search_result: { fg: "#c13900" bg: "#ffc88a" }
 
     shape_and: { fg: "#fc5e00" attr: "b" }
     shape_binary: { fg: "#fc5e00" attr: "b" }

--- a/themes/themes/iceberg-light.nu
+++ b/themes/themes/iceberg-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#33374c"
     block: "#33374c"
     hints: "dark_gray"
+    search_result: { fg: "#cc517a" bg: "#33374c" }
 
     shape_and: { fg: "#7759b4" attr: "b" }
     shape_binary: { fg: "#7759b4" attr: "b" }

--- a/themes/themes/icy.nu
+++ b/themes/themes/icy.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#095b67"
     block: "#095b67"
     hints: "dark_gray"
+    search_result: { fg: "#16c1d9" bg: "#095b67" }
 
     shape_and: { fg: "#00acc1" attr: "b" }
     shape_binary: { fg: "#00acc1" attr: "b" }

--- a/themes/themes/idle-toes.nu
+++ b/themes/themes/idle-toes.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#eeeeec"
     block: "#eeeeec"
     hints: "dark_gray"
+    search_result: { fg: "#d25252" bg: "#eeeeec" }
 
     shape_and: { fg: "#f680ff" attr: "b" }
     shape_binary: { fg: "#f680ff" attr: "b" }

--- a/themes/themes/idm_3b.nu
+++ b/themes/themes/idm_3b.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#606060"
     block: "#606060"
     hints: "dark_gray"
+    search_result: { fg: "#b04060" bg: "#606060" }
 
     shape_and: { fg: "#ba5aba" attr: "b" }
     shape_binary: { fg: "#ba5aba" attr: "b" }

--- a/themes/themes/ir-black.nu
+++ b/themes/themes/ir-black.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b5b3aa"
     block: "#b5b3aa"
     hints: "dark_gray"
+    search_result: { fg: "#ff6c60" bg: "#b5b3aa" }
 
     shape_and: { fg: "#ff73fd" attr: "b" }
     shape_binary: { fg: "#ff73fd" attr: "b" }

--- a/themes/themes/irblack.nu
+++ b/themes/themes/irblack.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b5b3aa"
     block: "#b5b3aa"
     hints: "dark_gray"
+    search_result: { fg: "#ff6c60" bg: "#b5b3aa" }
 
     shape_and: { fg: "#ff73fd" attr: "b" }
     shape_binary: { fg: "#ff73fd" attr: "b" }

--- a/themes/themes/isotope.nu
+++ b/themes/themes/isotope.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#ff0000" bg: "#d0d0d0" }
 
     shape_and: { fg: "#cc00ff" attr: "b" }
     shape_binary: { fg: "#cc00ff" attr: "b" }

--- a/themes/themes/jackie-brown.nu
+++ b/themes/themes/jackie-brown.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bfbfbf"
     block: "#bfbfbf"
     hints: "dark_gray"
+    search_result: { fg: "#ef5734" bg: "#bfbfbf" }
 
     shape_and: { fg: "#d05ec1" attr: "b" }
     shape_binary: { fg: "#d05ec1" attr: "b" }

--- a/themes/themes/japanesque.nu
+++ b/themes/themes/japanesque.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#fafaf6"
     block: "#fafaf6"
     hints: "dark_gray"
+    search_result: { fg: "#cf3f61" bg: "#fafaf6" }
 
     shape_and: { fg: "#a57fc4" attr: "b" }
     shape_binary: { fg: "#a57fc4" attr: "b" }

--- a/themes/themes/jellybeans.nu
+++ b/themes/themes/jellybeans.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dedede"
     block: "#dedede"
     hints: "dark_gray"
+    search_result: { fg: "#e27373" bg: "#dedede" }
 
     shape_and: { fg: "#e1c0fa" attr: "b" }
     shape_binary: { fg: "#e1c0fa" attr: "b" }

--- a/themes/themes/jet-brains-darcula.nu
+++ b/themes/themes/jet-brains-darcula.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#adadad"
     block: "#adadad"
     hints: "dark_gray"
+    search_result: { fg: "#fa5355" bg: "#adadad" }
 
     shape_and: { fg: "#fa54ff" attr: "b" }
     shape_binary: { fg: "#fa54ff" attr: "b" }

--- a/themes/themes/jup.nu
+++ b/themes/themes/jup.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f2f2f2"
     block: "#f2f2f2"
     hints: "dark_gray"
+    search_result: { fg: "#dd006f" bg: "#f2f2f2" }
 
     shape_and: { fg: "#6f00dd" attr: "b" }
     shape_binary: { fg: "#6f00dd" attr: "b" }

--- a/themes/themes/kibble.nu
+++ b/themes/themes/kibble.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e2d1e3"
     block: "#e2d1e3"
     hints: "dark_gray"
+    search_result: { fg: "#c70031" bg: "#e2d1e3" }
 
     shape_and: { fg: "#8400ff" attr: "b" }
     shape_binary: { fg: "#8400ff" attr: "b" }

--- a/themes/themes/kimber.nu
+++ b/themes/themes/kimber.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dedee7"
     block: "#dedee7"
     hints: "dark_gray"
+    search_result: { fg: "#c88c8c" bg: "#dedee7" }
 
     shape_and: { fg: "#86cacd" attr: "b" }
     shape_binary: { fg: "#86cacd" attr: "b" }

--- a/themes/themes/later-this-evening.nu
+++ b/themes/themes/later-this-evening.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#3c3d3d"
     block: "#3c3d3d"
     hints: "dark_gray"
+    search_result: { fg: "#d45a60" bg: "#3c3d3d" }
 
     shape_and: { fg: "#c092d6" attr: "b" }
     shape_binary: { fg: "#c092d6" attr: "b" }

--- a/themes/themes/lavandula.nu
+++ b/themes/themes/lavandula.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#736e7d"
     block: "#736e7d"
     hints: "dark_gray"
+    search_result: { fg: "#7d1625" bg: "#736e7d" }
 
     shape_and: { fg: "#5a3f7f" attr: "b" }
     shape_binary: { fg: "#5a3f7f" attr: "b" }

--- a/themes/themes/liquid-carbon-transparent.nu
+++ b/themes/themes/liquid-carbon-transparent.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bccccc"
     block: "#bccccc"
     hints: "dark_gray"
+    search_result: { fg: "#ff3030" bg: "#bccccc" }
 
     shape_and: { fg: "#cc69c8" attr: "b" }
     shape_binary: { fg: "#cc69c8" attr: "b" }

--- a/themes/themes/liquid-carbon.nu
+++ b/themes/themes/liquid-carbon.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bccccc"
     block: "#bccccc"
     hints: "dark_gray"
+    search_result: { fg: "#ff3030" bg: "#bccccc" }
 
     shape_and: { fg: "#cc69c8" attr: "b" }
     shape_binary: { fg: "#cc69c8" attr: "b" }

--- a/themes/themes/london-tube.nu
+++ b/themes/themes/london-tube.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d9d8d8"
     block: "#d9d8d8"
     hints: "dark_gray"
+    search_result: { fg: "#ee2e24" bg: "#d9d8d8" }
 
     shape_and: { fg: "#98005d" attr: "b" }
     shape_binary: { fg: "#98005d" attr: "b" }

--- a/themes/themes/macintosh.nu
+++ b/themes/themes/macintosh.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c0c0c0"
     block: "#c0c0c0"
     hints: "dark_gray"
+    search_result: { fg: "#dd0907" bg: "#c0c0c0" }
 
     shape_and: { fg: "#4700a5" attr: "b" }
     shape_binary: { fg: "#4700a5" attr: "b" }

--- a/themes/themes/maia.nu
+++ b/themes/themes/maia.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0e0e0"
     block: "#e0e0e0"
     hints: "dark_gray"
+    search_result: { fg: "#ba2922" bg: "#e0e0e0" }
 
     shape_and: { fg: "#43746a" attr: "b" }
     shape_binary: { fg: "#43746a" attr: "b" }

--- a/themes/themes/man-page.nu
+++ b/themes/themes/man-page.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cccccc"
     block: "#cccccc"
     hints: "dark_gray"
+    search_result: { fg: "#cc0000" bg: "#cccccc" }
 
     shape_and: { fg: "#b200b2" attr: "b" }
     shape_binary: { fg: "#b200b2" attr: "b" }

--- a/themes/themes/mar.nu
+++ b/themes/themes/mar.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f8f8f8"
     block: "#f8f8f8"
     hints: "dark_gray"
+    search_result: { fg: "#b5407b" bg: "#f8f8f8" }
 
     shape_and: { fg: "#7b40b5" attr: "b" }
     shape_binary: { fg: "#7b40b5" attr: "b" }

--- a/themes/themes/marrakesh.nu
+++ b/themes/themes/marrakesh.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#948e48"
     block: "#948e48"
     hints: "dark_gray"
+    search_result: { fg: "#c35359" bg: "#948e48" }
 
     shape_and: { fg: "#8868b3" attr: "b" }
     shape_binary: { fg: "#8868b3" attr: "b" }

--- a/themes/themes/materia.nu
+++ b/themes/themes/materia.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cdd3de"
     block: "#cdd3de"
     hints: "dark_gray"
+    search_result: { fg: "#ec5f67" bg: "#cdd3de" }
 
     shape_and: { fg: "#82aaff" attr: "b" }
     shape_binary: { fg: "#82aaff" attr: "b" }

--- a/themes/themes/material-dark.nu
+++ b/themes/themes/material-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#eeeeee"
     block: "#eeeeee"
     hints: "dark_gray"
+    search_result: { fg: "#b7141e" bg: "#eeeeee" }
 
     shape_and: { fg: "#550087" attr: "b" }
     shape_binary: { fg: "#550087" attr: "b" }

--- a/themes/themes/material-darker.nu
+++ b/themes/themes/material-darker.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#eeffff"
     block: "#eeffff"
     hints: "dark_gray"
+    search_result: { fg: "#f07178" bg: "#eeffff" }
 
     shape_and: { fg: "#c792ea" attr: "b" }
     shape_binary: { fg: "#c792ea" attr: "b" }

--- a/themes/themes/material-lighter.nu
+++ b/themes/themes/material-lighter.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#80cbc4"
     block: "#80cbc4"
     hints: "dark_gray"
+    search_result: { fg: "#ff5370" bg: "#80cbc4" }
 
     shape_and: { fg: "#7c4dff" attr: "b" }
     shape_binary: { fg: "#7c4dff" attr: "b" }

--- a/themes/themes/material-palenight.nu
+++ b/themes/themes/material-palenight.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#959dcb"
     block: "#959dcb"
     hints: "dark_gray"
+    search_result: { fg: "#f07178" bg: "#959dcb" }
 
     shape_and: { fg: "#c792ea" attr: "b" }
     shape_binary: { fg: "#c792ea" attr: "b" }

--- a/themes/themes/material-vivid.nu
+++ b/themes/themes/material-vivid.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#80868b"
     block: "#80868b"
     hints: "dark_gray"
+    search_result: { fg: "#f44336" bg: "#80868b" }
 
     shape_and: { fg: "#673ab7" attr: "b" }
     shape_binary: { fg: "#673ab7" attr: "b" }

--- a/themes/themes/material.nu
+++ b/themes/themes/material.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#eeffff"
     block: "#eeffff"
     hints: "dark_gray"
+    search_result: { fg: "#f07178" bg: "#eeffff" }
 
     shape_and: { fg: "#c792ea" attr: "b" }
     shape_binary: { fg: "#c792ea" attr: "b" }

--- a/themes/themes/mathias.nu
+++ b/themes/themes/mathias.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f2f2f2"
     block: "#f2f2f2"
     hints: "dark_gray"
+    search_result: { fg: "#e52222" bg: "#f2f2f2" }
 
     shape_and: { fg: "#fa2573" attr: "b" }
     shape_binary: { fg: "#fa2573" attr: "b" }

--- a/themes/themes/medallion.nu
+++ b/themes/themes/medallion.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cac29a"
     block: "#cac29a"
     hints: "dark_gray"
+    search_result: { fg: "#b64c00" bg: "#cac29a" }
 
     shape_and: { fg: "#8c5a90" attr: "b" }
     shape_binary: { fg: "#8c5a90" attr: "b" }

--- a/themes/themes/mellow-purple.nu
+++ b/themes/themes/mellow-purple.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffeeff"
     block: "#ffeeff"
     hints: "dark_gray"
+    search_result: { fg: "#00d9e9" bg: "#ffeeff" }
 
     shape_and: { fg: "#8991bb" attr: "b" }
     shape_binary: { fg: "#8991bb" attr: "b" }

--- a/themes/themes/mexico-light.nu
+++ b/themes/themes/mexico-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#383838"
     block: "#383838"
     hints: "dark_gray"
+    search_result: { fg: "#ab4642" bg: "#383838" }
 
     shape_and: { fg: "#96609e" attr: "b" }
     shape_binary: { fg: "#96609e" attr: "b" }

--- a/themes/themes/miramare.nu
+++ b/themes/themes/miramare.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#444444"
     block: "#444444"
     hints: "dark_gray"
+    search_result: { fg: "#e68183" bg: "#444444" }
 
     shape_and: { fg: "#d3a0bc" attr: "b" }
     shape_binary: { fg: "#d3a0bc" attr: "b" }

--- a/themes/themes/misterioso.nu
+++ b/themes/themes/misterioso.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e1e1e0"
     block: "#e1e1e0"
     hints: "dark_gray"
+    search_result: { fg: "#ff4242" bg: "#e1e1e0" }
 
     shape_and: { fg: "#9414e6" attr: "b" }
     shape_binary: { fg: "#9414e6" attr: "b" }

--- a/themes/themes/miu.nu
+++ b/themes/themes/miu.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d9d9d9"
     block: "#d9d9d9"
     hints: "dark_gray"
+    search_result: { fg: "#b87a7a" bg: "#d9d9d9" }
 
     shape_and: { fg: "#b87ab8" attr: "b" }
     shape_binary: { fg: "#b87ab8" attr: "b" }

--- a/themes/themes/mocha.nu
+++ b/themes/themes/mocha.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0c8c6"
     block: "#d0c8c6"
     hints: "dark_gray"
+    search_result: { fg: "#cb6077" bg: "#d0c8c6" }
 
     shape_and: { fg: "#a89bb9" attr: "b" }
     shape_binary: { fg: "#a89bb9" attr: "b" }

--- a/themes/themes/molokai.nu
+++ b/themes/themes/molokai.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#7325fa" bg: "#bbbbbb" }
 
     shape_and: { fg: "#ff0087" attr: "b" }
     shape_binary: { fg: "#ff0087" attr: "b" }

--- a/themes/themes/mona-lisa.nu
+++ b/themes/themes/mona-lisa.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f7d75c"
     block: "#f7d75c"
     hints: "dark_gray"
+    search_result: { fg: "#9b291c" bg: "#f7d75c" }
 
     shape_and: { fg: "#9b1d29" attr: "b" }
     shape_binary: { fg: "#9b1d29" attr: "b" }

--- a/themes/themes/mono-amber.nu
+++ b/themes/themes/mono-amber.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ff9400"
     block: "#ff9400"
     hints: "dark_gray"
+    search_result: { fg: "#ff9400" bg: "#ff9400" }
 
     shape_and: { fg: "#ff9400" attr: "b" }
     shape_binary: { fg: "#ff9400" attr: "b" }

--- a/themes/themes/mono-cyan.nu
+++ b/themes/themes/mono-cyan.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#00ccff"
     block: "#00ccff"
     hints: "dark_gray"
+    search_result: { fg: "#00ccff" bg: "#00ccff" }
 
     shape_and: { fg: "#00ccff" attr: "b" }
     shape_binary: { fg: "#00ccff" attr: "b" }

--- a/themes/themes/mono-green.nu
+++ b/themes/themes/mono-green.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#0bff00"
     block: "#0bff00"
     hints: "dark_gray"
+    search_result: { fg: "#0bff00" bg: "#0bff00" }
 
     shape_and: { fg: "#0bff00" attr: "b" }
     shape_binary: { fg: "#0bff00" attr: "b" }

--- a/themes/themes/mono-red.nu
+++ b/themes/themes/mono-red.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ff3600"
     block: "#ff3600"
     hints: "dark_gray"
+    search_result: { fg: "#ff3600" bg: "#ff3600" }
 
     shape_and: { fg: "#ff3600" attr: "b" }
     shape_binary: { fg: "#ff3600" attr: "b" }

--- a/themes/themes/mono-white.nu
+++ b/themes/themes/mono-white.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#fafafa"
     block: "#fafafa"
     hints: "dark_gray"
+    search_result: { fg: "#fafafa" bg: "#fafafa" }
 
     shape_and: { fg: "#fafafa" attr: "b" }
     shape_binary: { fg: "#fafafa" attr: "b" }

--- a/themes/themes/mono-yellow.nu
+++ b/themes/themes/mono-yellow.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffd300"
     block: "#ffd300"
     hints: "dark_gray"
+    search_result: { fg: "#ffd300" bg: "#ffd300" }
 
     shape_and: { fg: "#ffd300" attr: "b" }
     shape_binary: { fg: "#ffd300" attr: "b" }

--- a/themes/themes/monokai-dark.nu
+++ b/themes/themes/monokai-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f9f8f5"
     block: "#f9f8f5"
     hints: "dark_gray"
+    search_result: { fg: "#f92672" bg: "#f9f8f5" }
 
     shape_and: { fg: "#ae81ff" attr: "b" }
     shape_binary: { fg: "#ae81ff" attr: "b" }

--- a/themes/themes/monokai-soda.nu
+++ b/themes/themes/monokai-soda.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c4c5b5"
     block: "#c4c5b5"
     hints: "dark_gray"
+    search_result: { fg: "#f4005f" bg: "#c4c5b5" }
 
     shape_and: { fg: "#f4005f" attr: "b" }
     shape_binary: { fg: "#f4005f" attr: "b" }

--- a/themes/themes/monokai.nu
+++ b/themes/themes/monokai.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f8f8f2"
     block: "#f8f8f2"
     hints: "dark_gray"
+    search_result: { fg: "#f92672" bg: "#f8f8f2" }
 
     shape_and: { fg: "#ae81ff" attr: "b" }
     shape_binary: { fg: "#ae81ff" attr: "b" }

--- a/themes/themes/mountaineer-grey.nu
+++ b/themes/themes/mountaineer-grey.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c5c8c6"
     block: "#c5c8c6"
     hints: "dark_gray"
+    search_result: { fg: "#cc6666" bg: "#c5c8c6" }
 
     shape_and: { fg: "#b294bb" attr: "b" }
     shape_binary: { fg: "#b294bb" attr: "b" }

--- a/themes/themes/mountaineer.nu
+++ b/themes/themes/mountaineer.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c5c8c6"
     block: "#c5c8c6"
     hints: "dark_gray"
+    search_result: { fg: "#cc6666" bg: "#c5c8c6" }
 
     shape_and: { fg: "#b294bb" attr: "b" }
     shape_binary: { fg: "#b294bb" attr: "b" }

--- a/themes/themes/n0tch2k.nu
+++ b/themes/themes/n0tch2k.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0b8a3"
     block: "#d0b8a3"
     hints: "dark_gray"
+    search_result: { fg: "#a95551" bg: "#d0b8a3" }
 
     shape_and: { fg: "#767676" attr: "b" }
     shape_binary: { fg: "#767676" attr: "b" }

--- a/themes/themes/nebula.nu
+++ b/themes/themes/nebula.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a4a6a9"
     block: "#a4a6a9"
     hints: "dark_gray"
+    search_result: { fg: "#777abc" bg: "#a4a6a9" }
 
     shape_and: { fg: "#716cae" attr: "b" }
     shape_binary: { fg: "#716cae" attr: "b" }

--- a/themes/themes/neon-night.nu
+++ b/themes/themes/neon-night.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c9cccd"
     block: "#c9cccd"
     hints: "dark_gray"
+    search_result: { fg: "#ff8e8e" bg: "#c9cccd" }
 
     shape_and: { fg: "#dd92f6" attr: "b" }
     shape_binary: { fg: "#dd92f6" attr: "b" }

--- a/themes/themes/neopolitan.nu
+++ b/themes/themes/neopolitan.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f8f8f8"
     block: "#f8f8f8"
     hints: "dark_gray"
+    search_result: { fg: "#800000" bg: "#f8f8f8" }
 
     shape_and: { fg: "#ff0080" attr: "b" }
     shape_binary: { fg: "#ff0080" attr: "b" }

--- a/themes/themes/nep.nu
+++ b/themes/themes/nep.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f2f2f2"
     block: "#f2f2f2"
     hints: "dark_gray"
+    search_result: { fg: "#dd6f00" bg: "#f2f2f2" }
 
     shape_and: { fg: "#dd006f" attr: "b" }
     shape_binary: { fg: "#dd006f" attr: "b" }

--- a/themes/themes/neutron.nu
+++ b/themes/themes/neutron.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e6e8ef"
     block: "#e6e8ef"
     hints: "dark_gray"
+    search_result: { fg: "#b54036" bg: "#e6e8ef" }
 
     shape_and: { fg: "#a4799d" attr: "b" }
     shape_binary: { fg: "#a4799d" attr: "b" }

--- a/themes/themes/nightfly.nu
+++ b/themes/themes/nightfly.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a1aab8"
     block: "#a1aab8"
     hints: "dark_gray"
+    search_result: { fg: "#fc514e" bg: "#a1aab8" }
 
     shape_and: { fg: "#c792ea" attr: "b" }
     shape_binary: { fg: "#c792ea" attr: "b" }

--- a/themes/themes/nightlion-v1.nu
+++ b/themes/themes/nightlion-v1.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#bb0000" bg: "#bbbbbb" }
 
     shape_and: { fg: "#bb00bb" attr: "b" }
     shape_binary: { fg: "#bb00bb" attr: "b" }

--- a/themes/themes/nightlion-v2.nu
+++ b/themes/themes/nightlion-v2.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#bb0000" bg: "#bbbbbb" }
 
     shape_and: { fg: "#ce6fdb" attr: "b" }
     shape_binary: { fg: "#ce6fdb" attr: "b" }

--- a/themes/themes/nighty.nu
+++ b/themes/themes/nighty.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#828282"
     block: "#828282"
     hints: "dark_gray"
+    search_result: { fg: "#9b3e46" bg: "#828282" }
 
     shape_and: { fg: "#823065" attr: "b" }
     shape_binary: { fg: "#823065" attr: "b" }

--- a/themes/themes/nord-alt.nu
+++ b/themes/themes/nord-alt.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#8fbcbb"
     block: "#8fbcbb"
     hints: "dark_gray"
+    search_result: { fg: "#3b4252" bg: "#8fbcbb" }
 
     shape_and: { fg: "#e5e9f0" attr: "b" }
     shape_binary: { fg: "#e5e9f0" attr: "b" }

--- a/themes/themes/nord-light.nu
+++ b/themes/themes/nord-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b3b3b3"
     block: "#b3b3b3"
     hints: "dark_gray"
+    search_result: { fg: "#e64569" bg: "#b3b3b3" }
 
     shape_and: { fg: "#d961dc" attr: "b" }
     shape_binary: { fg: "#d961dc" attr: "b" }

--- a/themes/themes/nord.nu
+++ b/themes/themes/nord.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e5e9f0"
     block: "#e5e9f0"
     hints: "dark_gray"
+    search_result: { fg: "#bf616a" bg: "#e5e9f0" }
 
     shape_and: { fg: "#b48ead" attr: "b" }
     shape_binary: { fg: "#b48ead" attr: "b" }

--- a/themes/themes/nova.nu
+++ b/themes/themes/nova.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c5d4dd"
     block: "#c5d4dd"
     hints: "dark_gray"
+    search_result: { fg: "#83afe5" bg: "#c5d4dd" }
 
     shape_and: { fg: "#9a93e1" attr: "b" }
     shape_binary: { fg: "#9a93e1" attr: "b" }

--- a/themes/themes/novel.nu
+++ b/themes/themes/novel.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cccccc"
     block: "#cccccc"
     hints: "dark_gray"
+    search_result: { fg: "#cc0000" bg: "#cccccc" }
 
     shape_and: { fg: "#cc00cc" attr: "b" }
     shape_binary: { fg: "#cc00cc" attr: "b" }

--- a/themes/themes/nushell-dark.nu
+++ b/themes/themes/nushell-dark.nu
@@ -81,4 +81,8 @@ export def main [] { return {
     shape_table: blue_bold
     shape_variable: purple
     shape_vardecl: purple
+
+    background: dark_gray
+    foreground: default
+    cursor: red
 }}

--- a/themes/themes/nushell-dark.nu
+++ b/themes/themes/nushell-dark.nu
@@ -44,6 +44,7 @@ export def main [] { return {
     list: white
     block: white
     hints: dark_gray
+    search_result: {bg: red fg: white}
 
     shape_and: purple_bold
     shape_binary: purple_bold

--- a/themes/themes/nushell-light.nu
+++ b/themes/themes/nushell-light.nu
@@ -81,4 +81,8 @@ export def main [] { return {
     shape_table: blue_bold
     shape_variable: purple
     shape_vardecl: purple
+
+    background: light_gray
+    foreground: default
+    cursor: red
 }}

--- a/themes/themes/nushell-light.nu
+++ b/themes/themes/nushell-light.nu
@@ -44,6 +44,7 @@ export def main [] { return {
     list: white
     block: white
     hints: dark_gray
+    search_result: {fg: white bg: red}
 
     shape_and: purple_bold
     shape_binary: purple_bold

--- a/themes/themes/obsidian.nu
+++ b/themes/themes/obsidian.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#a60001" bg: "#bbbbbb" }
 
     shape_and: { fg: "#bb00bb" attr: "b" }
     shape_binary: { fg: "#bb00bb" attr: "b" }

--- a/themes/themes/ocean-dark.nu
+++ b/themes/themes/ocean-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#eeedee"
     block: "#eeedee"
     hints: "dark_gray"
+    search_result: { fg: "#af4b57" bg: "#eeedee" }
 
     shape_and: { fg: "#a4799d" attr: "b" }
     shape_binary: { fg: "#a4799d" attr: "b" }

--- a/themes/themes/ocean.nu
+++ b/themes/themes/ocean.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c0c5ce"
     block: "#c0c5ce"
     hints: "dark_gray"
+    search_result: { fg: "#bf616a" bg: "#c0c5ce" }
 
     shape_and: { fg: "#b48ead" attr: "b" }
     shape_binary: { fg: "#b48ead" attr: "b" }

--- a/themes/themes/oceanic-material.nu
+++ b/themes/themes/oceanic-material.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a4a4a4"
     block: "#a4a4a4"
     hints: "dark_gray"
+    search_result: { fg: "#ee2a29" bg: "#a4a4a4" }
 
     shape_and: { fg: "#8800a0" attr: "b" }
     shape_binary: { fg: "#8800a0" attr: "b" }

--- a/themes/themes/oceanic-next.nu
+++ b/themes/themes/oceanic-next.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#e44754" bg: "#ffffff" }
 
     shape_and: { fg: "#b77eb8" attr: "b" }
     shape_binary: { fg: "#b77eb8" attr: "b" }

--- a/themes/themes/oceanicnext.nu
+++ b/themes/themes/oceanicnext.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c0c5ce"
     block: "#c0c5ce"
     hints: "dark_gray"
+    search_result: { fg: "#ec5f67" bg: "#c0c5ce" }
 
     shape_and: { fg: "#c594c5" attr: "b" }
     shape_binary: { fg: "#c594c5" attr: "b" }

--- a/themes/themes/ollie.nu
+++ b/themes/themes/ollie.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#8a8eac"
     block: "#8a8eac"
     hints: "dark_gray"
+    search_result: { fg: "#ac2e31" bg: "#8a8eac" }
 
     shape_and: { fg: "#b08528" attr: "b" }
     shape_binary: { fg: "#b08528" attr: "b" }

--- a/themes/themes/one-dark.nu
+++ b/themes/themes/one-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#abb2bf"
     block: "#abb2bf"
     hints: "dark_gray"
+    search_result: { fg: "#e06c75" bg: "#abb2bf" }
 
     shape_and: { fg: "#c678dd" attr: "b" }
     shape_binary: { fg: "#c678dd" attr: "b" }

--- a/themes/themes/one-half-black.nu
+++ b/themes/themes/one-half-black.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dcdfe4"
     block: "#dcdfe4"
     hints: "dark_gray"
+    search_result: { fg: "#e06c75" bg: "#dcdfe4" }
 
     shape_and: { fg: "#c678dd" attr: "b" }
     shape_binary: { fg: "#c678dd" attr: "b" }

--- a/themes/themes/one-half-light.nu
+++ b/themes/themes/one-half-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#fafafa"
     block: "#fafafa"
     hints: "dark_gray"
+    search_result: { fg: "#e45649" bg: "#fafafa" }
 
     shape_and: { fg: "#a626a4" attr: "b" }
     shape_binary: { fg: "#a626a4" attr: "b" }

--- a/themes/themes/one-light.nu
+++ b/themes/themes/one-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#383a42"
     block: "#383a42"
     hints: "dark_gray"
+    search_result: { fg: "#ca1243" bg: "#383a42" }
 
     shape_and: { fg: "#a626a4" attr: "b" }
     shape_binary: { fg: "#a626a4" attr: "b" }

--- a/themes/themes/onedark.nu
+++ b/themes/themes/onedark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#abb2bf"
     block: "#abb2bf"
     hints: "dark_gray"
+    search_result: { fg: "#e06c75" bg: "#abb2bf" }
 
     shape_and: { fg: "#c678dd" attr: "b" }
     shape_binary: { fg: "#c678dd" attr: "b" }

--- a/themes/themes/orbital.nu
+++ b/themes/themes/orbital.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#0000d7"
     block: "#0000d7"
     hints: "dark_gray"
+    search_result: { fg: "#5f5f5f" bg: "#0000d7" }
 
     shape_and: { fg: "#87afd7" attr: "b" }
     shape_binary: { fg: "#87afd7" attr: "b" }

--- a/themes/themes/outrun-dark.nu
+++ b/themes/themes/outrun-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0fa"
     block: "#d0d0fa"
     hints: "dark_gray"
+    search_result: { fg: "#ff4242" bg: "#d0d0fa" }
 
     shape_and: { fg: "#f10596" attr: "b" }
     shape_binary: { fg: "#f10596" attr: "b" }

--- a/themes/themes/pali.nu
+++ b/themes/themes/pali.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f2f2f2"
     block: "#f2f2f2"
     hints: "dark_gray"
+    search_result: { fg: "#ab8f74" bg: "#f2f2f2" }
 
     shape_and: { fg: "#ab748f" attr: "b" }
     shape_binary: { fg: "#ab748f" attr: "b" }

--- a/themes/themes/palmtree.nu
+++ b/themes/themes/palmtree.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#fdfdfd"
     block: "#fdfdfd"
     hints: "dark_gray"
+    search_result: { fg: "#f37f97" bg: "#fdfdfd" }
 
     shape_and: { fg: "#c574dd" attr: "b" }
     shape_binary: { fg: "#c574dd" attr: "b" }

--- a/themes/themes/papercolor-dark.nu
+++ b/themes/themes/papercolor-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#808080"
     block: "#808080"
     hints: "dark_gray"
+    search_result: { fg: "#585858" bg: "#808080" }
 
     shape_and: { fg: "#00afaf" attr: "b" }
     shape_binary: { fg: "#00afaf" attr: "b" }

--- a/themes/themes/papercolor-light.nu
+++ b/themes/themes/papercolor-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#444444"
     block: "#444444"
     hints: "dark_gray"
+    search_result: { fg: "#bcbcbc" bg: "#444444" }
 
     shape_and: { fg: "#005faf" attr: "b" }
     shape_binary: { fg: "#005faf" attr: "b" }

--- a/themes/themes/paraiso-dark.nu
+++ b/themes/themes/paraiso-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a39e9b"
     block: "#a39e9b"
     hints: "dark_gray"
+    search_result: { fg: "#ef6155" bg: "#a39e9b" }
 
     shape_and: { fg: "#815ba4" attr: "b" }
     shape_binary: { fg: "#815ba4" attr: "b" }

--- a/themes/themes/paraiso.nu
+++ b/themes/themes/paraiso.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a39e9b"
     block: "#a39e9b"
     hints: "dark_gray"
+    search_result: { fg: "#ef6155" bg: "#a39e9b" }
 
     shape_and: { fg: "#815ba4" attr: "b" }
     shape_binary: { fg: "#815ba4" attr: "b" }

--- a/themes/themes/pasque.nu
+++ b/themes/themes/pasque.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dedcdf"
     block: "#dedcdf"
     hints: "dark_gray"
+    search_result: { fg: "#a92258" bg: "#dedcdf" }
 
     shape_and: { fg: "#953b9d" attr: "b" }
     shape_binary: { fg: "#953b9d" attr: "b" }

--- a/themes/themes/paul-millr.nu
+++ b/themes/themes/paul-millr.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#ff0000" bg: "#bbbbbb" }
 
     shape_and: { fg: "#b449be" attr: "b" }
     shape_binary: { fg: "#b449be" attr: "b" }

--- a/themes/themes/pencil-dark.nu
+++ b/themes/themes/pencil-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d9d9d9"
     block: "#d9d9d9"
     hints: "dark_gray"
+    search_result: { fg: "#c30771" bg: "#d9d9d9" }
 
     shape_and: { fg: "#523c79" attr: "b" }
     shape_binary: { fg: "#523c79" attr: "b" }

--- a/themes/themes/pencil-light.nu
+++ b/themes/themes/pencil-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d9d9d9"
     block: "#d9d9d9"
     hints: "dark_gray"
+    search_result: { fg: "#c30771" bg: "#d9d9d9" }
 
     shape_and: { fg: "#523c79" attr: "b" }
     shape_binary: { fg: "#523c79" attr: "b" }

--- a/themes/themes/peppermint.nu
+++ b/themes/themes/peppermint.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b3b3b3"
     block: "#b3b3b3"
     hints: "dark_gray"
+    search_result: { fg: "#e64569" bg: "#b3b3b3" }
 
     shape_and: { fg: "#d961dc" attr: "b" }
     shape_binary: { fg: "#d961dc" attr: "b" }

--- a/themes/themes/phd.nu
+++ b/themes/themes/phd.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b8bbc2"
     block: "#b8bbc2"
     hints: "dark_gray"
+    search_result: { fg: "#d07346" bg: "#b8bbc2" }
 
     shape_and: { fg: "#9989cc" attr: "b" }
     shape_binary: { fg: "#9989cc" attr: "b" }

--- a/themes/themes/piatto-light.nu
+++ b/themes/themes/piatto-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#b23670" bg: "#ffffff" }
 
     shape_and: { fg: "#a353b2" attr: "b" }
     shape_binary: { fg: "#a353b2" attr: "b" }

--- a/themes/themes/pico.nu
+++ b/themes/themes/pico.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#5f574f"
     block: "#5f574f"
     hints: "dark_gray"
+    search_result: { fg: "#ff004d" bg: "#5f574f" }
 
     shape_and: { fg: "#ff77a8" attr: "b" }
     shape_binary: { fg: "#ff77a8" attr: "b" }

--- a/themes/themes/pnevma.nu
+++ b/themes/themes/pnevma.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#a36666" bg: "#d0d0d0" }
 
     shape_and: { fg: "#c79ec4" attr: "b" }
     shape_binary: { fg: "#c79ec4" attr: "b" }

--- a/themes/themes/pop.nu
+++ b/themes/themes/pop.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#eb008a" bg: "#d0d0d0" }
 
     shape_and: { fg: "#b31e8d" attr: "b" }
     shape_binary: { fg: "#b31e8d" attr: "b" }

--- a/themes/themes/porple.nu
+++ b/themes/themes/porple.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d8d8d8"
     block: "#d8d8d8"
     hints: "dark_gray"
+    search_result: { fg: "#f84547" bg: "#d8d8d8" }
 
     shape_and: { fg: "#b74989" attr: "b" }
     shape_binary: { fg: "#b74989" attr: "b" }

--- a/themes/themes/pro.nu
+++ b/themes/themes/pro.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bfbfbf"
     block: "#bfbfbf"
     hints: "dark_gray"
+    search_result: { fg: "#990000" bg: "#bfbfbf" }
 
     shape_and: { fg: "#b200b2" attr: "b" }
     shape_binary: { fg: "#b200b2" attr: "b" }

--- a/themes/themes/railscasts.nu
+++ b/themes/themes/railscasts.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e6e1dc"
     block: "#e6e1dc"
     hints: "dark_gray"
+    search_result: { fg: "#da4939" bg: "#e6e1dc" }
 
     shape_and: { fg: "#b6b3eb" attr: "b" }
     shape_binary: { fg: "#b6b3eb" attr: "b" }

--- a/themes/themes/rebecca.nu
+++ b/themes/themes/rebecca.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f1eff8"
     block: "#f1eff8"
     hints: "dark_gray"
+    search_result: { fg: "#a0a0c5" bg: "#f1eff8" }
 
     shape_and: { fg: "#7aa5ff" attr: "b" }
     shape_binary: { fg: "#7aa5ff" attr: "b" }

--- a/themes/themes/red-alert.nu
+++ b/themes/themes/red-alert.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d6d6d6"
     block: "#d6d6d6"
     hints: "dark_gray"
+    search_result: { fg: "#d62e4e" bg: "#d6d6d6" }
 
     shape_and: { fg: "#e979d7" attr: "b" }
     shape_binary: { fg: "#e979d7" attr: "b" }

--- a/themes/themes/red-sands.nu
+++ b/themes/themes/red-sands.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bbbbbb"
     block: "#bbbbbb"
     hints: "dark_gray"
+    search_result: { fg: "#ff3f00" bg: "#bbbbbb" }
 
     shape_and: { fg: "#bb00bb" attr: "b" }
     shape_binary: { fg: "#bb00bb" attr: "b" }

--- a/themes/themes/relaxed-afterglow.nu
+++ b/themes/themes/relaxed-afterglow.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d9d9d9"
     block: "#d9d9d9"
     hints: "dark_gray"
+    search_result: { fg: "#bc5653" bg: "#d9d9d9" }
 
     shape_and: { fg: "#b06698" attr: "b" }
     shape_binary: { fg: "#b06698" attr: "b" }

--- a/themes/themes/renault-style-light.nu
+++ b/themes/themes/renault-style-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#da4839" bg: "#ffffff" }
 
     shape_and: { fg: "#cfcfff" attr: "b" }
     shape_binary: { fg: "#cfcfff" attr: "b" }

--- a/themes/themes/rippedcasts.nu
+++ b/themes/themes/rippedcasts.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bfbfbf"
     block: "#bfbfbf"
     hints: "dark_gray"
+    search_result: { fg: "#cdaf95" bg: "#bfbfbf" }
 
     shape_and: { fg: "#ff73fd" attr: "b" }
     shape_binary: { fg: "#ff73fd" attr: "b" }

--- a/themes/themes/rose-pine-dawn.nu
+++ b/themes/themes/rose-pine-dawn.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#575279"
     block: "#575279"
     hints: "dark_gray"
+    search_result: { fg: "#1f1d2e" bg: "#575279" }
 
     shape_and: { fg: "#907aa9" attr: "b" }
     shape_binary: { fg: "#907aa9" attr: "b" }

--- a/themes/themes/rose-pine-moon.nu
+++ b/themes/themes/rose-pine-moon.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0def4"
     block: "#e0def4"
     hints: "dark_gray"
+    search_result: { fg: "#ecebf0" bg: "#e0def4" }
 
     shape_and: { fg: "#c4a7e7" attr: "b" }
     shape_binary: { fg: "#c4a7e7" attr: "b" }

--- a/themes/themes/rose-pine.nu
+++ b/themes/themes/rose-pine.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0def4"
     block: "#e0def4"
     hints: "dark_gray"
+    search_result: { fg: "#e2e1e7" bg: "#e0def4" }
 
     shape_and: { fg: "#c4a7e7" attr: "b" }
     shape_binary: { fg: "#c4a7e7" attr: "b" }

--- a/themes/themes/royal.nu
+++ b/themes/themes/royal.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#524966"
     block: "#524966"
     hints: "dark_gray"
+    search_result: { fg: "#91284c" bg: "#524966" }
 
     shape_and: { fg: "#674d96" attr: "b" }
     shape_binary: { fg: "#674d96" attr: "b" }

--- a/themes/themes/sagelight.nu
+++ b/themes/themes/sagelight.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#383838"
     block: "#383838"
     hints: "dark_gray"
+    search_result: { fg: "#fa8480" bg: "#383838" }
 
     shape_and: { fg: "#c8a0d2" attr: "b" }
     shape_binary: { fg: "#c8a0d2" attr: "b" }

--- a/themes/themes/sandcastle.nu
+++ b/themes/themes/sandcastle.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a89984"
     block: "#a89984"
     hints: "dark_gray"
+    search_result: { fg: "#83a598" bg: "#a89984" }
 
     shape_and: { fg: "#d75f5f" attr: "b" }
     shape_binary: { fg: "#d75f5f" attr: "b" }

--- a/themes/themes/sat.nu
+++ b/themes/themes/sat.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f2f2f2"
     block: "#f2f2f2"
     hints: "dark_gray"
+    search_result: { fg: "#dd0007" bg: "#f2f2f2" }
 
     shape_and: { fg: "#d600dd" attr: "b" }
     shape_binary: { fg: "#d600dd" attr: "b" }

--- a/themes/themes/sea-shells.nu
+++ b/themes/themes/sea-shells.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#deb88d"
     block: "#deb88d"
     hints: "dark_gray"
+    search_result: { fg: "#d15123" bg: "#deb88d" }
 
     shape_and: { fg: "#68d4f1" attr: "b" }
     shape_binary: { fg: "#68d4f1" attr: "b" }

--- a/themes/themes/seafoam-pastel.nu
+++ b/themes/themes/seafoam-pastel.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e0e0e0"
     block: "#e0e0e0"
     hints: "dark_gray"
+    search_result: { fg: "#825d4d" bg: "#e0e0e0" }
 
     shape_and: { fg: "#8a7267" attr: "b" }
     shape_binary: { fg: "#8a7267" attr: "b" }

--- a/themes/themes/selenized-black.nu
+++ b/themes/themes/selenized-black.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#777777"
     block: "#777777"
     hints: "dark_gray"
+    search_result: { fg: "#ed4a46" bg: "#777777" }
 
     shape_and: { fg: "#eb6eb7" attr: "b" }
     shape_binary: { fg: "#eb6eb7" attr: "b" }

--- a/themes/themes/selenized-dark.nu
+++ b/themes/themes/selenized-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#72898f"
     block: "#72898f"
     hints: "dark_gray"
+    search_result: { fg: "#fa5750" bg: "#72898f" }
 
     shape_and: { fg: "#f275be" attr: "b" }
     shape_binary: { fg: "#f275be" attr: "b" }

--- a/themes/themes/selenized-light.nu
+++ b/themes/themes/selenized-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#909995"
     block: "#909995"
     hints: "dark_gray"
+    search_result: { fg: "#d2212d" bg: "#909995" }
 
     shape_and: { fg: "#ca4898" attr: "b" }
     shape_binary: { fg: "#ca4898" attr: "b" }

--- a/themes/themes/selenized-white.nu
+++ b/themes/themes/selenized-white.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#878787"
     block: "#878787"
     hints: "dark_gray"
+    search_result: { fg: "#d6000c" bg: "#878787" }
 
     shape_and: { fg: "#dd0f9d" attr: "b" }
     shape_binary: { fg: "#dd0f9d" attr: "b" }

--- a/themes/themes/seoul256.nu
+++ b/themes/themes/seoul256.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#d68787" bg: "#d0d0d0" }
 
     shape_and: { fg: "#d7afaf" attr: "b" }
     shape_binary: { fg: "#d7afaf" attr: "b" }

--- a/themes/themes/seti-ui.nu
+++ b/themes/themes/seti-ui.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d6d6d6"
     block: "#d6d6d6"
     hints: "dark_gray"
+    search_result: { fg: "#Cd3f45" bg: "#d6d6d6" }
 
     shape_and: { fg: "#a074c4" attr: "b" }
     shape_binary: { fg: "#a074c4" attr: "b" }

--- a/themes/themes/seti.nu
+++ b/themes/themes/seti.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d6d6d6"
     block: "#d6d6d6"
     hints: "dark_gray"
+    search_result: { fg: "#cd3f45" bg: "#d6d6d6" }
 
     shape_and: { fg: "#a074c4" attr: "b" }
     shape_binary: { fg: "#a074c4" attr: "b" }

--- a/themes/themes/shaman.nu
+++ b/themes/themes/shaman.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#405555"
     block: "#405555"
     hints: "dark_gray"
+    search_result: { fg: "#b2302d" bg: "#405555" }
 
     shape_and: { fg: "#00599d" attr: "b" }
     shape_binary: { fg: "#00599d" attr: "b" }

--- a/themes/themes/shapeshifter.nu
+++ b/themes/themes/shapeshifter.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#102015"
     block: "#102015"
     hints: "dark_gray"
+    search_result: { fg: "#e92f2f" bg: "#102015" }
 
     shape_and: { fg: "#f996e2" attr: "b" }
     shape_binary: { fg: "#f996e2" attr: "b" }

--- a/themes/themes/shel.nu
+++ b/themes/themes/shel.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#918988"
     block: "#918988"
     hints: "dark_gray"
+    search_result: { fg: "#ab2463" bg: "#918988" }
 
     shape_and: { fg: "#6c24a2" attr: "b" }
     shape_binary: { fg: "#6c24a2" attr: "b" }

--- a/themes/themes/sierra.nu
+++ b/themes/themes/sierra.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bb7774"
     block: "#bb7774"
     hints: "dark_gray"
+    search_result: { fg: "#515a45" bg: "#bb7774" }
 
     shape_and: { fg: "#897c5b" attr: "b" }
     shape_binary: { fg: "#897c5b" attr: "b" }

--- a/themes/themes/silk-dark.nu
+++ b/themes/themes/silk-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c7dbdd"
     block: "#c7dbdd"
     hints: "dark_gray"
+    search_result: { fg: "#fb6953" bg: "#c7dbdd" }
 
     shape_and: { fg: "#756b8a" attr: "b" }
     shape_binary: { fg: "#756b8a" attr: "b" }

--- a/themes/themes/silk-light.nu
+++ b/themes/themes/silk-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#385156"
     block: "#385156"
     hints: "dark_gray"
+    search_result: { fg: "#cf432e" bg: "#385156" }
 
     shape_and: { fg: "#6e6582" attr: "b" }
     shape_binary: { fg: "#6e6582" attr: "b" }

--- a/themes/themes/slate.nu
+++ b/themes/themes/slate.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#02c5e0"
     block: "#02c5e0"
     hints: "dark_gray"
+    search_result: { fg: "#e2a8bf" bg: "#02c5e0" }
 
     shape_and: { fg: "#a481d3" attr: "b" }
     shape_binary: { fg: "#a481d3" attr: "b" }

--- a/themes/themes/smyck.nu
+++ b/themes/themes/smyck.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b0b0b0"
     block: "#b0b0b0"
     hints: "dark_gray"
+    search_result: { fg: "#c75646" bg: "#b0b0b0" }
 
     shape_and: { fg: "#c8a0d1" attr: "b" }
     shape_binary: { fg: "#c8a0d1" attr: "b" }

--- a/themes/themes/snazzy.nu
+++ b/themes/themes/snazzy.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e2e4e5"
     block: "#e2e4e5"
     hints: "dark_gray"
+    search_result: { fg: "#ff5c57" bg: "#e2e4e5" }
 
     shape_and: { fg: "#ff6ac1" attr: "b" }
     shape_binary: { fg: "#ff6ac1" attr: "b" }

--- a/themes/themes/snow-dark.nu
+++ b/themes/themes/snow-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#afb7c0"
     block: "#afb7c0"
     hints: "dark_gray"
+    search_result: { fg: "#be868c" bg: "#afb7c0" }
 
     shape_and: { fg: "#a88cb3" attr: "b" }
     shape_binary: { fg: "#a88cb3" attr: "b" }

--- a/themes/themes/snow-light.nu
+++ b/themes/themes/snow-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#535c65"
     block: "#535c65"
     hints: "dark_gray"
+    search_result: { fg: "#ae5865" bg: "#535c65" }
 
     shape_and: { fg: "#8f63a2" attr: "b" }
     shape_binary: { fg: "#8f63a2" attr: "b" }

--- a/themes/themes/soft-server.nu
+++ b/themes/themes/soft-server.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#99a3a2"
     block: "#99a3a2"
     hints: "dark_gray"
+    search_result: { fg: "#a2686a" bg: "#99a3a2" }
 
     shape_and: { fg: "#6a71a3" attr: "b" }
     shape_binary: { fg: "#6a71a3" attr: "b" }

--- a/themes/themes/solar-flare.nu
+++ b/themes/themes/solar-flare.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#A6AFB8"
     block: "#A6AFB8"
     hints: "dark_gray"
+    search_result: { fg: "#EF5253" bg: "#A6AFB8" }
 
     shape_and: { fg: "#A363D5" attr: "b" }
     shape_binary: { fg: "#A363D5" attr: "b" }

--- a/themes/themes/solarflare-light.nu
+++ b/themes/themes/solarflare-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#586875"
     block: "#586875"
     hints: "dark_gray"
+    search_result: { fg: "#ef5253" bg: "#586875" }
 
     shape_and: { fg: "#a363d5" attr: "b" }
     shape_binary: { fg: "#a363d5" attr: "b" }

--- a/themes/themes/solarflare.nu
+++ b/themes/themes/solarflare.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a6afb8"
     block: "#a6afb8"
     hints: "dark_gray"
+    search_result: { fg: "#ef5253" bg: "#a6afb8" }
 
     shape_and: { fg: "#a363d5" attr: "b" }
     shape_binary: { fg: "#a363d5" attr: "b" }

--- a/themes/themes/solarized-darcula.nu
+++ b/themes/themes/solarized-darcula.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d2d8d9"
     block: "#d2d8d9"
     hints: "dark_gray"
+    search_result: { fg: "#f24840" bg: "#d2d8d9" }
 
     shape_and: { fg: "#797fd4" attr: "b" }
     shape_binary: { fg: "#797fd4" attr: "b" }

--- a/themes/themes/solarized-dark-higher-contrast.nu
+++ b/themes/themes/solarized-dark-higher-contrast.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#eae3cb"
     block: "#eae3cb"
     hints: "dark_gray"
+    search_result: { fg: "#d11c24" bg: "#eae3cb" }
 
     shape_and: { fg: "#c61c6f" attr: "b" }
     shape_binary: { fg: "#c61c6f" attr: "b" }

--- a/themes/themes/solarized-dark.nu
+++ b/themes/themes/solarized-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#93a1a1"
     block: "#93a1a1"
     hints: "dark_gray"
+    search_result: { fg: "#dc322f" bg: "#93a1a1" }
 
     shape_and: { fg: "#6c71c4" attr: "b" }
     shape_binary: { fg: "#6c71c4" attr: "b" }

--- a/themes/themes/solarized-light.nu
+++ b/themes/themes/solarized-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#586e75"
     block: "#586e75"
     hints: "dark_gray"
+    search_result: { fg: "#dc322f" bg: "#586e75" }
 
     shape_and: { fg: "#6c71c4" attr: "b" }
     shape_binary: { fg: "#6c71c4" attr: "b" }

--- a/themes/themes/source-code-x.nu
+++ b/themes/themes/source-code-x.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bfbfbf"
     block: "#bfbfbf"
     hints: "dark_gray"
+    search_result: { fg: "#fb695d" bg: "#bfbfbf" }
 
     shape_and: { fg: "#fb5ea3" attr: "b" }
     shape_binary: { fg: "#fb5ea3" attr: "b" }

--- a/themes/themes/sourcerer.nu
+++ b/themes/themes/sourcerer.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d3d3d3"
     block: "#d3d3d3"
     hints: "dark_gray"
+    search_result: { fg: "#aa4450" bg: "#d3d3d3" }
 
     shape_and: { fg: "#8f6f8f" attr: "b" }
     shape_binary: { fg: "#8f6f8f" attr: "b" }

--- a/themes/themes/sourcerer2.nu
+++ b/themes/themes/sourcerer2.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d3d3d3"
     block: "#d3d3d3"
     hints: "dark_gray"
+    search_result: { fg: "#aa4450" bg: "#d3d3d3" }
 
     shape_and: { fg: "#8f6f8f" attr: "b" }
     shape_binary: { fg: "#8f6f8f" attr: "b" }

--- a/themes/themes/spaceduck.nu
+++ b/themes/themes/spaceduck.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#686f9a"
     block: "#686f9a"
     hints: "dark_gray"
+    search_result: { fg: "#e33400" bg: "#686f9a" }
 
     shape_and: { fg: "#f2ce00" attr: "b" }
     shape_binary: { fg: "#f2ce00" attr: "b" }

--- a/themes/themes/spacedust.nu
+++ b/themes/themes/spacedust.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f0f1ce"
     block: "#f0f1ce"
     hints: "dark_gray"
+    search_result: { fg: "#e35b00" bg: "#f0f1ce" }
 
     shape_and: { fg: "#e35b00" attr: "b" }
     shape_binary: { fg: "#e35b00" attr: "b" }

--- a/themes/themes/spacegray-eighties-dull.nu
+++ b/themes/themes/spacegray-eighties-dull.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b3b8c3"
     block: "#b3b8c3"
     hints: "dark_gray"
+    search_result: { fg: "#b24a56" bg: "#b3b8c3" }
 
     shape_and: { fg: "#a5789e" attr: "b" }
     shape_binary: { fg: "#a5789e" attr: "b" }

--- a/themes/themes/spacegray-eighties.nu
+++ b/themes/themes/spacegray-eighties.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#efece7"
     block: "#efece7"
     hints: "dark_gray"
+    search_result: { fg: "#ec5f67" bg: "#efece7" }
 
     shape_and: { fg: "#bf83c1" attr: "b" }
     shape_binary: { fg: "#bf83c1" attr: "b" }

--- a/themes/themes/spacegray.nu
+++ b/themes/themes/spacegray.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b3b8c3"
     block: "#b3b8c3"
     hints: "dark_gray"
+    search_result: { fg: "#b04b57" bg: "#b3b8c3" }
 
     shape_and: { fg: "#a47996" attr: "b" }
     shape_binary: { fg: "#a47996" attr: "b" }

--- a/themes/themes/spacemacs.nu
+++ b/themes/themes/spacemacs.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a3a3a3"
     block: "#a3a3a3"
     hints: "dark_gray"
+    search_result: { fg: "#f2241f" bg: "#a3a3a3" }
 
     shape_and: { fg: "#a31db1" attr: "b" }
     shape_binary: { fg: "#a31db1" attr: "b" }

--- a/themes/themes/spiderman.nu
+++ b/themes/themes/spiderman.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#fffef6"
     block: "#fffef6"
     hints: "dark_gray"
+    search_result: { fg: "#e60712" bg: "#fffef6" }
 
     shape_and: { fg: "#2435db" attr: "b" }
     shape_binary: { fg: "#2435db" attr: "b" }

--- a/themes/themes/spring.nu
+++ b/themes/themes/spring.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#ff4d83" bg: "#ffffff" }
 
     shape_and: { fg: "#8959a8" attr: "b" }
     shape_binary: { fg: "#8959a8" attr: "b" }

--- a/themes/themes/square.nu
+++ b/themes/themes/square.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f2f2f2"
     block: "#f2f2f2"
     hints: "dark_gray"
+    search_result: { fg: "#e9897c" bg: "#f2f2f2" }
 
     shape_and: { fg: "#75507b" attr: "b" }
     shape_binary: { fg: "#75507b" attr: "b" }

--- a/themes/themes/srcery.nu
+++ b/themes/themes/srcery.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#baa67f"
     block: "#baa67f"
     hints: "dark_gray"
+    search_result: { fg: "#ef2f27" bg: "#baa67f" }
 
     shape_and: { fg: "#e02c6d" attr: "b" }
     shape_binary: { fg: "#e02c6d" attr: "b" }

--- a/themes/themes/substrata.nu
+++ b/themes/themes/substrata.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b5b4c9"
     block: "#b5b4c9"
     hints: "dark_gray"
+    search_result: { fg: "#cf8164" bg: "#b5b4c9" }
 
     shape_and: { fg: "#a18daf" attr: "b" }
     shape_binary: { fg: "#a18daf" attr: "b" }

--- a/themes/themes/summercamp.nu
+++ b/themes/themes/summercamp.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#736e55"
     block: "#736e55"
     hints: "dark_gray"
+    search_result: { fg: "#e35142" bg: "#736e55" }
 
     shape_and: { fg: "#ff8080" attr: "b" }
     shape_binary: { fg: "#ff8080" attr: "b" }

--- a/themes/themes/summerfruit-dark.nu
+++ b/themes/themes/summerfruit-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#ff0086" bg: "#d0d0d0" }
 
     shape_and: { fg: "#ad00a1" attr: "b" }
     shape_binary: { fg: "#ad00a1" attr: "b" }

--- a/themes/themes/summerfruit-light.nu
+++ b/themes/themes/summerfruit-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#101010"
     block: "#101010"
     hints: "dark_gray"
+    search_result: { fg: "#ff0086" bg: "#101010" }
 
     shape_and: { fg: "#ad00a1" attr: "b" }
     shape_binary: { fg: "#ad00a1" attr: "b" }

--- a/themes/themes/sundried.nu
+++ b/themes/themes/sundried.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c9c9c9"
     block: "#c9c9c9"
     hints: "dark_gray"
+    search_result: { fg: "#a7463d" bg: "#c9c9c9" }
 
     shape_and: { fg: "#864651" attr: "b" }
     shape_binary: { fg: "#864651" attr: "b" }

--- a/themes/themes/symphonic.nu
+++ b/themes/themes/symphonic.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#dc322f" bg: "#ffffff" }
 
     shape_and: { fg: "#b729d9" attr: "b" }
     shape_binary: { fg: "#b729d9" attr: "b" }

--- a/themes/themes/synth-midnight-dark.nu
+++ b/themes/themes/synth-midnight-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c1c3c4"
     block: "#c1c3c4"
     hints: "dark_gray"
+    search_result: { fg: "#b53b50" bg: "#c1c3c4" }
 
     shape_and: { fg: "#ea5ce2" attr: "b" }
     shape_binary: { fg: "#ea5ce2" attr: "b" }

--- a/themes/themes/synth-midnight-light.nu
+++ b/themes/themes/synth-midnight-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#28292a"
     block: "#28292a"
     hints: "dark_gray"
+    search_result: { fg: "#b53b50" bg: "#28292a" }
 
     shape_and: { fg: "#ea5ce2" attr: "b" }
     shape_binary: { fg: "#ea5ce2" attr: "b" }

--- a/themes/themes/tango-dark.nu
+++ b/themes/themes/tango-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d3d7cf"
     block: "#d3d7cf"
     hints: "dark_gray"
+    search_result: { fg: "#cc0000" bg: "#d3d7cf" }
 
     shape_and: { fg: "#74507a" attr: "b" }
     shape_binary: { fg: "#74507a" attr: "b" }

--- a/themes/themes/tango-light.nu
+++ b/themes/themes/tango-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d3d7cf"
     block: "#d3d7cf"
     hints: "dark_gray"
+    search_result: { fg: "#cc0000" bg: "#d3d7cf" }
 
     shape_and: { fg: "#74507a" attr: "b" }
     shape_binary: { fg: "#74507a" attr: "b" }

--- a/themes/themes/tango.nu
+++ b/themes/themes/tango.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d3d7cf"
     block: "#d3d7cf"
     hints: "dark_gray"
+    search_result: { fg: "#cc0000" bg: "#d3d7cf" }
 
     shape_and: { fg: "#75507b" attr: "b" }
     shape_binary: { fg: "#75507b" attr: "b" }

--- a/themes/themes/teerb.nu
+++ b/themes/themes/teerb.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0d0d0"
     block: "#d0d0d0"
     hints: "dark_gray"
+    search_result: { fg: "#d68686" bg: "#d0d0d0" }
 
     shape_and: { fg: "#d6aed6" attr: "b" }
     shape_binary: { fg: "#d6aed6" attr: "b" }

--- a/themes/themes/tempus-autumn.nu
+++ b/themes/themes/tempus-autumn.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a5918a"
     block: "#a5918a"
     hints: "dark_gray"
+    search_result: { fg: "#f16c50" bg: "#a5918a" }
 
     shape_and: { fg: "#dd758e" attr: "b" }
     shape_binary: { fg: "#dd758e" attr: "b" }

--- a/themes/themes/tempus-classic.nu
+++ b/themes/themes/tempus-classic.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#949d9f"
     block: "#949d9f"
     hints: "dark_gray"
+    search_result: { fg: "#d2813d" bg: "#949d9f" }
 
     shape_and: { fg: "#b58d88" attr: "b" }
     shape_binary: { fg: "#b58d88" attr: "b" }

--- a/themes/themes/tempus-dawn.nu
+++ b/themes/themes/tempus-dawn.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#e2e4e1"
     block: "#e2e4e1"
     hints: "dark_gray"
+    search_result: { fg: "#a32a3a" bg: "#e2e4e1" }
 
     shape_and: { fg: "#8d377e" attr: "b" }
     shape_binary: { fg: "#8d377e" attr: "b" }

--- a/themes/themes/tempus-day.nu
+++ b/themes/themes/tempus-day.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#eae9dd"
     block: "#eae9dd"
     hints: "dark_gray"
+    search_result: { fg: "#c81000" bg: "#eae9dd" }
 
     shape_and: { fg: "#b63052" attr: "b" }
     shape_binary: { fg: "#b63052" attr: "b" }

--- a/themes/themes/tempus-dusk.nu
+++ b/themes/themes/tempus-dusk.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a29899"
     block: "#a29899"
     hints: "dark_gray"
+    search_result: { fg: "#cb8d56" bg: "#a29899" }
 
     shape_and: { fg: "#b190af" attr: "b" }
     shape_binary: { fg: "#b190af" attr: "b" }

--- a/themes/themes/tempus-fugit.nu
+++ b/themes/themes/tempus-fugit.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f2ebe9"
     block: "#f2ebe9"
     hints: "dark_gray"
+    search_result: { fg: "#c61a14" bg: "#f2ebe9" }
 
     shape_and: { fg: "#a83884" attr: "b" }
     shape_binary: { fg: "#a83884" attr: "b" }

--- a/themes/themes/tempus-future.nu
+++ b/themes/themes/tempus-future.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a59ebd"
     block: "#a59ebd"
     hints: "dark_gray"
+    search_result: { fg: "#ff778a" bg: "#a59ebd" }
 
     shape_and: { fg: "#e58a82" attr: "b" }
     shape_binary: { fg: "#e58a82" attr: "b" }

--- a/themes/themes/tempus-night.nu
+++ b/themes/themes/tempus-night.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c4bdaf"
     block: "#c4bdaf"
     hints: "dark_gray"
+    search_result: { fg: "#fb7e8e" bg: "#c4bdaf" }
 
     shape_and: { fg: "#ee80c0" attr: "b" }
     shape_binary: { fg: "#ee80c0" attr: "b" }

--- a/themes/themes/tempus-past.nu
+++ b/themes/themes/tempus-past.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ece6de"
     block: "#ece6de"
     hints: "dark_gray"
+    search_result: { fg: "#c00c50" bg: "#ece6de" }
 
     shape_and: { fg: "#b02874" attr: "b" }
     shape_binary: { fg: "#b02874" attr: "b" }

--- a/themes/themes/tempus-rift.nu
+++ b/themes/themes/tempus-rift.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ab9aa9"
     block: "#ab9aa9"
     hints: "dark_gray"
+    search_result: { fg: "#c19904" bg: "#ab9aa9" }
 
     shape_and: { fg: "#c8954c" attr: "b" }
     shape_binary: { fg: "#c8954c" attr: "b" }

--- a/themes/themes/tempus-spring.nu
+++ b/themes/themes/tempus-spring.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#96aca7"
     block: "#96aca7"
     hints: "dark_gray"
+    search_result: { fg: "#ff855a" bg: "#96aca7" }
 
     shape_and: { fg: "#e69092" attr: "b" }
     shape_binary: { fg: "#e69092" attr: "b" }

--- a/themes/themes/tempus-summer.nu
+++ b/themes/themes/tempus-summer.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#919ab9"
     block: "#919ab9"
     hints: "dark_gray"
+    search_result: { fg: "#f76f6e" bg: "#919ab9" }
 
     shape_and: { fg: "#cc84ad" attr: "b" }
     shape_binary: { fg: "#cc84ad" attr: "b" }

--- a/themes/themes/tempus-tempest.nu
+++ b/themes/themes/tempus-tempest.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#b0c8ca"
     block: "#b0c8ca"
     hints: "dark_gray"
+    search_result: { fg: "#c6c80a" bg: "#b0c8ca" }
 
     shape_and: { fg: "#c0c4aa" attr: "b" }
     shape_binary: { fg: "#c0c4aa" attr: "b" }

--- a/themes/themes/tempus-totus.nu
+++ b/themes/themes/tempus-totus.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f3f1f3"
     block: "#f3f1f3"
     hints: "dark_gray"
+    search_result: { fg: "#a80000" bg: "#f3f1f3" }
 
     shape_and: { fg: "#882a7a" attr: "b" }
     shape_binary: { fg: "#882a7a" attr: "b" }

--- a/themes/themes/tempus-warp.nu
+++ b/themes/themes/tempus-warp.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#928080"
     block: "#928080"
     hints: "dark_gray"
+    search_result: { fg: "#fa3333" bg: "#928080" }
 
     shape_and: { fg: "#d54cbf" attr: "b" }
     shape_binary: { fg: "#d54cbf" attr: "b" }

--- a/themes/themes/tempus-winter.nu
+++ b/themes/themes/tempus-winter.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#909294"
     block: "#909294"
     hints: "dark_gray"
+    search_result: { fg: "#eb6a58" bg: "#909294" }
 
     shape_and: { fg: "#cd7b7e" attr: "b" }
     shape_binary: { fg: "#cd7b7e" attr: "b" }

--- a/themes/themes/tender.nu
+++ b/themes/themes/tender.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#eeeeee"
     block: "#eeeeee"
     hints: "dark_gray"
+    search_result: { fg: "#f43753" bg: "#eeeeee" }
 
     shape_and: { fg: "#d3b987" attr: "b" }
     shape_binary: { fg: "#d3b987" attr: "b" }

--- a/themes/themes/terminal-basic.nu
+++ b/themes/themes/terminal-basic.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bfbfbf"
     block: "#bfbfbf"
     hints: "dark_gray"
+    search_result: { fg: "#990000" bg: "#bfbfbf" }
 
     shape_and: { fg: "#b200b2" attr: "b" }
     shape_binary: { fg: "#b200b2" attr: "b" }

--- a/themes/themes/terminix-dark.nu
+++ b/themes/themes/terminix-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#777777"
     block: "#777777"
     hints: "dark_gray"
+    search_result: { fg: "#a54242" bg: "#777777" }
 
     shape_and: { fg: "#85678f" attr: "b" }
     shape_binary: { fg: "#85678f" attr: "b" }

--- a/themes/themes/thayer-bright.nu
+++ b/themes/themes/thayer-bright.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ccccc6"
     block: "#ccccc6"
     hints: "dark_gray"
+    search_result: { fg: "#f92672" bg: "#ccccc6" }
 
     shape_and: { fg: "#8c54fe" attr: "b" }
     shape_binary: { fg: "#8c54fe" attr: "b" }

--- a/themes/themes/the-hulk.nu
+++ b/themes/themes/the-hulk.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d8d8d0"
     block: "#d8d8d0"
     hints: "dark_gray"
+    search_result: { fg: "#259d1a" bg: "#d8d8d0" }
 
     shape_and: { fg: "#641e73" attr: "b" }
     shape_binary: { fg: "#641e73" attr: "b" }

--- a/themes/themes/tin.nu
+++ b/themes/themes/tin.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#ffffff"
     block: "#ffffff"
     hints: "dark_gray"
+    search_result: { fg: "#8d534e" bg: "#ffffff" }
 
     shape_and: { fg: "#8d4e88" attr: "b" }
     shape_binary: { fg: "#8d4e88" attr: "b" }

--- a/themes/themes/tokyo-day.nu
+++ b/themes/themes/tokyo-day.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#6172b0"
     block: "#6172b0"
     hints: "dark_gray"
+    search_result: { fg: "#f52a65" bg: "#6172b0" }
 
     shape_and: { fg: "#9854f1" attr: "b" }
     shape_binary: { fg: "#9854f1" attr: "b" }

--- a/themes/themes/tokyo-night.nu
+++ b/themes/themes/tokyo-night.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a9b1d6"
     block: "#a9b1d6"
     hints: "dark_gray"
+    search_result: { fg: "#f7768e" bg: "#a9b1d6" }
 
     shape_and: { fg: "#bb9af7" attr: "b" }
     shape_binary: { fg: "#bb9af7" attr: "b" }

--- a/themes/themes/tokyo-storm.nu
+++ b/themes/themes/tokyo-storm.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a9b1d6"
     block: "#a9b1d6"
     hints: "dark_gray"
+    search_result: { fg: "#f7768e" bg: "#a9b1d6" }
 
     shape_and: { fg: "#bb9af7" attr: "b" }
     shape_binary: { fg: "#bb9af7" attr: "b" }

--- a/themes/themes/tomorrow-night-blue.nu
+++ b/themes/themes/tomorrow-night-blue.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#fffefe"
     block: "#fffefe"
     hints: "dark_gray"
+    search_result: { fg: "#ff9da3" bg: "#fffefe" }
 
     shape_and: { fg: "#ebbbff" attr: "b" }
     shape_binary: { fg: "#ebbbff" attr: "b" }

--- a/themes/themes/tomorrow-night-bright.nu
+++ b/themes/themes/tomorrow-night-bright.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#fffefe"
     block: "#fffefe"
     hints: "dark_gray"
+    search_result: { fg: "#d54e53" bg: "#fffefe" }
 
     shape_and: { fg: "#c397d8" attr: "b" }
     shape_binary: { fg: "#c397d8" attr: "b" }

--- a/themes/themes/tomorrow-night-eighties.nu
+++ b/themes/themes/tomorrow-night-eighties.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cccccc"
     block: "#cccccc"
     hints: "dark_gray"
+    search_result: { fg: "#f2777a" bg: "#cccccc" }
 
     shape_and: { fg: "#cc99cc" attr: "b" }
     shape_binary: { fg: "#cc99cc" attr: "b" }

--- a/themes/themes/tomorrow-night.nu
+++ b/themes/themes/tomorrow-night.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c5c8c6"
     block: "#c5c8c6"
     hints: "dark_gray"
+    search_result: { fg: "#cc6666" bg: "#c5c8c6" }
 
     shape_and: { fg: "#b294bb" attr: "b" }
     shape_binary: { fg: "#b294bb" attr: "b" }

--- a/themes/themes/tomorrow.nu
+++ b/themes/themes/tomorrow.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#4d4d4c"
     block: "#4d4d4c"
     hints: "dark_gray"
+    search_result: { fg: "#c82829" bg: "#4d4d4c" }
 
     shape_and: { fg: "#8959a8" attr: "b" }
     shape_binary: { fg: "#8959a8" attr: "b" }

--- a/themes/themes/toy-chest.nu
+++ b/themes/themes/toy-chest.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#23d183"
     block: "#23d183"
     hints: "dark_gray"
+    search_result: { fg: "#be2d26" bg: "#23d183" }
 
     shape_and: { fg: "#8a5edc" attr: "b" }
     shape_binary: { fg: "#8a5edc" attr: "b" }

--- a/themes/themes/treehouse.nu
+++ b/themes/themes/treehouse.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#786b53"
     block: "#786b53"
     hints: "dark_gray"
+    search_result: { fg: "#b2270e" bg: "#786b53" }
 
     shape_and: { fg: "#97363d" attr: "b" }
     shape_binary: { fg: "#97363d" attr: "b" }

--- a/themes/themes/tube.nu
+++ b/themes/themes/tube.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d9d8d8"
     block: "#d9d8d8"
     hints: "dark_gray"
+    search_result: { fg: "#ee2e24" bg: "#d9d8d8" }
 
     shape_and: { fg: "#98005d" attr: "b" }
     shape_binary: { fg: "#98005d" attr: "b" }

--- a/themes/themes/twilight.nu
+++ b/themes/themes/twilight.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a7a7a7"
     block: "#a7a7a7"
     hints: "dark_gray"
+    search_result: { fg: "#cf6a4c" bg: "#a7a7a7" }
 
     shape_and: { fg: "#9b859d" attr: "b" }
     shape_binary: { fg: "#9b859d" attr: "b" }

--- a/themes/themes/two-firewatch.nu
+++ b/themes/themes/two-firewatch.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dcdfe4"
     block: "#dcdfe4"
     hints: "dark_gray"
+    search_result: { fg: "#e06c75" bg: "#dcdfe4" }
 
     shape_and: { fg: "#c678dd" attr: "b" }
     shape_binary: { fg: "#c678dd" attr: "b" }

--- a/themes/themes/unikitty-dark.nu
+++ b/themes/themes/unikitty-dark.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#bcbabe"
     block: "#bcbabe"
     hints: "dark_gray"
+    search_result: { fg: "#d8137f" bg: "#bcbabe" }
 
     shape_and: { fg: "#bb60ea" attr: "b" }
     shape_binary: { fg: "#bb60ea" attr: "b" }

--- a/themes/themes/unikitty-light.nu
+++ b/themes/themes/unikitty-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#6c696e"
     block: "#6c696e"
     hints: "dark_gray"
+    search_result: { fg: "#d8137f" bg: "#6c696e" }
 
     shape_and: { fg: "#aa17e6" attr: "b" }
     shape_binary: { fg: "#aa17e6" attr: "b" }

--- a/themes/themes/ura.nu
+++ b/themes/themes/ura.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#808080"
     block: "#808080"
     hints: "dark_gray"
+    search_result: { fg: "#c21b6f" bg: "#808080" }
 
     shape_and: { fg: "#6f1bc2" attr: "b" }
     shape_binary: { fg: "#6f1bc2" attr: "b" }

--- a/themes/themes/urple.nu
+++ b/themes/themes/urple.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#87799c"
     block: "#87799c"
     hints: "dark_gray"
+    search_result: { fg: "#b0425b" bg: "#87799c" }
 
     shape_and: { fg: "#6c3ca1" attr: "b" }
     shape_binary: { fg: "#6c3ca1" attr: "b" }

--- a/themes/themes/vag.nu
+++ b/themes/themes/vag.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#8a8a8a"
     block: "#8a8a8a"
     hints: "dark_gray"
+    search_result: { fg: "#a87139" bg: "#8a8a8a" }
 
     shape_and: { fg: "#a83971" attr: "b" }
     shape_binary: { fg: "#a83971" attr: "b" }

--- a/themes/themes/vaughn.nu
+++ b/themes/themes/vaughn.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#709080"
     block: "#709080"
     hints: "dark_gray"
+    search_result: { fg: "#705050" bg: "#709080" }
 
     shape_and: { fg: "#f08cc3" attr: "b" }
     shape_binary: { fg: "#f08cc3" attr: "b" }

--- a/themes/themes/vibrant-ink.nu
+++ b/themes/themes/vibrant-ink.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#f5f5f5"
     block: "#f5f5f5"
     hints: "dark_gray"
+    search_result: { fg: "#ff6600" bg: "#f5f5f5" }
 
     shape_and: { fg: "#9933cc" attr: "b" }
     shape_binary: { fg: "#9933cc" attr: "b" }

--- a/themes/themes/vs-code-dark-plus.nu
+++ b/themes/themes/vs-code-dark-plus.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c3dde1"
     block: "#c3dde1"
     hints: "dark_gray"
+    search_result: { fg: "#e9653b" bg: "#c3dde1" }
 
     shape_and: { fg: "#e17599" attr: "b" }
     shape_binary: { fg: "#e17599" attr: "b" }

--- a/themes/themes/vulcan.nu
+++ b/themes/themes/vulcan.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#5b778c"
     block: "#5b778c"
     hints: "dark_gray"
+    search_result: { fg: "#818591" bg: "#5b778c" }
 
     shape_and: { fg: "#9198a3" attr: "b" }
     shape_binary: { fg: "#9198a3" attr: "b" }

--- a/themes/themes/warm-neon.nu
+++ b/themes/themes/warm-neon.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#d0b8a3"
     block: "#d0b8a3"
     hints: "dark_gray"
+    search_result: { fg: "#e24346" bg: "#d0b8a3" }
 
     shape_and: { fg: "#f920fb" attr: "b" }
     shape_binary: { fg: "#f920fb" attr: "b" }

--- a/themes/themes/wez.nu
+++ b/themes/themes/wez.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cccccc"
     block: "#cccccc"
     hints: "dark_gray"
+    search_result: { fg: "#cc5555" bg: "#cccccc" }
 
     shape_and: { fg: "#cc55cc" attr: "b" }
     shape_binary: { fg: "#cc55cc" attr: "b" }

--- a/themes/themes/wild-cherry.nu
+++ b/themes/themes/wild-cherry.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#fff8de"
     block: "#fff8de"
     hints: "dark_gray"
+    search_result: { fg: "#d94085" bg: "#fff8de" }
 
     shape_and: { fg: "#ececec" attr: "b" }
     shape_binary: { fg: "#ececec" attr: "b" }

--- a/themes/themes/windows-10-light.nu
+++ b/themes/themes/windows-10-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#767676"
     block: "#767676"
     hints: "dark_gray"
+    search_result: { fg: "#c50f1f" bg: "#767676" }
 
     shape_and: { fg: "#881798" attr: "b" }
     shape_binary: { fg: "#881798" attr: "b" }

--- a/themes/themes/windows-10.nu
+++ b/themes/themes/windows-10.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cccccc"
     block: "#cccccc"
     hints: "dark_gray"
+    search_result: { fg: "#e74856" bg: "#cccccc" }
 
     shape_and: { fg: "#b4009e" attr: "b" }
     shape_binary: { fg: "#b4009e" attr: "b" }

--- a/themes/themes/windows-95-light.nu
+++ b/themes/themes/windows-95-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#545454"
     block: "#545454"
     hints: "dark_gray"
+    search_result: { fg: "#a80000" bg: "#545454" }
 
     shape_and: { fg: "#a800a8" attr: "b" }
     shape_binary: { fg: "#a800a8" attr: "b" }

--- a/themes/themes/windows-95.nu
+++ b/themes/themes/windows-95.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a8a8a8"
     block: "#a8a8a8"
     hints: "dark_gray"
+    search_result: { fg: "#fc5454" bg: "#a8a8a8" }
 
     shape_and: { fg: "#fc54fc" attr: "b" }
     shape_binary: { fg: "#fc54fc" attr: "b" }

--- a/themes/themes/windows-highcontrast-light.nu
+++ b/themes/themes/windows-highcontrast-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#545454"
     block: "#545454"
     hints: "dark_gray"
+    search_result: { fg: "#800000" bg: "#545454" }
 
     shape_and: { fg: "#800080" attr: "b" }
     shape_binary: { fg: "#800080" attr: "b" }

--- a/themes/themes/windows-highcontrast.nu
+++ b/themes/themes/windows-highcontrast.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c0c0c0"
     block: "#c0c0c0"
     hints: "dark_gray"
+    search_result: { fg: "#fc5454" bg: "#c0c0c0" }
 
     shape_and: { fg: "#fc54fc" attr: "b" }
     shape_binary: { fg: "#fc54fc" attr: "b" }

--- a/themes/themes/windows-nt-light.nu
+++ b/themes/themes/windows-nt-light.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#808080"
     block: "#808080"
     hints: "dark_gray"
+    search_result: { fg: "#800000" bg: "#808080" }
 
     shape_and: { fg: "#800080" attr: "b" }
     shape_binary: { fg: "#800080" attr: "b" }

--- a/themes/themes/windows-nt.nu
+++ b/themes/themes/windows-nt.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#c0c0c0"
     block: "#c0c0c0"
     hints: "dark_gray"
+    search_result: { fg: "#ff0000" bg: "#c0c0c0" }
 
     shape_and: { fg: "#ff00ff" attr: "b" }
     shape_binary: { fg: "#ff00ff" attr: "b" }

--- a/themes/themes/wombat.nu
+++ b/themes/themes/wombat.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dedacf"
     block: "#dedacf"
     hints: "dark_gray"
+    search_result: { fg: "#ff615a" bg: "#dedacf" }
 
     shape_and: { fg: "#e86aff" attr: "b" }
     shape_binary: { fg: "#e86aff" attr: "b" }

--- a/themes/themes/woodland.nu
+++ b/themes/themes/woodland.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#cabcb1"
     block: "#cabcb1"
     hints: "dark_gray"
+    search_result: { fg: "#d35c5c" bg: "#cabcb1" }
 
     shape_and: { fg: "#bb90e2" attr: "b" }
     shape_binary: { fg: "#bb90e2" attr: "b" }

--- a/themes/themes/wryan.nu
+++ b/themes/themes/wryan.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#899ca1"
     block: "#899ca1"
     hints: "dark_gray"
+    search_result: { fg: "#8c4665" bg: "#899ca1" }
 
     shape_and: { fg: "#5e468c" attr: "b" }
     shape_binary: { fg: "#5e468c" attr: "b" }

--- a/themes/themes/xcode-dusk.nu
+++ b/themes/themes/xcode-dusk.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#939599"
     block: "#939599"
     hints: "dark_gray"
+    search_result: { fg: "#b21889" bg: "#939599" }
 
     shape_and: { fg: "#b21889" attr: "b" }
     shape_binary: { fg: "#b21889" attr: "b" }

--- a/themes/themes/yachiyo.nu
+++ b/themes/themes/yachiyo.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#a0be99"
     block: "#a0be99"
     hints: "dark_gray"
+    search_result: { fg: "#86b79b" bg: "#a0be99" }
 
     shape_and: { fg: "#9298e7" attr: "b" }
     shape_binary: { fg: "#9298e7" attr: "b" }

--- a/themes/themes/zenburn.nu
+++ b/themes/themes/zenburn.nu
@@ -41,6 +41,7 @@ export def main [] { return {
     list: "#dcdccc"
     block: "#dcdccc"
     hints: "dark_gray"
+    search_result: { fg: "#dca3a3" bg: "#dcdccc" }
 
     shape_and: { fg: "#dc8cc3" attr: "b" }
     shape_binary: { fg: "#dc8cc3" attr: "b" }


### PR DESCRIPTION
related to
- https://github.com/nushell/nu_scripts/pull/519
- https://github.com/nushell/nushell/pull/9326

in this PR, i've
- added the `search_result` key introduced in https://github.com/nushell/nushell/pull/9326 to the `nushell-*` themes manually and to the `make.nu` template
- regenerated all the themes
- added the `background`, `foreground` and `cursor` to the `nushell-*` themes manually to make  https://github.com/nushell/nu_scripts/pull/519 work with all the themes

> **Note**
> files of interest
> - `themes/make.nu`
> - `themes/themes/nushell-dark.nu`
> - `themes/themes/nushell-light.nu`
>
> all the others files have been modified automatically with a call to `./themes/make.nu` in dda5dc2