### PR TITLE
fix the date schedule in the release scripts

### DIFF
--- a/make_release/release-note/create-pr
+++ b/make_release/release-note/create-pr
@@ -50,19 +50,40 @@ def main [
     let body = $"Please add your new features and breaking changes to the release notes
 by opening PRs against the `release-notes-($version)` branch."
 
+    log info "creating release note from template"
+    let release_note = $env.CURRENT_FILE
+        | path dirname
+        | path join "template.md"
+        | open
+        | str replace --all --string "{{VERSION}}" $version
+
+    log info $"branch: ($branch)"
+    log info $"blog: ($blog_path | str replace $repo "" | path split | skip 1 | path join)"
+    log info $"title: ($title)"
+
+    match (["yes" "no"] | input list --fuzzy "Inspect the release note document? ") {
+        "yes" => { $release_note | explore },
+        "no" | "" | _ => {},
+    }
+
+    match (["no" "yes"] | input list --fuzzy "Open release note PR? ") {
+        "yes" => {},
+        "no" | "" | _ => {
+            log warning "aborting."
+            return
+        },
+    }
+
+    return
+
     log info "setting up nushell.github.io repo"
     git clone git@github.com:nushell/nushell.github.io $repo --origin nushell --branch main --single-branch
 
     log info "creating release branch"
     git -C $repo checkout -b $branch nushell/main
 
-    log info "creating release note from template"
-    $env.CURRENT_FILE
-    | path dirname
-    | path join "template.md"
-    | open
-    | str replace --all --string "{{VERSION}}" $version
-    | save --force $blog_path
+    log info "writing release note"
+    $release_note | save --force $blog_path
 
     log info "commiting release note"
     git -C $repo add $blog_path

--- a/make_release/release-note/create-pr
+++ b/make_release/release-note/create-pr
@@ -79,7 +79,7 @@ by opening PRs against the `release-notes-($version)` branch."
         error make --unspanned {
             msg: ([
                 $out.stderr
-                $"please open the PR manually from a browser (ansi blue_underline)($pr_url | ansi link --text 'here')(ansi reset)"
+                $"please open the PR manually from a browser (ansi blue_underline)($pr_url)(ansi reset)"
             ] | str join "\n")
         }
     }

--- a/make_release/release-note/get-full-changelog
+++ b/make_release/release-note/get-full-changelog
@@ -1,6 +1,8 @@
 #!/usr/bin/env nu
 
-def main [] {
+def main [
+    date?: datetime  # the date of the last release (default to 3 weeks ago, excluded)
+] {
     let list_merged_prs_script = (
         $env.CURRENT_FILE | path dirname | path join "list-merged-prs"
     )
@@ -18,7 +20,7 @@ def main [] {
     $changelogs | each {|changelog|
         [
             $"## ($changelog.title)"
-            (^$list_merged_prs_script $changelog.repo --pretty)
+            (^$list_merged_prs_script $changelog.repo --pretty $date)
         ] | str join "\n"
     }
     | str join "\n\n"

--- a/make_release/release-note/get-full-changelog
+++ b/make_release/release-note/get-full-changelog
@@ -1,7 +1,7 @@
 #!/usr/bin/env nu
 
 def main [
-    date?: datetime  # the date of the last release (default to 3 weeks ago, excluded)
+    date?: datetime  # the date of the last release (default to 4 weeks ago, excluded)
 ] {
     let list_merged_prs_script = (
         $env.CURRENT_FILE | path dirname | path join "list-merged-prs"

--- a/make_release/release-note/list-merged-prs
+++ b/make_release/release-note/list-merged-prs
@@ -17,6 +17,9 @@ def main [
 ] {
     let date = $date | default ((date now) - 4wk) | date format "%Y-%m-%d"
 
+    let since = (date now | date format %F | into datetime) - ($date | into datetime)
+    log info $"listing PRs in ($repo) since ($date) \(($since) ago\)"
+
     let query = if $label == null {
         $"merged:>($date)"
     } else {

--- a/make_release/release-note/list-merged-prs
+++ b/make_release/release-note/list-merged-prs
@@ -10,12 +10,12 @@ def md-link [
 # list all merged PRs since last release
 def main [
     repo: string  # the name of the repo, e.g. `nushell/nushell`
-    date?: datetime  # the date of the last release (default to 3 weeks ago, excluded)
+    date?: datetime  # the date of the last release (default to 4 weeks ago, excluded)
     --label: string  # the label to filter the PRs by, e.g. `good-first-issue`
     --pretty: bool  # pretty-print for the MarkDown release not
     --no-author: bool  # do not group the contributions by author
 ] {
-    let date = $date | default ((date now) - 3wk + 1day) | date format "%Y-%m-%d"
+    let date = $date | default ((date now) - 4wk) | date format "%Y-%m-%d"
 
     let query = if $label == null {
         $"merged:>($date)"

--- a/make_release/release-note/list-merged-prs
+++ b/make_release/release-note/list-merged-prs
@@ -15,10 +15,7 @@ def main [
     --pretty: bool  # pretty-print for the MarkDown release not
     --no-author: bool  # do not group the contributions by author
 ] {
-    let date = (
-        if $date == null { (date now) - 3wk + 1day } else { $date }
-        | date format "%Y-%m-%d"
-    )
+    let date = $date | default ((date now) - 3wk + 1day) | date format "%Y-%m-%d"
 
     let query = if $label == null {
         $"merged:>($date)"


### PR DESCRIPTION
related
- https://github.com/nushell/nushell.github.io/pull/966

this PR
- allows to pass the date as an argument to `get-full-changelog`
- switches to a 4-week schedule by default
- remove the call to `ansi link` from *extra* in `list-merged-prs`
- show the date before printing in `list-merged-prs`
- in `create-pr`
    - show the title, the branch name...
    - ask the user if they want to `explore` the release note draft before opening the PR
    - ask the user for confirmation to open the PR on GitHub 