### PR TITLE
Update some benchmarks. Re-port the gradient benchmark

### DIFF
--- a/benchmarks/gradient-old.nu
+++ b/benchmarks/gradient-old.nu
@@ -1,0 +1,41 @@
+# this script will print a blue gradient on the screen
+
+# We can get the terminal width and height now with term size
+# but we like to use the script as a benchmark, so let's keep
+# it a constant size for now
+let height = 40 # really need to get the terminal height here
+let width = 160  # really need to get the terminal width here
+let stamp = 'Nu'
+seq 0 $height | each { |row|
+    let row_data = (seq 0 $width | each { |col|
+        let fgcolor = (iter_inc 2 2 $col)
+        if $fgcolor > 200 and $fgcolor < 210 {
+            $"(ansi -e '48;2;0;0;')($fgcolor)m($stamp)(ansi -e '0m')"
+        } else {
+            $"(ansi -e '48;2;0;0;')($fgcolor)m(char sp)(ansi -e '0m')"
+        }
+    } | str join)
+    print -n $"($row_data)(char newline)"
+} | str join
+
+def iter_inc [incr mult iter] {
+    $incr + $mult * $iter
+}
+
+
+# ╭────────────────────┬──────────────────────────────────────────────────────╮
+# │ version            │ 0.1.0                                                │
+# │ branch             │ main                                                 │
+# │ short_commit       │ ec94ca46                                             │
+# │ commit_hash        │ ec94ca46bb64f3aa95f1366d76d60da2ddc53782             │
+# │ commit_date        │ 2022-01-24 19:45:20 +00:00                           │
+# │ build_os           │ windows-x86_64                                       │
+# │ rust_version       │ rustc 1.58.1 (db9d1b20b 2022-01-20)                  │
+# │ rust_channel       │ stable-x86_64-pc-windows-msvc                        │
+# │ cargo_version      │ cargo 1.58.0 (f01b232bc 2022-01-19)                  │
+# │ pkg_version        │ 0.1.0                                                │
+# │ build_time         │ 2022-01-24 15:04:00 -06:00                           │
+# │ build_rust_channel │ debug                                                │
+# │ features           │ dataframe, default, which, zip                       │
+# │ installed_plugins  │ gstat, inc, nu-example-1, nu-example-2, nu-example-3 │
+# ╰────────────────────┴──────────────────────────────────────────────────────╯

--- a/benchmarks/gradient.nu
+++ b/benchmarks/gradient.nu
@@ -1,41 +1,37 @@
-# this script will print a blue gradient on the screen
+# height = 40
+# width = 160
+# stamp = "py"
 
-# We can get the terminal width and height now with term size
-# but we like to use the script as a benchmark, so let's keep
-# it a constant size for now
-let height = 40 # really need to get the terminal height here
-let width = 160  # really need to get the terminal width here
-let stamp = 'Nu'
-seq 0 $height | each { |row|
-    let row_data = (seq 0 $width | each { |col|
-        let fgcolor = (iter_inc 2 2 $col)
+# for line in range(0, height):
+#     row_data = ""
+
+#     for col in range(0, width):
+#         fgcolor = 2 + 2 * col
+#         if fgcolor > 200 and fgcolor < 210:
+#             row_data = row_data + color(stamp, bg='rgb(0, 0, %d)' % fgcolor)
+#         else:
+#             fg = fgcolor % 256
+#             row_data = row_data + color(' ', bg='rgb(0, 0, %d)' % fg)
+
+#     print(row_data)
+
+const height = 40
+const width = 160
+const stamp = "Nu"
+
+for line in 0..$height {
+    mut row_data = ""
+
+    for col in 0..$width {
+        let fgcolor = 2 + 2 * $col
+
         if $fgcolor > 200 and $fgcolor < 210 {
-            $"(ansi -e '48;2;0;0;')($fgcolor)m($stamp)(ansi -e '0m')"
+            $row_data += $"(ansi -e '48;2;0;0;')($fgcolor)m($stamp)(ansi -e '0m')"
         } else {
-            $"(ansi -e '48;2;0;0;')($fgcolor)m(char sp)(ansi -e '0m')"
+            let fg = $fgcolor mod 256
+            $row_data += $"(ansi -e '48;2;0;0;')($fg)m (ansi -e '0m')"
         }
-    } | str join)
-    print -n $"($row_data)(char newline)"
-} | str join
+    }
 
-def iter_inc [incr mult iter] {
-    $incr + $mult * $iter
+    print $row_data
 }
-
-
-# ╭────────────────────┬──────────────────────────────────────────────────────╮
-# │ version            │ 0.1.0                                                │
-# │ branch             │ main                                                 │
-# │ short_commit       │ ec94ca46                                             │
-# │ commit_hash        │ ec94ca46bb64f3aa95f1366d76d60da2ddc53782             │
-# │ commit_date        │ 2022-01-24 19:45:20 +00:00                           │
-# │ build_os           │ windows-x86_64                                       │
-# │ rust_version       │ rustc 1.58.1 (db9d1b20b 2022-01-20)                  │
-# │ rust_channel       │ stable-x86_64-pc-windows-msvc                        │
-# │ cargo_version      │ cargo 1.58.0 (f01b232bc 2022-01-19)                  │
-# │ pkg_version        │ 0.1.0                                                │
-# │ build_time         │ 2022-01-24 15:04:00 -06:00                           │
-# │ build_rust_channel │ debug                                                │
-# │ features           │ dataframe, default, which, zip                       │
-# │ installed_plugins  │ gstat, inc, nu-example-1, nu-example-2, nu-example-3 │
-# ╰────────────────────┴──────────────────────────────────────────────────────╯

--- a/benchmarks/gradient_benchmark.nu
+++ b/benchmarks/gradient_benchmark.nu
@@ -7,10 +7,9 @@ def iter_inc [incr mult iter] {
 let is_release = (input "Did you compile in a release mode? y/n ")
 
 if ($is_release | str downcase | str trim) == "y" {
-
     print $"running test 0 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
     # 0. this has wrong output
-    let 0 = (seq 10 | timeit {
+    let 0 = (seq 1 10 | each { timeit {
         let height = 40
         let width = 160
         let stamp = 'Nu'
@@ -25,12 +24,12 @@ if ($is_release | str downcase | str trim) == "y" {
             } | str join)
             $"($row_data)(char newline)"
         } | str join
-    } | math avg)
+    }} | math avg)
 
 
     print $"running test 1 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
     # 1. Fixed newline to fix the output (char cr)
-    let 1 = (seq 10 | timeit {
+    let 1 = (seq 1 10 | each { timeit {
         let height = 40
         let width = 160
         let stamp = 'Nu'
@@ -45,11 +44,11 @@ if ($is_release | str downcase | str trim) == "y" {
             } | str join)
             $"($row_data)(char cr)"
         } | str join
-    } | math avg)
+    }} | math avg)
 
     print $"running test 2 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
     # 2. Replace (char sp) with just space
-    let 2 = (seq 10 | timeit {
+    let 2 = (seq 1 10 | each { timeit {
         let height = 40
         let width = 160
         let stamp = 'Nu'
@@ -64,11 +63,11 @@ if ($is_release | str downcase | str trim) == "y" {
             } | str join)
             $"($row_data)(char cr)"
         } | str join
-    } | math avg)
+    }} | math avg)
 
     print $"running test 3 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
     # 3. Precompute (ansi -e '48;2;0;0;') and (ansi -e '0m') -- seems to be slower
-    let 3 = (seq 10 | timeit {
+    let 3 = (seq 1 10 | each { timeit {
         let height = 40
         let width = 160
         let stamp = 'Nu'
@@ -85,11 +84,11 @@ if ($is_release | str downcase | str trim) == "y" {
             } | str join)
             $"($row_data)(char cr)"
         } | str join
-    } | math avg)
+    }} | math avg)
 
     print $"running test 4 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
     # 4. Inline iter_inc call
-    let 4 = (seq 10 | timeit {
+    let 4 = (seq 1 10 | each { timeit {
         let height = 40
         let width = 160
         let stamp = 'Nu'
@@ -104,11 +103,11 @@ if ($is_release | str downcase | str trim) == "y" {
             } | str join)
             $"($row_data)(char cr)"
         } | str join
-    } | math avg)
+    }} | math avg)
 
     print $"running test 5 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
     # 5. Combine (char sp) substitution and iter_inc inlining
-    let 5 = (seq 10 | timeit {
+    let 5 = (seq 1 10 | each { timeit {
         let height = 40
         let width = 160
         let stamp = 'Nu'
@@ -123,11 +122,11 @@ if ($is_release | str downcase | str trim) == "y" {
             } | str join)
             $"($row_data)(char cr)"
         } | str join
-    } | math avg)
+    }} | math avg)
 
     print $"running test 6 at (date now |  date format '%Y-%m-%d %H:%M:%S.%3f')"
     # 6. The above with par-each outer loop (using par-each anywhere else breaks the output)
-    let 6 = (seq 10 | timeit {
+    let 6 = (seq 1 10 | each { timeit {
         let height = 40
         let width = 160
         let stamp = 'Nu'
@@ -142,11 +141,18 @@ if ($is_release | str downcase | str trim) == "y" {
             } | str join)
             $"($row_data)(char cr)"
         } | str join
-    } | math avg)
+    }} | math avg)
 
     print 'collating tests'
-    [ $0 $1 $2 $3 $4 $5 $6 ]
-
+    {
+        wrong_output: $0
+        newline: $1 
+        span: $2
+        precompute_ansi: $3
+        inline_call: $4
+        space_and_inline_call: $5
+        par_each: $6
+    }
 } else {
     print "Compile in a release mode!"
 }


### PR DESCRIPTION
This PR updates `gradient_benchmark` to be run correctly (before it had errors that was causing silent issues)

It also re-ports `gradient.nu` to work more closely to `gradient.py`