### PR TITLE
Replace deprecated `fetch` with `http get`

### DIFF
--- a/sourced/cool-oneliners/dict.nu
+++ b/sourced/cool-oneliners/dict.nu
@@ -3,7 +3,7 @@ def dict [...word #word(s) to query the dictionary API but they have to make sen
 ] {
 	let query = ($word | str join %20)
   let link = ('https://api.dictionaryapi.dev/api/v2/entries/en/' + ($query|str replace ' ' '%20'))
-  let output = (fetch $link | rename word)
+  let output = (http get $link | rename word)
   let w = ($output.word | first)
 
   if $w == "No Definitions Found" {

--- a/sourced/gitlab/gitlab.nu
+++ b/sourced/gitlab/gitlab.nu
@@ -7,7 +7,7 @@ def call-gitlab [
   ...args: string
   --query: string
 ] {
-  fetch -H [Authorization $"Bearer ($env.GITLAB_TOKEN)"] $"($projects)($args|str join)?($query)"
+  http get -H [Authorization $"Bearer ($env.GITLAB_TOKEN)"] $"($projects)($args|str join)?($query)"
 }
 # Search files on your GitLab server
 def main [

--- a/sourced/misc/nu_defs.nu
+++ b/sourced/misc/nu_defs.nu
@@ -310,7 +310,7 @@ def mbitly [longurl] {
     let username = "user"
     let url = $"https://api-ssl.bitly.com/v3/shorten?access_token=($Accesstoken)&login=($username)&longUrl=($longurl)"
 
-    let shorturl = (fetch $url | get data | get url)
+    let shorturl = (http get $url | get data | get url)
 
     $shorturl
     $shorturl | xclip -sel clip
@@ -345,7 +345,7 @@ def trans [
 
     let url = $"https://api.mymemory.translated.net/get?q=($to_translate)&langpair=($from)%7C($to)&of=json&key=($key)&de=($user)"
 
-    fetch $url | get responseData | get translatedText
+    http get $url | get responseData | get translatedText
   }
 }
 

--- a/sourced/update_hosts.nu
+++ b/sourced/update_hosts.nu
@@ -26,7 +26,7 @@ module hosts {
         let whitelisted = "(" + ($WHITELIST | str join "|") + ")"
         let pattern = ($"0.0.0.0.*($whitelisted).*$")
         let OLD_FILE = "/etc/hosts"
-        let TMP_FILE = (fetch $LINK | lines)
+        let TMP_FILE = (http get $LINK | lines)
 
         if ($env.LAST_EXIT_CODE == 0) {
             let OLD_HEAD = (open $OLD_FILE --raw | lines | first 8 | last 3)

--- a/sourced/webscraping/shell_stars.nu
+++ b/sourced/webscraping/shell_stars.nu
@@ -35,7 +35,7 @@ $shell_list | each { |r|
         print ""
     } else {
         let url = $"https://api.github.com/repos/($r.repo)"
-        let count = (fetch -u $env.GITHUB_USERNAME -p $env.GITHUB_PASSWORD ($url) | get stargazers_count)
+        let count = (http get -u $env.GITHUB_USERNAME -p $env.GITHUB_PASSWORD ($url) | get stargazers_count)
         print $" ($count)"
         [[shell repo stars]; [($r.name) ($r.repo) ($count)]]
     }


### PR DESCRIPTION
When I was learning nushell from this repository,  scripts that used `fetch` didn't run with the following errors.

```console
❯ nu --version
0.81.0

❯ fetch "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/gambling-porn/hosts" | lines
Error: nu::shell::deprecated_command

  × Deprecated command fetch
   ╭─[entry #26:1:1]
 1 │ fetch "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/gambling-porn/hosts" | lines
   · ──┬──
   ·   ╰── 'fetch' is deprecated. Please use 'http get' instead.
   ╰────
```

Looks related to https://github.com/nushell/nushell/pull/7796.
So I replaced the `fetch` command with `http get` except for `before_v0.60/*` files in this PR.