### PR TITLE
move the extra menus of Nushell into `custom-menus/extra/`

### DIFF
--- a/custom-menus/extra/commands.nu
+++ b/custom-menus/extra/commands.nu
@@ -1,3 +1,12 @@
+# can be used in the REPL by adding something like the following block to `$env.config.keybindings` in your `config.nu`
+# {
+#     name: commands_menu
+#     modifier: control
+#     keycode: char_t
+#     mode: [emacs, vi_normal, vi_insert]
+#     event: { send: menu name: commands_menu }
+# }
+
 {
     name: commands_menu
     only_buffer_difference: false

--- a/custom-menus/extra/commands.nu
+++ b/custom-menus/extra/commands.nu
@@ -1,0 +1,21 @@
+{
+    name: commands_menu
+    only_buffer_difference: false
+    marker: "# "
+    type: {
+        layout: columnar
+        columns: 4
+        col_width: 20
+        col_padding: 2
+    }
+    style: {
+        text: green
+        selected_text: green_reverse
+        description_text: yellow
+    }
+    source: { |buffer, position|
+        scope commands
+        | where name =~ $buffer
+        | each { |it| {value: $it.name description: $it.usage} }
+    }
+}

--- a/custom-menus/extra/commands_with_description.nu
+++ b/custom-menus/extra/commands_with_description.nu
@@ -1,0 +1,23 @@
+{
+    name: commands_with_description_menu
+    only_buffer_difference: true
+    marker: "# "
+    type: {
+        layout: description
+        columns: 4
+        col_width: 20
+        col_padding: 2
+        selection_rows: 4
+        description_rows: 10
+    }
+    style: {
+        text: green
+        selected_text: green_reverse
+        description_text: yellow
+    }
+    source: { |buffer, position|
+        scope commands
+        | where name =~ $buffer
+        | each { |it| {value: $it.name description: $it.usage} }
+    }
+}

--- a/custom-menus/extra/commands_with_description.nu
+++ b/custom-menus/extra/commands_with_description.nu
@@ -1,3 +1,12 @@
+# can be used in the REPL by adding something like the following block to `$env.config.keybindings` in your `config.nu`
+# {
+#     name: commands_with_description_menu
+#     modifier: control
+#     keycode: char_s
+#     mode: [emacs, vi_normal, vi_insert]
+#     event: { send: menu name: commands_with_description }
+# }
+
 {
     name: commands_with_description_menu
     only_buffer_difference: true

--- a/custom-menus/extra/vars.nu
+++ b/custom-menus/extra/vars.nu
@@ -1,3 +1,12 @@
+# can be used in the REPL by adding something like the following block to `$env.config.keybindings` in your `config.nu`
+# {
+#     name: vars_menu
+#     modifier: alt
+#     keycode: char_o
+#     mode: [emacs, vi_normal, vi_insert]
+#     event: { send: menu name: vars_menu }
+# }
+
 {
     name: vars_menu
     only_buffer_difference: true

--- a/custom-menus/extra/vars.nu
+++ b/custom-menus/extra/vars.nu
@@ -1,0 +1,20 @@
+{
+    name: vars_menu
+    only_buffer_difference: true
+    marker: "# "
+    type: {
+        layout: list
+        page_size: 10
+    }
+    style: {
+        text: green
+        selected_text: green_reverse
+        description_text: yellow
+    }
+    source: { |buffer, position|
+        scope variables
+        | where name =~ $buffer
+        | sort-by name
+        | each { |it| {value: $it.name description: $it.type} }
+    }
+}


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/9676#discussion_r1262948758

in this PR, i just move the *extra* menus from the `default_config.nu` configuration file of Nushell into the `custom-menus/extra/` directory.

and i've also added the bindings from https://github.com/nushell/nushell/pull/9676 in 71516ba as notes inline.