### PR TITLE
Expand git completions

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -406,6 +406,14 @@ export extern "git tag" [
   --delete(-d): string@"nu-complete git tags"         # delete a tag
 ]
 
+# Prune all unreachable objects
+export extern "git prune" [
+  --dry-run(-n)                                       # dry run
+  --expire: string                                    # expire objects older than
+  --progress                                          # show progress
+  --verbose(-v)                                       # report all removed objects
+]
+
 # Start a binary search to find the commit that introduced a bug
 export extern "git bisect start" [
   bad?: string                 # a commit that has the bug

--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -365,6 +365,8 @@ export extern "git stash push" [
 
 # Unstash previously stashed changes
 export extern "git stash pop" [
+  stash?: string@"nu-complete git stash-list"          # stash to pop
+  --index(-i)                                          # try to reinstate not only the working tree's changes, but also the index's ones
 ]
 
 # List stashed changes

--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -345,17 +345,29 @@ export extern "git reflog" [
 
 # Stage files
 export extern "git add" [
+  --all(-A)                                           # add all files
+  --dry-run(-n)                                       # don't actually add the file(s), just show if they exist and/or will be ignored
+  --edit(-e)                                          # open the diff vs. the index in an editor and let the user edit it
+  --force(-f)                                         # allow adding otherwise ignored files
+  --interactive(-i)                                   # add modified contents in the working tree interactively to the index
   --patch(-p)                                         # interactively choose hunks to stage
+  --verbose(-v)                                       # be verbose
 ]
 
 # Delete file from the working tree and the index
 export extern "git rm" [
   -r                                                   # recursive
+  --force(-f)                                          # override the up-to-date check
+  --dry-run(-n)                                        # Don't actually remove any file(s)
+  --cached                                             # unstage and remove paths only from the index
 ]
 
 # Show the working tree status
 export extern "git status" [
-  --verbose(-v)                                       # verbose
+  --verbose(-v)                                       # be verbose
+  --short(-s)                                         # show status concisely
+  --branch(-b)                                        # show branch information
+  --show-stash                                        # show stash information
 ]
 
 # Stash changes for later


### PR DESCRIPTION
I've expanded the selection of completions that are offered, in particular

* `git add`
* `git rm`
* `git status`
* `git prune`

Additionally, 
* `git stash pop` will now give you completions for *which* stash you might want to pop
* `git add` will now give you a list of files you want to stage. This change is the one I'm least certain about, as I'm not super familiar with the language. If there's a nicer way let me know.
Example of current `git add ...` completion
![image](https://github.com/nushell/nu_scripts/assets/8009284/7ed5a73a-2cf5-4f1f-a689-cf6dd5d01753)
