### PR TITLE
added Brace exspansion module

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -62,6 +62,29 @@ An extensive example of a wrapper for docker operations, with nushell completion
 ## filesystem
 
 - [bm](./filesystem/bm.nu) - A Simple bookmarking module. It uses `XGD_DATA_HOME` to save bookmarks.
+- [expand](./filesystem/expand.nu) - expansion module that implements bashes brace expansion. 
+The expansion uses a list inside of braces seperated by `,` to expand into a list of multiple string variations like:
+```
+ expand a/{b,c}/d{e,f,g}.nu{,on}
+```
+parses into:
+
+```
+╭────┬─────────────╮
+│  0 │ a/b/de.nu   │
+│  1 │ a/c/de.nu   │
+│  2 │ a/b/df.nu   │
+│  3 │ a/c/df.nu   │
+│  4 │ a/b/dg.nu   │
+│  5 │ a/c/dg.nu   │
+│  6 │ a/b/de.nuon │
+│  7 │ a/c/de.nuon │
+│  8 │ a/b/df.nuon │
+│  9 │ a/c/df.nuon │
+│ 10 │ a/b/dg.nuon │
+│ 11 │ a/c/dg.nuon │
+╰────┴─────────────╯
+```
 
 ## formats
 Examples of input/output formatters:

--- a/modules/filesystem/expand.nu
+++ b/modules/filesystem/expand.nu
@@ -31,7 +31,7 @@ def listify [lst] {
 }
 
 export def help [] {
-  print -n ( expand -h )
+  print -n ( main -h )
 
   print (
   [

--- a/modules/filesystem/expand.nu
+++ b/modules/filesystem/expand.nu
@@ -31,7 +31,7 @@ def listify [lst] {
 }
 
 export def help [] {
-  print -n ( expand --help )
+  print -n ( expand -h )
 
   print (
   [

--- a/modules/filesystem/expand.nu
+++ b/modules/filesystem/expand.nu
@@ -43,7 +43,20 @@ export def help [] {
     $"  > (ansi light_green)expand (ansi green).config/nushell/config.nu{,on}(ansi reset)"
     $"╭───┬─────────────────────────────╮\n│ 0 │ .config/nushell/config.nu   │\n│ 1 │ .config/nushell/config.nuon │\n╰───┴─────────────────────────────╯"
     $"  > (ansi light_green)expand (ansi green)a/{b,c}/{d,e,f,g}  (ansi reset)(ansi purple)|(ansi reset)(ansi light_green) each(ansi reset) (ansi light_green){ |d| (ansi reset)(ansi light_green) mkdir(ansi reset) (ansi purple)$d (ansi reset)(ansi light_green)}(ansi reset);(ansi light_green)tree(ansi reset)"
-    $"╭────────────╮\n│ empty list │\n╰────────────╯"
+    $".
+`-- a
+    |-- b
+    |   |-- d
+    |   |-- e
+    |   |-- f
+    |   `-- g
+    `-- c
+        |-- d
+        |-- e
+        |-- f
+        `-- g
+
+12 directories, 0 files"
   ] |
   str join "\n" |
   nu-highlight

--- a/modules/filesystem/expand.nu
+++ b/modules/filesystem/expand.nu
@@ -1,0 +1,51 @@
+
+# A bash like quick string manipulation script
+# the script works by creating a list from brace contents, seperated by a brace.
+
+# Expand the given string into a list on braces like bashes brace expansion 
+export def main [ 
+  input: string   # the string to expand.
+  ] {
+  listify $input
+}
+
+def listify [lst] {
+  try {
+    ($lst 
+      | parse -r '(?P<left>.*)(?<!\\){(?P<list>.*)(?<!\\)}(?P<right>.*)'
+      | get 0
+      | upsert list { |l|
+        $l.list
+        | split row ","
+        | str trim
+      }
+      | each { |it| 
+        $it.list 
+        | each { |l|
+          listify $"($it.left)($l)($it.right)"
+        }})
+    | flatten
+  } catch {
+    $lst
+  }
+}
+
+export def help [] {
+  print -n ( expand --help )
+
+  print (
+  [
+    $"(ansi green)Examples(ansi reset):"
+    $"  > (ansi light_green)expand (ansi green)a/{b,c}/d(ansi reset)"
+    $"╭───┬───────╮\n│ 0 │ a/b/d │\n│ 1 │ a/c/d │\n╰───┴───────╯"
+    $"  > (ansi light_green)expand (ansi green)\"my {beautifull,ugly} duckling\"(ansi reset)"
+    $"╭───┬────────────────────────╮\n│ 0 │ my beautifull duckling │\n│ 1 │ my ugly duckling       │\n╰───┴────────────────────────╯"
+    $"  > (ansi light_green)expand (ansi green).config/nushell/config.nu{,on}(ansi reset)"
+    $"╭───┬─────────────────────────────╮\n│ 0 │ .config/nushell/config.nu   │\n│ 1 │ .config/nushell/config.nuon │\n╰───┴─────────────────────────────╯"
+    $"  > (ansi light_green)expand (ansi green)a/{b,c}/{d,e,f,g}  (ansi reset)(ansi purple)|(ansi reset)(ansi light_green) each(ansi reset) (ansi light_green){ |d| (ansi reset)(ansi light_green) mkdir(ansi reset) (ansi purple)$d (ansi reset)(ansi light_green)}(ansi reset);(ansi light_green)tree(ansi reset)"
+    $"╭────────────╮\n│ empty list │\n╰────────────╯"
+  ] |
+  str join "\n" |
+  nu-highlight
+  )
+}


### PR DESCRIPTION
I have seen that many still miss bashes brace expansion.

this module adds a function `expand` that adds bashes brace expansion to nushell.
it resides in `modules/filesystem` and the `README.md` has been updated.
any change proposals are welcome.

while it doesn't work like bash 1:1, it adds similar expansion. Currently it only supports the expansion of items inside of braces that are split into a list by `,`.

information on how it works can be invoked using `expand help`.