### PR TITLE
fix weather duration after latest nushell changes

### DIFF
--- a/modules/weather/get-weather.nu
+++ b/modules/weather/get-weather.nu
@@ -73,7 +73,7 @@ def get_weather_by_ip [locIdx: int, units: string, token: string] {
         let forecast = ($forecast_data.list | each {|day|
                     {
                         id: ($day.weather.0.id)
-                        dt: ($day.dt | into string | into datetime -z local | format date '%a, %b %e') #'%Y-%m-%d')
+                        dt: ($day.dt * 1_000_000_000 | into string | into datetime -z local | format date '%a, %b %e') #'%Y-%m-%d')
                         high: ($day.temp.max)
                         low: ($day.temp.min)
                     }


### PR DESCRIPTION
This PR fixes the weather script because `into datetime` changes how it handles timestamps. They have to be multiplied by 1_000_000_000 now.