### PR TITLE
add `$.type` to `package.nuon`

### DIFF
--- a/package.nuon
+++ b/package.nuon
@@ -4,4 +4,5 @@
     documentation: "https://github.com/nushell/nu_scripts/blob/main/README.md"
     license: "https://github.com/nushell/nu_scripts/blob/main/LICENSE"
     version: 0.1.0
+    type: "module"
 }


### PR DESCRIPTION
related to nushell/nupm#12

this PR adds `$.type` to `package.nuon` so that one can use `nupm install --path .` to install the `nu_scripts` :+1: 