### PR TITLE
fix the release note scripts

### DIFF
--- a/make_release/release-note/get-full-changelog
+++ b/make_release/release-note/get-full-changelog
@@ -12,7 +12,7 @@ def main [] {
         [Extension nushell/vscode-nushell-lang]
         [Documentation nushell/nushell.github.io]
         [Nu_Scripts nushell/nu_scripts]
-        [Reedline reedline]
+        [Reedline nushell/reedline]
     ]
 
     $changelogs | each {|changelog|

--- a/make_release/release-note/list-merged-prs
+++ b/make_release/release-note/list-merged-prs
@@ -41,7 +41,7 @@ def main [
         if $no_author {
             return (
                 $prs | each {|pr|
-                    let link = (md-link $pr.number $pr.url)
+                    let link = (md-link $"#($pr.number)" $pr.url)
                     $"- ($link) ($pr.title)"
                 }
                 | str join "\n"


### PR DESCRIPTION
i was writing stuff for https://github.com/nushell/nushell.github.io/pull/945 and noticed two issues with the `make_release/release-note/` scripts.

this PR fixes both of them
- add a `#` before the PR numbers in markdown links
- the name of the Reedline repo is `nushell/reedline` not `reedline`