### PR TITLE
fix pass-completion as `let` cannot be used at module level

### DIFF
--- a/custom-completions/pass/pass-completions.nu
+++ b/custom-completions/pass/pass-completions.nu
@@ -1,19 +1,23 @@
-let pass_completions_directory = if ($env | columns | any { |it| $it == "PASSWORD_STORE_DIR" }) {
-	$env.PASSWORD_STORE_DIR
-} else {
-	(^realpath ~/.password-store/) + "/"
+def pass_completions_directory [] {
+    if ($env | columns | any { |it| $it == "PASSWORD_STORE_DIR" }) {
+        return $env.PASSWORD_STORE_DIR
+    } else {
+        return $"(^realpath ~/.password-store/)/"
+    }
 }
 
 def "nu-complete pass-files" [] {
-	^find $pass_completions_directory -name "*.gpg" -type f
-		| lines 
-		| each {|it| ($it | str replace $pass_completions_directory "" | str replace ".gpg" "") }
+    let dir = (pass_completions_directory)
+	ls $"(pass_completions_directory)/**/*.gpg"
+		| get name 
+		| each {|it| ($it | str replace $dir "" | str replace ".gpg" "") }
 }
 
 def "nu-complete pass-directories" [] {
-	^find $pass_completions_directory -name ".git" -prune -o -type d -print
+    let dir = (pass_completions_directory)
+	^find $dir -name ".git" -prune -o -type d -print
 		| lines
-		| each {|it| ($it | str replace $pass_completions_directory "") }
+		| each {|it| ($it | str replace $dir "") }
 		| filter { |it| ($it | is-empty) == false }
 }
 

--- a/custom-completions/pass/pass-completions.nu
+++ b/custom-completions/pass/pass-completions.nu
@@ -2,23 +2,27 @@ def pass_completions_directory [] {
     if ($env | columns | any { |it| $it == "PASSWORD_STORE_DIR" }) {
         return $env.PASSWORD_STORE_DIR
     } else {
-        return $"(^realpath ~/.password-store/)/"
+        return ("~/.password-store" | path expand)
     }
 }
 
 def "nu-complete pass-files" [] {
     let dir = (pass_completions_directory)
-	ls $"(pass_completions_directory)/**/*.gpg"
+	ls ($dir | path join "**" | path join "*.gpg")
 		| get name 
-		| each {|it| ($it | str replace $dir "" | str replace ".gpg" "") }
+		| each {|it| ( $it
+            | path relative-to $dir
+            | str replace ".gpg" ""
+            )
+        }
 }
 
 def "nu-complete pass-directories" [] {
     let dir = (pass_completions_directory)
-	^find $dir -name ".git" -prune -o -type d -print
-		| lines
-		| each {|it| ($it | str replace $dir "") }
-		| filter { |it| ($it | is-empty) == false }
+	ls ($dir | path join **)
+        | get name
+        | filter { |it| not (ls $it | is-empty) }
+		| each {|it| ( $it | path relative-to $dir) }
 }
 
 # Show folders in the password store
@@ -29,6 +33,8 @@ export extern "pass ls" [
 # Show the value of a password
 export extern "pass show" [
 	name: string@"nu-complete pass-files"
+    --clip(-c) # do not print the password but instead copy the first (or otherwise specified, example: -c2) line to the clipboard.
+    --qrcode(-q) # do not print the password but instead display a QR code.
 ]
 
 # Add a new password
@@ -74,3 +80,4 @@ export extern "pass cp" [
 	newname: string@"nu-complete pass-directories"
 	--force(-f) # Omit prompt when trying to overwrite existing password
 ]
+


### PR DESCRIPTION
`let` cannont be used at module level. #8248 proposes to add `const` for modules, but in the meantime, a function is the best way to make this script useable as a module.