### PR TITLE
Replace deprecated `hash base64` with `decode`

### DIFF
--- a/sourced/gitlab/gitlab.nu
+++ b/sourced/gitlab/gitlab.nu
@@ -27,7 +27,7 @@ def main [
     if ($payload|columns|find message|is-empty) {
       $payload
       |get content
-      |hash base64 --decode
+      |decode base64
       |lines
       |find $phrase
       |if ($in|length) > 0 {


### PR DESCRIPTION
Same motivation as #530

```console
❯ nu --version
0.81.0

❯ echo 'Zm9vYmFy' | hash base64 --decode
Error: nu::parser::unknown_flag

  × The `hash base64` command doesn't have flag `decode`.
   ╭─[entry #56:1:1]
 1 │ echo 'Zm9vYmFy' | hash base64 --decode
   ·                               ────┬───
   ·                                   ╰── unknown flag
   ╰────
  help: Available flags: --help(-h). Use `--help` for more information.
```

Looks related to https://github.com/nushell/nushell/issues/5861