### PR TITLE
Replace exa by eza aliases

### DIFF
--- a/aliases/eza/eza-aliases.nu
+++ b/aliases/eza/eza-aliases.nu
@@ -1,0 +1,6 @@
+export alias x = eza --icons
+export alias xa = eza --icons --all
+export alias xl	= eza --long
+export alias xla = eza --long --all
+export alias xt	= eza --icons --tree
+export alias xta = eza --icons --tree --all


### PR DESCRIPTION
exa is unmaintained and replaced by the active fork eza. See https://github.com/ogham/exa/issues/1243

I chose to keep `x` as the alias letter as I currently use `z` for zoxide. Let me know what you think!