### PR TITLE
conda fix

### DIFF
--- a/modules/virtual_environments/conda.nu
+++ b/modules/virtual_environments/conda.nu
@@ -83,12 +83,13 @@ export def-env deactivate [] {
     hide-env CONDA_DEFAULT_ENV
     hide-env CONDA_OLD_PATH
 
-    $env.PROMPT_COMMAND = if $env.CONDA_OLD_PROMPT_COMMAND == $nothing {
-        $env.PROMPT_COMMAND
-    } else {
-        $env.CONDA_OLD_PROMPT_COMMAND
-    }
-
+    $env.PROMPT_COMMAND = (
+        if $env.CONDA_OLD_PROMPT_COMMAND == $nothing {
+            $env.PROMPT_COMMAND
+        } else {
+            $env.CONDA_OLD_PROMPT_COMMAND
+        }
+    )
     hide-env CONDA_OLD_PROMPT_COMMAND
 }
 


### PR DESCRIPTION
seems like that somehow #a61256d broke conda, which I use:

```
   ╭─[/Users/user/apps-files/github/nu_scripts/modules/virtual_environments/conda.nu:85:1]
 85 │
 86 │     $env.PROMPT_COMMAND = if $env.CONDA_OLD_PROMPT_COMMAND == $nothing {
    ·                              ──────────────┬──────────────
    ·                                            ╰── expected operator
```

Seems like this PR fix it.