### PR TITLE
refactor: simplify the `nu_release` script

### DIFF
--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -1,4 +1,3 @@
-cd crates
 
 let subcrates_wave_1 = [
     nu-glob,
@@ -37,24 +36,16 @@ let subcrates_wave_3 = [
 ]
 
 for subcrate in $subcrates_wave_1 {
-    cd $subcrate
-    cargo publish
-    cd ..
+    cargo publish --manifest-path ("crates" | path join $subcrate "Cargo.toml")
 }
 
 for subcrate in $subcrates_wave_2 {
-    cd $subcrate
     # due to build.rs in `nu-command`
-    cargo publish --no-verify
-    cd ..
+    cargo publish --manifest-path ("crates" | path join $subcrate "Cargo.toml") --no-verify
 }
 
 for subcrate in $subcrates_wave_3 {
-    cd $subcrate
-    cargo publish
-    cd ..
+    cargo publish --manifest-path ("crates" | path join $subcrate "Cargo.toml")
 }
-
-cd ..
 
 cargo publish

--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -1,3 +1,4 @@
+use std log
 
 let subcrates_wave_1 = [
     nu-glob,
@@ -35,15 +36,18 @@ let subcrates_wave_3 = [
     nu_plugin_formats,
 ]
 
+log warning "publishing the first wave of crates"
 for subcrate in $subcrates_wave_1 {
     cargo publish --manifest-path ("crates" | path join $subcrate "Cargo.toml")
 }
 
+log warning "publishing the second wave of crates"
 for subcrate in $subcrates_wave_2 {
     # due to build.rs in `nu-command`
     cargo publish --manifest-path ("crates" | path join $subcrate "Cargo.toml") --no-verify
 }
 
+log warning "publishing the third wave of crates"
 for subcrate in $subcrates_wave_3 {
     cargo publish --manifest-path ("crates" | path join $subcrate "Cargo.toml")
 }

--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -1,5 +1,18 @@
 use std log
 
+def publish [
+    crate: path # the path to the crate to publish.
+    --no-verify: bool # don’t verify the contents by building them. Can be useful for crates with a `build.rs`.
+] {
+    cd $crate
+
+    if $no_verify {
+        cargo publish --no-verify
+    } else {
+        cargo publish
+    }
+}
+
 let subcrates_wave_1 = [
     nu-glob,
     nu-json,
@@ -38,18 +51,17 @@ let subcrates_wave_3 = [
 
 log warning "publishing the first wave of crates"
 for subcrate in $subcrates_wave_1 {
-    cargo publish --manifest-path ("crates" | path join $subcrate "Cargo.toml")
+    publish ("crates" | path join $subcrate)
 }
 
 log warning "publishing the second wave of crates"
 for subcrate in $subcrates_wave_2 {
-    # due to build.rs in `nu-command`
-    cargo publish --manifest-path ("crates" | path join $subcrate "Cargo.toml") --no-verify
+    publish ("crates" | path join $subcrate) --no-verify
 }
 
 log warning "publishing the third wave of crates"
 for subcrate in $subcrates_wave_3 {
-    cargo publish --manifest-path ("crates" | path join $subcrate "Cargo.toml")
+    publish ("crates" | path join $subcrate)
 }
 
 cargo publish

--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -1,7 +1,6 @@
 cd crates
 
 let subcrates_wave_1 = [
-    # components
     nu-glob,
     nu-json,
     nu-path,
@@ -31,20 +30,15 @@ let subcrates_wave_3 = [
     nu-cli,
     nu-std,
 
-    # plugins
     nu_plugin_query,
     nu_plugin_inc,
     nu_plugin_gstat,
     nu_plugin_formats,
 ]
 
-# Recent versions of cargo verify the upload of your crate
-# So no need to `sleep` anymore.
-
 for subcrate in $subcrates_wave_1 {
     cd $subcrate
     cargo publish
-    # sleep 1min
     cd ..
 }
 
@@ -52,14 +46,12 @@ for subcrate in $subcrates_wave_2 {
     cd $subcrate
     # due to build.rs in `nu-command`
     cargo publish --no-verify
-    # sleep 1min
     cd ..
 }
 
 for subcrate in $subcrates_wave_3 {
     cd $subcrate
     cargo publish
-    # sleep 1min
     cd ..
 }
 


### PR DESCRIPTION
in the `nu_release.nu` scripts, this PR
- removes useless / deprecated comments
- uses the `--manifest-path` option of `cargo publish` instead of `cd`ing into the crates in and out, which is harder to read, understand and more error prone
```bash
# in `cargo help publish`
       --manifest-path path
           Path to the Cargo.toml file. By default, Cargo searches for the Cargo.toml file in the current directory or any
           parent directory.
```
- add a bit of logging