### PR TITLE
make the release note TODOs HTML comments

### DIFF
--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -27,19 +27,19 @@ As part of this release, we also publish a set of optional plugins you can insta
 ## New theme ([author](https://github.com/nushell/nushell/pulls))
 
 # Breaking changes
-{{ TODO
+<!-- TODO
     paste the output of
     ```nu
     ./make_release/release-note/list-merged-prs nushell/nushell --label breaking-change --pretty --no-author
     ```
     here
-}}
+-->
 
 # Full changelog
-{{ TODO
+<!-- TODO
     paste the output of
     ```nu
     ./make_release/release-note/get-full-changelog
     ```
     here
-}}
+-->


### PR DESCRIPTION
should close #556 

## description
as we can see in https://github.com/nushell/nushell.github.io/pull/966, https://github.com/nushell/nushell.github.io/pull/966/commits/356df01d5391fa34f00ca43fecc07c69388b23df preserves the CI being green.

this PR implements the same fix into the release note template document for the next releases not to break the CI of the website again :relieved: 