### PR TITLE
Specify that config versions need updating as well

### DIFF
--- a/make_release/Readme.md
+++ b/make_release/Readme.md
@@ -25,7 +25,8 @@
 
 ## 1. Minor bump of the version ([example][nushell bump example])
 - [ ] bump the version with `sd 'version = "0.xx.1"' 'version = "0.xx+1.0"' **/Cargo.toml`
-- [ ] commit `Cargo.lock`
+- [ ] bump the version info in the default configs with  `sd 'version = 0.xx.1' 'version = 0.xx+1.0' **/*.nu`
+- [ ] Also commit `Cargo.lock` AFTER running a cargo command (or update via `sd 'version = "0.xx.1"' 'version = "0.xx+1.0"' **/Cargo.lock` assuming no other package carries that version specifier)
 
 ## 2. Tag the [`nushell`] repo
 > **Warning**  


### PR DESCRIPTION
Our default config files carry a version specifier as well to make diagnosis easier.

You need to update them with the version bump PR!