### PR TITLE
parse name of positional args in `parse cmd`

### DIFF
--- a/modules/git/git-v2.nu
+++ b/modules/git/git-v2.nu
@@ -496,7 +496,9 @@ export alias gts = git tag -s
 
 export def _git_status [] {
     # TODO: show-stash
-    let raw_status = (do -i { git --no-optional-locks status --porcelain=2 --branch --show-stash | lines })
+    let raw_status = (do -i { git --no-optional-locks status --porcelain=2 --branch | lines })
+
+    let stashes = (git stash list | lines | length)
 
     mut status = {
         idx_added_staged    : 0
@@ -513,7 +515,7 @@ export def _git_status [] {
         conflicts           : 0
         ahead               : 0
         behind              : 0
-        stashes             : 0
+        stashes             : $stashes
         repo_name           : no_repository
         tag                 : no_tag
         branch              : no_branch

--- a/modules/git/git-v2.nu
+++ b/modules/git/git-v2.nu
@@ -498,7 +498,7 @@ export def _git_status [] {
     # TODO: show-stash
     let raw_status = (do -i { git --no-optional-locks status --porcelain=2 --branch | lines })
 
-    let stashes = (git stash list | lines | length)
+    let stashes = (do -i { git stash list | lines | length })
 
     mut status = {
         idx_added_staged    : 0

--- a/modules/git/git-v2.nu
+++ b/modules/git/git-v2.nu
@@ -36,6 +36,7 @@ def get-sign [cmd] {
     let x = ($nu.scope.commands | where name == $cmd).signatures?.0?.any?
     mut s = []
     mut n = {}
+    mut p = []
     for it in $x {
         if $it.parameter_type in ['switch' 'named'] {
             let name = $it.parameter_name
@@ -48,9 +49,11 @@ def get-sign [cmd] {
                     $s = ($s | append $it.short_flag)
                 }
             }
+        } else if $it.parameter_type == 'positional' {
+            $p = ($p | append $it.parameter_name)
         }
     }
-    { switch: $s, name: $n }
+    { switch: $s, name: $n, positional: $p }
 }
 
 def "parse cmd" [] {
@@ -85,7 +88,8 @@ def "parse cmd" [] {
             $sw = ''
         }
     }
-    $opt.args = $pos
+    $opt._args = $pos
+    $opt._pos = ( $pos | range 1.. | enumerate | reduce -f {} {|it, acc| $acc | upsert ($sign.positional | get $it.index) $it.item } )
     $opt
 }
 
@@ -158,8 +162,8 @@ export def gb [
         }
         if $branch in (remote_braches | each {|x| $x.1}) and (agree -n 'delete remote branch?!') {
             let remote = if ($remote|is-empty) { 'origin' } else { $remote }
-            git push $remote -d $branch
             git branch -D -r $'($remote)/($branch)'
+            git push $remote -d $branch
         }
     } else if $branch in $bs {
         git checkout $branch
@@ -491,7 +495,8 @@ export alias gswc = git switch -c
 export alias gts = git tag -s
 
 export def _git_status [] {
-    let raw_status = (do -i { git --no-optional-locks status --porcelain=2 --branch | lines })
+    # TODO: show-stash
+    let raw_status = (do -i { git --no-optional-locks status --porcelain=2 --branch --show-stash | lines })
 
     mut status = {
         idx_added_staged    : 0
@@ -659,7 +664,7 @@ export def remote_braches [] {
 def "nu-complete git remote branches" [context: string, offset: int] {
     let ctx = ($context | parse cmd)
     let rb = (remote_braches)
-    if ($ctx.args | length) < 3 {
+    if ($ctx._args | length) < 3 {
         $rb | each {|x| {value: $x.1, description: $x.0} }
     } else {
         $rb | filter {|x| $x.1 == $ctx.1 } | each {|x| $x.0}

--- a/modules/prompt/powerline/power_git.nu
+++ b/modules/prompt/powerline/power_git.nu
@@ -1,6 +1,9 @@
 ### git
-export def git_status [] {
+def _git_status [] {
+    # TODO: show-stash
     let raw_status = (do -i { git --no-optional-locks status --porcelain=2 --branch | lines })
+
+    let stashes = (git stash list | lines | length)
 
     mut status = {
         idx_added_staged    : 0
@@ -17,7 +20,7 @@ export def git_status [] {
         conflicts           : 0
         ahead               : 0
         behind              : 0
-        stashes             : 0
+        stashes             : $stashes
         repo_name           : no_repository
         tag                 : no_tag
         branch              : no_branch
@@ -91,18 +94,9 @@ export def git_status [] {
     $status
 }
 
-export def _git_status [] {
-    let status = (do -i { gstat })
-    if not ($status | is-empty) {
-        $status
-    } else {
-        git_status_raw
-    }
-}
-
 export def git_stat [] {
     {|bg|
-        let status = (git_status)
+        let status = (_git_status)
 
         if $status.branch == 'no_branch' { return [$bg ''] }
 
@@ -134,7 +128,6 @@ export-env {
         [
             [behind              (char branch_behind) yellow]
             [ahead               (char branch_ahead) yellow]
-            [stashes             = blue]
             [conflicts           ! red]
             [ignored             _ purple]
             [idx_added_staged    + green]
@@ -147,6 +140,7 @@ export-env {
             [wt_deleted          - red]
             [wt_renamed          % red]
             [wt_type_changed     * red]
+            [stashes             = blue]
         ]
     )
 

--- a/modules/prompt/powerline/power_git.nu
+++ b/modules/prompt/powerline/power_git.nu
@@ -3,7 +3,7 @@ def _git_status [] {
     # TODO: show-stash
     let raw_status = (do -i { git --no-optional-locks status --porcelain=2 --branch | lines })
 
-    let stashes = (git stash list | lines | length)
+    let stashes = (do -i { git stash list | lines | length })
 
     mut status = {
         idx_added_staged    : 0


### PR DESCRIPTION
- Parse positional arguments, additionally with the names of the formal parameters. Because parameters with the same name have different positions in different functions
- In the parsed results, the two special fields args and pos start with an underscore
- Add completion for 'helm charts'
- Fix the problem that git stashes cannot be parsed correctly