### PR TITLE
add a script to bump the version of Nushell

### DIFF
--- a/make_release/Readme.md
+++ b/make_release/Readme.md
@@ -24,9 +24,11 @@
 - [ ] bump the version on the Nushell side ([example with `reedline`][reedline pin example]) (reference the release notes for courtesy)
 
 ## 1. Minor bump of the version ([example][nushell bump example])
-- [ ] bump the version with `sd 'version = "0.xx.1"' 'version = "0.xx+1.0"' **/Cargo.toml`
-- [ ] bump the version info in the default configs with  `sd 'version = 0.xx.1' 'version = 0.xx+1.0' **/*.nu`
-- [ ] Also commit `Cargo.lock` AFTER running a cargo command (or update via `sd 'version = "0.xx.1"' 'version = "0.xx+1.0"' **/Cargo.lock` assuming no other package carries that version specifier)
+- [ ] in the repo of Nushell, run `/path/to/nu_scripts/make_release/bump-version.nu`
+- [ ] Also commit `Cargo.lock` AFTER running a Cargo command like `cargo check --workspace`
+
+> **Note**  
+> the `Cargo.lock` file can be updated via `sd 'version = "0.xx.1"' 'version = "0.xx+1.0"' **/Cargo.lock` assuming no other package carries that version specifier
 
 ## 2. Tag the [`nushell`] repo
 > **Warning**  
@@ -86,7 +88,10 @@
 - [ ] run `./make_release/release-note/create-pr 0.xx.0 ((date now) + 4wk | date format "%Y-%m-%d" | into datetime)`
 
 ## 8. Bump the version as development
-- [ ] bump the patch version on [`nushell`] ([example][nushell dev example])
+- [ ] bump the patch version on [`nushell`] ([example][nushell dev example]) by running
+```nushell
+/path/to/nu_scripts/make_release/bump-version.nu --patch
+```
 
 
 [reedline bump example]: https://github.com/nushell/reedline/pull/596/files

--- a/make_release/Readme.md
+++ b/make_release/Readme.md
@@ -27,9 +27,6 @@
 - [ ] in the repo of Nushell, run `/path/to/nu_scripts/make_release/bump-version.nu`
 - [ ] Also commit `Cargo.lock` AFTER running a Cargo command like `cargo check --workspace`
 
-> **Note**  
-> the `Cargo.lock` file can be updated via `sd 'version = "0.xx.1"' 'version = "0.xx+1.0"' **/Cargo.lock` assuming no other package carries that version specifier
-
 ## 2. Tag the [`nushell`] repo
 > **Warning**  
 > this is maybe the most critical step of the whole release process!!

--- a/make_release/bump-version.nu
+++ b/make_release/bump-version.nu
@@ -29,11 +29,7 @@ def main [
             | save --force $file.name
     }
 
-    let config_files = "crates"
-        | path join "nu-utils" "src" "sample_config" "default_{config,env}.nu"
-        | str expand
-
-    $config_files | each {|file|
+    "crates/nu-utils/src/sample_config/default_{config,env}.nu" | str expand | each {|file|
         log debug $"bumping ($file) from ($version) to ($new_version)"
         open --raw $file
             | str replace --all --string $'version = ($version)' $'version = ($new_version)'

--- a/make_release/bump-version.nu
+++ b/make_release/bump-version.nu
@@ -24,11 +24,15 @@ def main [
 
     ls **/Cargo.toml | each {|file|
         log debug $"bumping ($file.name) from ($version) to ($new_version)"
-        open --raw $file.name | str replace --all --string $'version = "($version)"' $'version = "($new_version)"' | save --force $file.name
+        open --raw $file.name
+            | str replace --all --string $'version = "($version)"' $'version = "($new_version)"'
+            | save --force $file.name
     }
     ls **/*.nu | each {|file|
         log debug $"bumping ($file.name) from ($version) to ($new_version)"
-        open --raw $file.name | str replace --all --string $'version = ($version)' $'version = ($new_version)' | save --force $file.name
+        open --raw $file.name
+            | str replace --all --string $'version = ($version)' $'version = ($new_version)'
+            | save --force $file.name
     }
 
     null

--- a/make_release/bump-version.nu
+++ b/make_release/bump-version.nu
@@ -1,0 +1,35 @@
+#!/usr/bin/env nu
+use std log
+
+# bump the minor or patch version of a Rust / Nushell project
+def main [
+    --patch: bool  # update the minor version instead of the minor
+]: nothing -> nothing {
+    let version = open Cargo.toml
+        | get package.version
+        | parse "{major}.{minor}.{patch}"
+        | into int major minor patch
+        | into record
+
+    let new_version = if $patch {
+        $version | update patch { $in + 1 }
+    } else {
+        $version | update minor { $in + 1 } | update patch { 0 }
+    }
+
+    let version = $version | transpose | get column1 | str join "."
+    let new_version = $new_version | transpose | get column1 | str join "."
+
+    log info $"bumping all packages and Nushell files in (open Cargo.toml | get package.name) from ($version) to ($new_version)"
+
+    ls **/Cargo.toml | each {|file|
+        log debug $"bumping ($file.name) from ($version) to ($new_version)"
+        open --raw $file.name | str replace --all --string $'version = "($version)"' $'version = "($new_version)"' | save --force $file.name
+    }
+    ls **/*.nu | each {|file|
+        log debug $"bumping ($file.name) from ($version) to ($new_version)"
+        open --raw $file.name | str replace --all --string $'version = ($version)' $'version = ($new_version)' | save --force $file.name
+    }
+
+    null
+}

--- a/make_release/bump-version.nu
+++ b/make_release/bump-version.nu
@@ -1,7 +1,7 @@
 #!/usr/bin/env nu
 use std log
 
-# bump the minor or patch version of a Rust / Nushell project
+# bump the minor or patch version of the Nushell project
 def main [
     --patch: bool  # update the minor version instead of the minor
 ]: nothing -> nothing {
@@ -28,11 +28,16 @@ def main [
             | str replace --all --string $'version = "($version)"' $'version = "($new_version)"'
             | save --force $file.name
     }
-    ls **/*.nu | each {|file|
-        log debug $"bumping ($file.name) from ($version) to ($new_version)"
-        open --raw $file.name
+
+    let config_files = "crates"
+        | path join "nu-utils" "src" "sample_config" "default_{config,env}.nu"
+        | str expand
+
+    $config_files | each {|file|
+        log debug $"bumping ($file) from ($version) to ($new_version)"
+        open --raw $file
             | str replace --all --string $'version = ($version)' $'version = ($new_version)'
-            | save --force $file.name
+            | save --force $file
     }
 
     null


### PR DESCRIPTION
this PR
- adds `make_release/bump-version.nu` to bump a version automatically, without even worrying about what the current version is
- updates the `Readme.md` of the release guide

Note that this script does not use the external `sd` command anymore.