### PR TITLE
use `$env.` instead of `let-env `

### DIFF
--- a/custom-menus/zoxide-menu.nu
+++ b/custom-menus/zoxide-menu.nu
@@ -44,7 +44,7 @@ def __edit_keybinding [] {
 }
 
 export-env {
-    let-env config  = ($env.config
+    $env.config  = ($env.config
                   | upsert menus ($env.config.menus | append (__zoxide_menu))
                   | upsert keybindings ($env.config.keybindings | append [(__zoxide_keybinding) (__edit_keybinding)])
                   )

--- a/hooks/direnv/config.nu
+++ b/hooks/direnv/config.nu
@@ -1,7 +1,7 @@
 ## To enable direnv in nushell we must run code in the context of the current shell - i.e it cannot be within a block and it needs to run as a "code" string as per https://github.com/nushell/nushell/pull/5982 (so you must run nushell 0.66 or later). That way it works as if you'd typed in and run the code directly in your shell.
 ## Direnv knows what to do otherwise and will export the env to load (or unload) based on what is in your current environment so this is all that is needed with some checks for empty strings, defaulting then to an empty table so that load-env is always happy.
 
-let-env config = {
+$env.config = {
   hooks: {
     pre_prompt: [{
       code: "

--- a/hooks/direnv/direnv.nu
+++ b/hooks/direnv/direnv.nu
@@ -20,7 +20,7 @@ def direnv [] {
 }
 
 export-env {
-    let-env config = ( $env.config | upsert hooks.env_change.PWD { |config|
+    $env.config = ( $env.config | upsert hooks.env_change.PWD { |config|
         let o = ($config | get -i hooks.env_change.PWD)
         let val = (direnv)
         if $o == $nothing {

--- a/hooks/dynamic-load/dynamic-load.nu
+++ b/hooks/dynamic-load/dynamic-load.nu
@@ -8,7 +8,7 @@ def dynamic_load [] {
 }
 
 export-env {
-    let-env config = ( $env.config | upsert hooks.env_change.PWD { |config|
+    $env.config = ( $env.config | upsert hooks.env_change.PWD { |config|
         let o = ($config | get -i hooks.env_change.PWD)
         let val = (dynamic_load)
         if $o == $nothing {

--- a/hooks/filesystem/autojump.nu
+++ b/hooks/filesystem/autojump.nu
@@ -11,14 +11,14 @@
 #    Run `j` to jump arround
 
 def autojump_add_to_database [dir] {
-        let-env AUTOJUMP_SOURCED = 1
+        $env.AUTOJUMP_SOURCED = 1
         autojump --add $dir
 }
 def-env j [dir] {
-        let-env AUTOJUMP_SOURCED = 1
+        $env.AUTOJUMP_SOURCED = 1
         cd (autojump $dir)
 }
-let-env config = ($env.config | upsert hooks.env_change.PWD {|config|
+$env.config = ($env.config | upsert hooks.env_change.PWD {|config|
     let val = ($config | get -i hooks.env_change.PWD)
 
     if $val == $nothing {

--- a/modules/base16/README.md
+++ b/modules/base16/README.md
@@ -33,7 +33,7 @@ Next, set up Nushell config, assuming the base16 colors are generated
 use ~/.config/nushell/base16.nu
 
 # File containing base16 colors
-let-env BASE16_TXT = "/tmp/base16.txt"
+$env.BASE16_TXT = "/tmp/base16.txt"
 
 let config = {
     color_config: (base16 build-nu-config $env.BASE16_TXT)

--- a/modules/base16/base16.nu
+++ b/modules/base16/base16.nu
@@ -67,7 +67,7 @@ export def build-alacritty-config [base_txt: path] {
     # | save --raw "~/.config/alacritty/alacritty_colors.yml"
     let conf = ($base16 | apply-base16-mustache $template)
 
-    let-env ALACRITTY_CONFIG = $conf
+    $env.ALACRITTY_CONFIG = $conf
 
     nu -c "$nu.env.ALACRITTY_CONFIG | save --raw '~/.config/alacritty/alacritty_colors.yml'"
 }

--- a/modules/docker/docker.nu
+++ b/modules/docker/docker.nu
@@ -1,7 +1,7 @@
 export-env {
     for c in [podman nerdctl docker] {
         if not (which $c | is-empty) {
-            let-env docker-cli = $c
+            $env.docker-cli = $c
             break
         }
     }

--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -112,8 +112,8 @@ export def `kcache flush` [] {
 }
 
 export-env {
-    let-env KUBERNETES_SCHEMA_URL = $"file:///($env.HOME)/.config/kubernetes-json-schema/all.json"
-    let-env KUBERNETES_RESOURCE_ABBR = {
+    $env.KUBERNETES_SCHEMA_URL = $"file:///($env.HOME)/.config/kubernetes-json-schema/all.json"
+    $env.KUBERNETES_RESOURCE_ABBR = {
         s: services
         d: deployments
         p: pods
@@ -388,7 +388,7 @@ export def-env kcconf [name: string@"nu-complete kube ctx"] {
     let dist = $"($env.HOME)/.kube/config.d"
     mkdir $dist
     kconf export $name | save -fr $"($dist)/($name)"
-    let-env KUBECONFIG = $"($dist)/($name)"
+    $env.KUBECONFIG = $"($dist)/($name)"
 }
 
 ### common

--- a/modules/nvim/nvim.nu
+++ b/modules/nvim/nvim.nu
@@ -40,7 +40,7 @@ def nvim_tcd [] {
 }
 
 export-env {
-    let-env config = ( $env.config | upsert hooks.env_change.PWD { |config|
+    $env.config = ( $env.config | upsert hooks.env_change.PWD { |config|
         let o = ($config | get -i hooks.env_change.PWD)
         let val = (nvim_tcd)
         if $o == $nothing {

--- a/modules/prompt/async_git_prompt/prompt.nu
+++ b/modules/prompt/async_git_prompt/prompt.nu
@@ -26,6 +26,6 @@ def prompt-create-right-prompt [] {
     $nothing
 }
 
-let-env PROMPT_COMMAND = { prompt-create-left-prompt }
-let-env PROMPT_COMMAND_RIGHT = { prompt-create-right-prompt }
-let-env PROMPT_INDICATOR = { $" (ansi green_bold)〉" }
+$env.PROMPT_COMMAND = { prompt-create-left-prompt }
+$env.PROMPT_COMMAND_RIGHT = { prompt-create-right-prompt }
+$env.PROMPT_INDICATOR = { $" (ansi green_bold)〉" }

--- a/modules/prompt/full-line.nu
+++ b/modules/prompt/full-line.nu
@@ -3,15 +3,15 @@
 # 
 # to use:
 # 1. copy this file to `($nu.default-config-dir | path add 'scripts')` (Or someplace on your $env.NU_LIB_DIRS path, defined in env.nu)
-# 2. cut `let-env PROMPT_COMMAND` and `PROMPT_OMMAND_RIGHT' from your env.nu.  
+# 2. cut `$env.PROMPT_COMMAND` and `PROMPT_OMMAND_RIGHT' from your env.nu.  
 #    These will depend on `use full-line`, which can not be done in env.nu.
 #    You can leave the `PROMPT-*INDICATOR*` statements in env.nu or 
 #    consolidate all prompt stuff in config.nu.
 # 3. Add new prompt setup stuff somewhere in config.nu:
 #   ```
 #   use prompt-builder.nu
-#   let-env PROMPT_COMMAND = {|| prompt-builder }
-#   let-env PROMPT_COMMAND_RIGHT = ""
+#   $env.PROMPT_COMMAND = {|| prompt-builder }
+#   $env.PROMPT_COMMAND_RIGHT = ""
 #   ```
 #
 # credit panache-git for the git status widget.  

--- a/modules/prompt/oh-my-minimal.nu
+++ b/modules/prompt/oh-my-minimal.nu
@@ -274,11 +274,11 @@ export def get_prompt [nerd?] {
     #
     # in the config.nu you would do something like
     # use "c:\some\path\to\nu_scripts\engine-q\prompt\oh-my-minimal.nu" get_prompt
-    # let-env PROMPT_COMMAND = { (get_prompt).left_prompt }
-    # let-env PROMPT_COMMAND_RIGHT = { (get_prompt).right_prompt }
-    # let-env PROMPT_INDICATOR = " "
+    # $env.PROMPT_COMMAND = { (get_prompt).left_prompt }
+    # $env.PROMPT_COMMAND_RIGHT = { (get_prompt).right_prompt }
+    # $env.PROMPT_INDICATOR = " "
     # or with nerdfonts
-    # let-env PROMPT_COMMAND = { (get_prompt 1).left_prompt }
-    # let-env PROMPT_COMMAND_RIGHT = { (get_prompt 1).right_prompt }
+    # $env.PROMPT_COMMAND = { (get_prompt 1).left_prompt }
+    # $env.PROMPT_COMMAND_RIGHT = { (get_prompt 1).right_prompt }
 
 }

--- a/modules/prompt/oh-my-v2-docs.md
+++ b/modules/prompt/oh-my-v2-docs.md
@@ -6,9 +6,9 @@ The thought would be that at some point this file source read another file for c
 
 In order to use this script you need to source it and then set these.
 ```
-let-env PROMPT_COMMAND = { (get_prompt 8bit).left_prompt }
-let-env PROMPT_COMMAND_RIGHT = { (get_prompt 8bit).right_prompt }
-let-env PROMPT_INDICATOR = { "" }
+$env.PROMPT_COMMAND = { (get_prompt 8bit).left_prompt }
+$env.PROMPT_COMMAND_RIGHT = { (get_prompt 8bit).right_prompt }
+$env.PROMPT_INDICATOR = { "" }
 ```
 
 I'd love for someone to take up the torch and work on this script in order to make it better, configurable, awesome.

--- a/modules/prompt/oh-my.nu
+++ b/modules/prompt/oh-my.nu
@@ -539,7 +539,7 @@ export def git_prompt [] {
     #
     # in the config.nu you would do something like
     # use "c:\some\path\to\nu_scripts\prompt\oh-my.nu" git_prompt
-    # let-env PROMPT_COMMAND = { (git_prompt).left_prompt }
-    # let-env PROMPT_COMMAND_RIGHT = { (git_prompt).right_prompt }
-    # let-env PROMPT_INDICATOR = " "
+    # $env.PROMPT_COMMAND = { (git_prompt).left_prompt }
+    # $env.PROMPT_COMMAND_RIGHT = { (git_prompt).right_prompt }
+    # $env.PROMPT_INDICATOR = " "
 }

--- a/modules/prompt/panache-git.nu
+++ b/modules/prompt/panache-git.nu
@@ -9,8 +9,8 @@
 #   - Disable the separate prompt indicator by setting it to an empty string
 # - For example, with this file in your home directory:
 #     use ~/panache-git.nu panache-git
-#     let-env PROMPT_COMMAND = { panache-git }
-#     let-env PROMPT_INDICATOR = { "" }
+#     $env.PROMPT_COMMAND = { panache-git }
+#     $env.PROMPT_INDICATOR = { "" }
 # - Restart Nushell
 #
 # For more documentation or to file an issue, see https://github.com/ehdevries/panache-git

--- a/modules/prompt/powerline/README.md
+++ b/modules/prompt/powerline/README.md
@@ -17,7 +17,7 @@ power init
 ```
 or
 ```
-let-env NU_POWER_SCHEMA = [
+$env.NU_POWER_SCHEMA = [
     [
         {source: pwd,   color: '#353230'}
         {source: git,   color: '#504945'}
@@ -38,19 +38,19 @@ power init
 `$env.NU_POWER_SCHEMA` support configuring dynamically
 
 ## mode
-- `let-env NU_POWER_MODE = '<power|fast>'` fast mode and default mode (experimental)
-- `let-env NU_POWER_DECORATOR = '<power|plain>'` power mode and plain mode
-- `let-env NU_POWER_FRAME = '<default|fill>'` two line prompt (experimental)
+- `$env.NU_POWER_MODE = '<power|fast>'` fast mode and default mode (experimental)
+- `$env.NU_POWER_DECORATOR = '<power|plain>'` power mode and plain mode
+- `$env.NU_POWER_FRAME = '<default|fill>'` two line prompt (experimental)
 
 ### benchmark
 ```
-let-env NU_POWER_BENCHMARK = true
+$env.NU_POWER_BENCHMARK = true
 ```
 Then execute a few commands casually, such as pressing the Enter key continuously.
 then execute
 
 ```
-let-env NU_POWER_MODE = 'fast' # or 'power'
+$env.NU_POWER_MODE = 'fast' # or 'power'
 ```
 
 Go ahead and press enter,

--- a/modules/prompt/powerline/power.nu
+++ b/modules/prompt/powerline/power.nu
@@ -372,21 +372,21 @@ export def-env init [] {
         'default' => {
             match $env.NU_POWER_MODE {
                 'power' => {
-                    let-env PROMPT_COMMAND = (wraptime
+                    $env.PROMPT_COMMAND = (wraptime
                         'dynamic left'
                         (left_prompt $env.NU_POWER_SCHEMA.0)
                     )
-                    let-env PROMPT_COMMAND_RIGHT = (wraptime
+                    $env.PROMPT_COMMAND_RIGHT = (wraptime
                         'dynamic right'
                         (right_prompt $env.NU_POWER_SCHEMA.1)
                     )
                 }
                 'fast' => {
-                    let-env PROMPT_COMMAND = (wraptime
+                    $env.PROMPT_COMMAND = (wraptime
                         'static left'
                         (left_prompt_gen $env.NU_POWER_SCHEMA.0)
                     )
-                    let-env PROMPT_COMMAND_RIGHT = (wraptime
+                    $env.PROMPT_COMMAND_RIGHT = (wraptime
                         'static right'
                         (right_prompt_gen $env.NU_POWER_SCHEMA.1)
                     )
@@ -394,26 +394,26 @@ export def-env init [] {
             }
         }
         'fill' => {
-            let-env PROMPT_COMMAND = (up_prompt $env.NU_POWER_SCHEMA)
+            $env.PROMPT_COMMAND = (up_prompt $env.NU_POWER_SCHEMA)
         }
     }
 
-    let-env PROMPT_INDICATOR = {||
+    $env.PROMPT_INDICATOR = {||
         match $env.NU_POWER_DECORATOR {
             'plain' => { "> " }
             _ => { " " }
         }
     }
-    let-env PROMPT_INDICATOR_VI_INSERT = {|| ": " }
-    let-env PROMPT_INDICATOR_VI_NORMAL = {|| "> " }
-    let-env PROMPT_MULTILINE_INDICATOR = {||
+    $env.PROMPT_INDICATOR_VI_INSERT = {|| ": " }
+    $env.PROMPT_INDICATOR_VI_NORMAL = {|| "> " }
+    $env.PROMPT_MULTILINE_INDICATOR = {||
         match $env.NU_POWER_DECORATOR {
             'plain' => { "::: " }
             _ => { $"(char haze) " }
         }
     }
 
-    let-env config = ( $env.config | update menus ($env.config.menus
+    $env.config = ( $env.config | update menus ($env.config.menus
         | each {|x|
             if ($x.marker in $env.NU_POWER_MENU_MARKER) {
                 let c = ($env.NU_POWER_MENU_MARKER | get $x.marker)
@@ -428,7 +428,7 @@ export def-env init [] {
 }
 
 export def-env set [name theme config?] {
-    let-env NU_POWER_THEME = (if ($theme | is-empty) {
+    $env.NU_POWER_THEME = (if ($theme | is-empty) {
             $env.NU_POWER_THEME
         } else {
             $env.NU_POWER_THEME
@@ -439,7 +439,7 @@ export def-env set [name theme config?] {
                 })
         })
 
-    let-env NU_POWER_CONFIG = (if ($config | is-empty) {
+    $env.NU_POWER_CONFIG = (if ($config | is-empty) {
             $env.NU_POWER_CONFIG
         } else {
             $env.NU_POWER_CONFIG
@@ -454,7 +454,7 @@ export def-env set [name theme config?] {
 export def-env register [name source theme config?] {
     set $name $theme $config
 
-    let-env NU_PROMPT_COMPONENTS = (
+    $env.NU_PROMPT_COMPONENTS = (
         $env.NU_PROMPT_COMPONENTS | upsert $name {|| $source }
     )
 }
@@ -471,7 +471,7 @@ export def-env inject [pos idx define theme? config?] {
         ] | flatten
     }
 
-    let-env NU_POWER_SCHEMA = (
+    $env.NU_POWER_SCHEMA = (
         $env.NU_POWER_SCHEMA
         | update $pos $next
     )
@@ -484,7 +484,7 @@ export def-env inject [pos idx define theme? config?] {
         let next_theme = ($theme | transpose k v)
         for n in $next_theme {
             if $n.k in $prev_cols {
-                let-env NU_POWER_THEME = (
+                $env.NU_POWER_THEME = (
                     $env.NU_POWER_THEME | update $kind {|conf|
                       $conf | get $kind | update $n.k (ansi -e {fg: $n.v})
                     }
@@ -497,7 +497,7 @@ export def-env inject [pos idx define theme? config?] {
         let prev_cols = ($env.NU_POWER_CONFIG | get $kind | columns)
         for n in ($config | transpose k v) {
             if $n.k in $prev_cols {
-                let-env NU_POWER_CONFIG = (
+                $env.NU_POWER_CONFIG = (
                     $env.NU_POWER_CONFIG | update $kind {|conf|
                       $conf | get $kind | update $n.k $n.v
                     }
@@ -512,7 +512,7 @@ export def-env eject [] {
 }
 
 export def-env hook [] {
-    let-env config = ( $env.config | upsert hooks.env_change { |config|
+    $env.config = ( $env.config | upsert hooks.env_change { |config|
         let init = [{|before, after| if not ($before | is-empty) { init } }]
         $config.hooks.env_change
         | upsert NU_POWER_MODE $init
@@ -532,14 +532,14 @@ export def-env hook [] {
 }
 
 export-env {
-    let-env NU_POWER_BENCHMARK = false
+    $env.NU_POWER_BENCHMARK = false
 
-    let-env NU_POWER_MODE = (default_env
+    $env.NU_POWER_MODE = (default_env
         NU_POWER_MODE
         'power' # power | fast
     )
 
-    let-env NU_POWER_SCHEMA = (default_env
+    $env.NU_POWER_SCHEMA = (default_env
         NU_POWER_SCHEMA
         [
             [
@@ -553,17 +553,17 @@ export-env {
         ]
     )
 
-    let-env NU_POWER_FRAME = (default_env
+    $env.NU_POWER_FRAME = (default_env
         NU_POWER_FRAME
         'default' # default | fill
     )
 
-    let-env NU_POWER_DECORATOR = (default_env
+    $env.NU_POWER_DECORATOR = (default_env
         NU_POWER_DECORATOR
         'power' # power | plain
     )
 
-    let-env NU_POWER_MENU_MARKER = (default_env
+    $env.NU_POWER_MENU_MARKER = (default_env
         NU_POWER_MENU_MARKER
         {
             "| " : 'green'
@@ -573,7 +573,7 @@ export-env {
         }
     )
 
-    let-env NU_POWER_THEME = (default_env
+    $env.NU_POWER_THEME = (default_env
         NU_POWER_THEME
         {
             pwd: {
@@ -594,7 +594,7 @@ export-env {
         }
     )
 
-    let-env NU_POWER_CONFIG = (default_env
+    $env.NU_POWER_CONFIG = (default_env
         NU_POWER_CONFIG
         {
             time: {
@@ -603,7 +603,7 @@ export-env {
         }
     )
 
-    let-env NU_PROMPT_COMPONENTS = {
+    $env.NU_PROMPT_COMPONENTS = {
         pwd: (pwd_abbr)
         proxy: (proxy_stat)
         host: (host_abbr)

--- a/modules/prompt/powerline/power_git.nu
+++ b/modules/prompt/powerline/power_git.nu
@@ -123,7 +123,7 @@ export def git_stat [] {
 }
 
 export-env {
-    let-env NU_PROMPT_GIT_FORMATTER = (power default_env
+    $env.NU_PROMPT_GIT_FORMATTER = (power default_env
         NU_PROMPT_GIT_FORMATTER
         [
             [behind              (char branch_behind) yellow]

--- a/modules/prompt/shell_space.nu
+++ b/modules/prompt/shell_space.nu
@@ -18,4 +18,4 @@ def create_right_prompt [] {
     $time_segment
 }
 
-let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
+$env.PROMPT_COMMAND_RIGHT = { create_right_prompt }

--- a/modules/prompt/starship.nu
+++ b/modules/prompt/starship.nu
@@ -2,10 +2,10 @@ def create_left_prompt [] {
     ^starship prompt --cmd-duration $env.CMD_DURATION_MS $'--status=($env.LAST_EXIT_CODE)'
 }
 
-let-env PROMPT_COMMAND = { create_left_prompt }
+$env.PROMPT_COMMAND = { create_left_prompt }
 
 # avoid same PROMPT_INDICATOR
-let-env PROMPT_INDICATOR = { "" }
-let-env PROMPT_INDICATOR_VI_INSERT = { ": " }
-let-env PROMPT_INDICATOR_VI_NORMAL = { "〉" }
-let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
+$env.PROMPT_INDICATOR = { "" }
+$env.PROMPT_INDICATOR_VI_INSERT = { ": " }
+$env.PROMPT_INDICATOR_VI_NORMAL = { "〉" }
+$env.PROMPT_MULTILINE_INDICATOR = { "::: " }

--- a/modules/virtual_environments/README.md
+++ b/modules/virtual_environments/README.md
@@ -15,7 +15,7 @@ The activation and deactivation commands are exported from the `conda` module.
 
 The `activate` command also includes custom completions for the environment names.
 To disable the prompt changes (e.g., to let [Starship](https://starship.rs) include its own), set the environment variable `CONDA_NO_PROMPT`.
-To set it globally, add the line `let-env CONDA_NO_PROMPT = true` to `$nu.config-path`.
+To set it globally, add the line `$env.CONDA_NO_PROMPT = true` to `$nu.config-path`.
 
 ## Limitations
 

--- a/modules/virtual_environments/auto-venv/README.md
+++ b/modules/virtual_environments/auto-venv/README.md
@@ -14,7 +14,7 @@ For example:
 # config.nu
 
 export-env {
-    let-env AUTO_VENV_TRIGGER = '__auto-venv.nu'
+    $env.AUTO_VENV_TRIGGER = '__auto-venv.nu'
 
     source-env ~/path/to/nu_scripts/modules/virtual_environments/auto-venv/auto-venv.nu
 }

--- a/modules/virtual_environments/auto-venv/auto-venv.nu
+++ b/modules/virtual_environments/auto-venv/auto-venv.nu
@@ -8,13 +8,13 @@ export use path_extensions.nu
 export-env {
 
     # this needs to be set somewhere
-    # let-env AUTO_VENV_TRIGGER = '__auto-venv.nu'
+    # $env.AUTO_VENV_TRIGGER = '__auto-venv.nu'
 
     let hooks = (default-hooks)
 
     let hooks = ($hooks | append (build-hooks))
 
-    let-env config = ($env.config | upsert hooks.env_change.PWD $hooks )
+    $env.config = ($env.config | upsert hooks.env_change.PWD $hooks )
 }
 
 

--- a/modules/virtual_environments/conda.nu
+++ b/modules/virtual_environments/conda.nu
@@ -75,7 +75,7 @@ export def-env activate [
 # Deactivate currently active conda environment
 export def-env deactivate [] {
     let path_name = if "PATH" in $env { "PATH" } else { "Path" }
-    let-env $path_name = $env.CONDA_OLD_PATH
+    $env.$path_name = $env.CONDA_OLD_PATH
 
     hide-env CONDA_PROMPT_MODIFIER
     hide-env CONDA_PREFIX
@@ -83,7 +83,7 @@ export def-env deactivate [] {
     hide-env CONDA_DEFAULT_ENV
     hide-env CONDA_OLD_PATH
 
-    let-env PROMPT_COMMAND = if $env.CONDA_OLD_PROMPT_COMMAND == $nothing {
+    $env.PROMPT_COMMAND = if $env.CONDA_OLD_PROMPT_COMMAND == $nothing {
         $env.PROMPT_COMMAND
     } else {
         $env.CONDA_OLD_PROMPT_COMMAND

--- a/modules/virtual_environments/nu_conda/nu_conda.nu
+++ b/modules/virtual_environments/nu_conda/nu_conda.nu
@@ -1,5 +1,5 @@
 export-env {
-  let-env CONDA_BASE_PATH = (if ((sys).host.name == "Windows") {$env.Path} else {$env.PATH})
+  $env.CONDA_BASE_PATH = (if ((sys).host.name == "Windows") {$env.Path} else {$env.PATH})
 
   let info = (
       if not (which mamba | is-empty) {
@@ -10,16 +10,16 @@ export-env {
         ('{"root_prefix": "", "envs": ""}' | from json)
       })
 
-  let-env CONDA_ROOT = $info.root_prefix
+  $env.CONDA_ROOT = $info.root_prefix
 
-  let-env CONDA_ENVS = ($info.envs | reduce -f {} {|it, acc|
+  $env.CONDA_ENVS = ($info.envs | reduce -f {} {|it, acc|
       if $it == $info.root_prefix {
         $acc | upsert "base" $it
       } else {
         $acc | upsert ($it | path basename) $it
       }})
 
-  let-env CONDA_CURR = null
+  $env.CONDA_CURR = null
 }
 
 export def-env activate [name: string] {
@@ -50,7 +50,7 @@ export def-env deactivate [] {
     return
   }
 
-  let-env CONDA_CURR = null
+  $env.CONDA_CURR = null
 
   load-env {Path: $env.CONDA_BASE_PATH, PATH: $env.CONDA_BASE_PATH}
 }

--- a/modules/virtual_environments/nu_msvs/nu_msvs.nu
+++ b/modules/virtual_environments/nu_msvs/nu_msvs.nu
@@ -1,5 +1,5 @@
 export-env {
-  let-env MSVS_BASE_PATH = $env.Path
+  $env.MSVS_BASE_PATH = $env.Path
 
   let info = (
       if not (which vswhere | is-empty) {
@@ -9,9 +9,9 @@ export-env {
       }
   )
 
-  let-env MSVS_ROOT = ($info.installationPath.0 | str replace -a '\\' '/')
+  $env.MSVS_ROOT = ($info.installationPath.0 | str replace -a '\\' '/')
 
-  let-env MSVS_MSVC_ROOT = (
+  $env.MSVS_MSVC_ROOT = (
       if not ($"($env.MSVS_ROOT)/VC/Tools/MSVC/" | path exists) {
         ""
       } else if (ls $"($env.MSVS_ROOT)/VC/Tools/MSVC/*" | is-empty) {
@@ -20,13 +20,13 @@ export-env {
         ((ls $"($env.MSVS_ROOT)/VC/Tools/MSVC/*").name.0 | str replace -a '\\' '/')
       })
 
-  let-env MSVS_MSDK_ROOT = (REG QUERY 'HKLM\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0' /v "InstallationFolder" | str replace '(.|\n)+REG_SZ\s+(.+)' "$2")
-  let-env MSVS_MSDK_ROOT = ($env.MSVS_MSDK_ROOT | str replace -a '\\' '/')
+  $env.MSVS_MSDK_ROOT = (REG QUERY 'HKLM\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0' /v "InstallationFolder" | str replace '(.|\n)+REG_SZ\s+(.+)' "$2")
+  $env.MSVS_MSDK_ROOT = ($env.MSVS_MSDK_ROOT | str replace -a '\\' '/')
 
-  let-env MSVS_MSDK_VER = (REG QUERY 'HKLM\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0' /v "ProductVersion" | str replace '(.|\n)+REG_SZ\s+(.+)' "$2")
-  let-env MSVS_MSDK_VER = $"($env.MSVS_MSDK_VER).0"
+  $env.MSVS_MSDK_VER = (REG QUERY 'HKLM\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0' /v "ProductVersion" | str replace '(.|\n)+REG_SZ\s+(.+)' "$2")
+  $env.MSVS_MSDK_VER = $"($env.MSVS_MSDK_VER).0"
 
-  let-env MSVS_INCLUDE_PATH = ([
+  $env.MSVS_INCLUDE_PATH = ([
     $"($env.MSVS_ROOT)/Include/($env.MSVS_MSDK_VER)/cppwinrt/winrt",
     $"($env.MSVS_MSVC_ROOT)/include",
     $"($env.MSVS_MSDK_ROOT)Include/($env.MSVS_MSDK_VER)/cppwinrt/winrt",

--- a/modules/weather/timed_weather_run_env.nu
+++ b/modules/weather/timed_weather_run_env.nu
@@ -9,7 +9,7 @@
 use get-weather.nu get_weather
 
 # Create a mutable weather table to hold the weather data
-let-env WEATHER = (get_weather | upsert last_run_time { (date now | date format '%Y-%m-%d %H:%M:%S %z')})
+$env.WEATHER = (get_weather | upsert last_run_time { (date now | date format '%Y-%m-%d %H:%M:%S %z')})
 
 #command to run at interval
 def-env timed_weather_run [
@@ -30,7 +30,7 @@ def-env timed_weather_run [
     } else {
         # $"interval met, running command: [($command)](char nl)"
 
-        let-env WEATHER = (get_weather | upsert last_run_time { (date now | date format '%Y-%m-%d %H:%M:%S %z')})
+        $env.WEATHER = (get_weather | upsert last_run_time { (date now | date format '%Y-%m-%d %H:%M:%S %z')})
         let temp = ($env.WEATHER.Temperature)
         let emoji = ($env.WEATHER.Emoji)
         {

--- a/sourced/TODO.md
+++ b/sourced/TODO.md
@@ -19,7 +19,7 @@ your terminal documentation or find a work around
 - *Recommended*
   In your `env.nu`, add an environment variable pointing to the `todo.txt`. Example:
   ```nu
-  let-env TODO = ($nu.config-path | path dirname | path join 'scripts/todo.txt')
+  $env.TODO = ($nu.config-path | path dirname | path join 'scripts/todo.txt')
   ```
 - Source the `todo` command in your `config.nu`. Example
   ```nu

--- a/sourced/filesystem/cdpath.nu
+++ b/sourced/filesystem/cdpath.nu
@@ -31,6 +31,6 @@ def-env c [dir = ""] {
 }
 
 # You need to have $env.CDPATH variable declared, my suggestion from config.nu:
-# let-env CDPATH = [".", $env.HOME, "/", ([$env.HOME, ".config"] | path join)]
+# $env.CDPATH = [".", $env.HOME, "/", ([$env.HOME, ".config"] | path join)]
 # WINDOWS:
-# let-env CDPATH = ["", $env.USERPROFILE, ([$env.USERPROFILE, "AppData\\Roaming\\"] | path join)]
+# $env.CDPATH = ["", $env.USERPROFILE, ([$env.USERPROFILE, "AppData\\Roaming\\"] | path join)]

--- a/sourced/update-path.nu
+++ b/sourced/update-path.nu
@@ -32,6 +32,6 @@ module update-path {
         | append (registry query --hklm 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment'| parse-paths)
     }
     export def-env update-path [] {
-        let-env Path = ($env.Path|append (get-paths-from-registry)|uniq)
+        $env.Path = ($env.Path|append (get-paths-from-registry)|uniq)
     }
 }

--- a/themes/README.md
+++ b/themes/README.md
@@ -12,7 +12,7 @@ ls ./themes/themes
 To use the `dracula` theme for instance, please run
 ```rust
 use ./themes/themes/dracula.nu
-let-env config = ($env.config | merge {color_config: (dracula)})
+$env.config = ($env.config | merge {color_config: (dracula)})
 ```
 
 The theme should be activated!


### PR DESCRIPTION
related to nushell/nushell#9574

this PR moves from using `let-env FOO = ...` to using `$env.FOO = ...` in all the `nu_scripts`.

## procedure
this was an automatic commit, i've simply run the following commands :+1: 
```nushell
sd --string-mode "let-env " '$env.' **/*
git rst before_v0.60/
```

cc/ @jntrnr 