### PR TITLE
add a "command not found" hook

### DIFF
--- a/hooks/command_not_found/README.md
+++ b/hooks/command_not_found/README.md
@@ -1,0 +1,2 @@
+some `config.hooks.command_not_found` hooks:
+- `did_you_mean.nu`: gives a list of 3 external commands that are close to the "not found" one

--- a/hooks/command_not_found/did_you_mean.nu
+++ b/hooks/command_not_found/did_you_mean.nu
@@ -1,0 +1,48 @@
+# example:
+# ```nu
+# > got
+# Error: nu::shell::external_command
+#
+#   × External command failed
+#    ╭─[entry #1:1:1]
+#  1 │ got
+#    · ─┬─
+#    ·  ╰── did you mean 'get'?
+#    ╰────
+#   help: No such file or directory (os error 2)
+#
+#         did you mean?
+#             dot
+#             git
+#             go
+# ```
+{|cmd|
+    let commands_in_path = (
+        $env.PATH | each {|directory|
+            if ($directory | path exists) {
+                ls $directory | get name | path parse | update parent "" | path join
+            }
+        }
+        | flatten
+        | wrap cmd
+    )
+
+    let closest_commands = (
+        $commands_in_path
+        | insert distance {|it|
+            $it.cmd | str distance $cmd
+        }
+        | uniq
+        | sort-by distance
+        | get cmd
+        | first 3
+    )
+
+    let pretty_commands = (
+        $closest_commands | each {|cmd|
+            $"    (ansi {fg: "default" attr: "di"})($cmd)(ansi reset)"
+        }
+    )
+
+    $"\ndid you mean?\n($pretty_commands | str join "\n")"
+}


### PR DESCRIPTION
this is a little "did you mean" `command_not_found` hook i wanted to share before removing it from my config :relieved: 