### PR TITLE
fix: fix default fg and bg coloring for hl.nu

### DIFF
--- a/modules/coloring/hl.nu
+++ b/modules/coloring/hl.nu
@@ -15,7 +15,7 @@ export def combine [txt: string, fg: record, bg: record] {
 }
 
 export def create [txt: string,
-    fg = "n", bg = "n",
+    fg = "default", bg = "default",
     bli = false, bol = false, dim = false, hid = false,
     ita = false, rev = false, stk = false, und = false] {
   {


### PR DESCRIPTION
I found this issue since v0.81.0. Based on what I got from the Discord help channel, using "n" for foreground and background does not make it transparent.