### PR TITLE
add the `random-bytes` benchmark

### DIFF
--- a/benchmarks/random-bytes.nu
+++ b/benchmarks/random-bytes.nu
@@ -1,0 +1,10 @@
+def main [n: int]: nothing -> binary {
+    seq 1 ($n / 8 + 1)
+        | each { random integer }
+        | into binary
+        | enumerate
+        | reduce -f 0x[] {|it, acc|
+            $acc | bytes add $it.item
+        }
+        | first $n
+}

--- a/benchmarks/random-bytes.nu
+++ b/benchmarks/random-bytes.nu
@@ -1,4 +1,6 @@
-def main [n: int]: nothing -> binary {
+use std bench
+
+def "random bytes" [n: int]: nothing -> binary {
     seq 1 ($n / 8 + 1)
         | each { random integer }
         | into binary
@@ -8,3 +10,11 @@ def main [n: int]: nothing -> binary {
         }
         | first $n
 }
+
+let ns = [10, 100, 1_000, 10_000, 100_000]
+
+let report = $ns | each {|n|
+    bench { random bytes $n } --rounds 10 --pretty --verbose
+} | wrap time | merge ($ns | wrap n)
+
+$report


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/10263

this adds the following command to the benchmarks
```nushell
def "random bytes" [n: int]: nothing -> binary {
    seq 1 ($n / 8 + 1)
        | each { random integer }
        | into binary
        | enumerate
        | reduce -f 0x[] {|it, acc|
            $acc | bytes add $it.item
        }
        | first $n
}
```
and runs it a bunch of times.

## example output
```nushell
> nu benchmarks/random-bytes.nu
╭───┬──────────────────────────────────────┬────────╮
│ # │                 time                 │   n    │
├───┼──────────────────────────────────────┼────────┤
│ 0 │ 4ms 224µs 690ns +/- 748µs 111ns      │     10 │
│ 1 │ 3ms 943µs 418ns +/- 527µs 64ns       │    100 │
│ 2 │ 5ms 253µs 628ns +/- 503µs 133ns      │   1000 │
│ 3 │ 15ms 434µs 510ns +/- 538µs 919ns     │  10000 │
│ 4 │ 170ms 617µs 135ns +/- 3ms 747µs 98ns │ 100000 │
╰───┴──────────────────────────────────────┴────────╯
```