### PR TITLE
minor changes to nu_conda.nu and nu_msvs.nu

### DIFF
--- a/modules/virtual_environments/nu_conda/README.md
+++ b/modules/virtual_environments/nu_conda/README.md
@@ -3,7 +3,7 @@ A simple module for activating and deactivating Conda environments.
 
 
 ## Prerequisites
-- [nushell](https://github.com/nushell/nushell) >= 0.73.0
+- [nushell](https://github.com/nushell/nushell) >= 0.83.0
 
 
 ## Installation
@@ -15,6 +15,7 @@ Put `nu_conda.nu` into the module folder of your nushell configuration workspace
 use nu_conda.nu         # activate module
 nu_conda activate py36  # activate a Conda environment, e.g. py36
 nu_conda deactivate     # deactivate the activated Conda environment
+nu_conda list           # list available environments, same as `$env.CONDA_ENVS`
 ```
 
 ## How It Works

--- a/modules/virtual_environments/nu_conda/nu_conda.nu
+++ b/modules/virtual_environments/nu_conda/nu_conda.nu
@@ -24,13 +24,13 @@ export-env {
 
 export def-env activate [name: string] {
   if ($env.CONDA_ROOT | is-empty) {
-    echo "Neither Conda nor Mamba is valid."
+    print "Neither Conda nor Mamba is valid."
     return
   }
 
-  if not $name in $env.CONDA_ENVS {
-    echo $"Environment ($name) is invalid. Available:"
-    echo $env.CONDA_ENVS
+  if not ($name in $env.CONDA_ENVS) {
+    print $"Environment ($name) is invalid. Available:"
+    print $env.CONDA_ENVS
     return
   }
 
@@ -46,13 +46,17 @@ export def-env activate [name: string] {
 
 export def-env deactivate [] {
   if ($env.CONDA_ROOT | is-empty) {
-    echo "Neither Conda nor Mamba is valid."
+    print "Neither Conda nor Mamba is valid."
     return
   }
 
   $env.CONDA_CURR = null
 
   load-env {Path: $env.CONDA_BASE_PATH, PATH: $env.CONDA_BASE_PATH}
+}
+
+export def-env list [] {
+  print $env.CONDA_ENVS
 }
 
 def update-path-linux [env_path: path] {

--- a/modules/virtual_environments/nu_msvs/README.md
+++ b/modules/virtual_environments/nu_msvs/README.md
@@ -3,7 +3,7 @@ A module for Using Microsoft Visual Studio (MSVS) command line tools from Nushel
 
 
 ## Prerequisites
-- [nushell](https://github.com/nushell/nushell) >= 0.73.0
+- [nushell](https://github.com/nushell/nushell) >= 0.83.0
 - [vswhere](https://github.com/microsoft/vswhere) standalone or comes with VS
 
 


### PR DESCRIPTION
1. feat(nu_conda): add `nu_conda list` to list available envs
2. fix: use `print` instead of `echo` to print warnings
3. doc: change minimum support version to 0.83.0

I was about to replace `let-env` with `$env.` in these two scripts to make them work with nushell 0.83.0, but then I found it was done by #543. Therefore, this PR is just a minor maintenance.