### PR TITLE
add `$.version` to `package.nuon`

### DIFF
--- a/package.nuon
+++ b/package.nuon
@@ -3,4 +3,5 @@
     description: "A place to share Nushell scripts with each other"
     documentation: "https://github.com/nushell/nu_scripts/blob/main/README.md"
     license: "https://github.com/nushell/nu_scripts/blob/main/LICENSE"
+    version: 0.1.0
 }


### PR DESCRIPTION
since nushell/nupm#6, `$.version` is a required key in `package.nuon` for a Nushell package.

this PR sets the version for the `nu_scripts`.