### PR TITLE
simplify `typeof` output

### DIFF
--- a/sourced/typeof.nu
+++ b/sourced/typeof.nu
@@ -4,20 +4,17 @@ def typeof [] {
     let raw_type = $data | describe
 
     match ($raw_type | str replace --regex "<.*" "") {
-        "list" => { {
-            type: "list"
-            items: ($raw_type | parse "list<{type}>" | get type.0)
-        } },
+        "list" => {
+            list: ($raw_type | parse "list<{type}>" | get type.0)
+        },
         "record" => {
-            type: "record"
-            fields: ($data | columns | each {|field| {
+            record: ($data | columns | each {|field| {
                 name: $field,
                 type: ($data | get $field | typeof)
             } } | transpose -rid)
         },
         "table" => {
-            type: "table"
-            columns: ($data | columns | each {|col| {
+            table: ($data | columns | each {|col| {
                 name: $col,
                 type: ($data | get $col | describe | parse "list<{type}>" | get type.0)
             } } | transpose -rid)
@@ -39,17 +36,16 @@ def simple_type [] {
 def list_type [] {
     use std assert
 
-    assert equal ([1 2 3] | typeof) {type: "list", items: "int"}
-    assert equal (["foo" "bar" "baz"] | typeof) {type: "list", items: "string"}
-    assert equal (["foo" 2 true] | typeof) {type: "list", items: "any"}
+    assert equal ([1 2 3] | typeof) {list: "int"}
+    assert equal (["foo" "bar" "baz"] | typeof) {list: "string"}
+    assert equal (["foo" 2 true] | typeof) {list: "any"}
 }
 
 #[test]
 def table_type [] {
     use std assert
     assert equal (ls | typeof) {
-        type: "table",
-        columns: {
+        table: {
             name: "string",
             type: "string",
             size: "filesize",
@@ -63,8 +59,7 @@ def table_type [] {
 def record_type [] {
     use std assert
     assert equal ($nu | typeof) {
-        type: "record",
-        fields: {
+        record: {
             default-config-dir: "string",
             config-path: "string",
             env-path: "string",
@@ -75,8 +70,7 @@ def record_type [] {
             temp-path: "string",
             pid: "int",
             os-info: {
-                type: "record",
-                fields: {
+                record: {
                     name: "string",
                     arch: "string",
                     family: "string",

--- a/sourced/typeof.nu
+++ b/sourced/typeof.nu
@@ -44,6 +44,7 @@ def list_type [] {
 #[test]
 def table_type [] {
     use std assert
+
     assert equal (ls | typeof) {
         table: {
             name: "string",
@@ -58,6 +59,7 @@ def table_type [] {
 #[test]
 def record_type [] {
     use std assert
+
     assert equal ($nu | typeof) {
         record: {
             default-config-dir: "string",


### PR DESCRIPTION
just after submitting #597, i had an idea to simplify the output of `typeof` but it was too late when i came back

## examples
### `ls | typeof`
#### before
```nushell
───────┬─────────────────
type   │table
       │────────┬────────
columns│name    │string
       │type    │string
       │size    │filesize
       │modified│date
       │────────┴────────
───────┴─────────────────
```

#### after
```nushell
─────┬─────────────────
     │────────┬────────
table│name    │string
     │type    │string
     │size    │filesize
     │modified│date
     │────────┴────────
─────┴─────────────────
```

### `open package.nuon | typeof`
#### before
```nushell
──────┬────────────────────
      │─────────────┬──────
record│name         │string
      │description  │string
      │documentation│string
      │license      │string
      │version      │string
      │type         │string
      │─────────────┴──────
──────┴────────────────────
```

#### after
```nushell
──────┬────────────────────
type  │record
      │─────────────┬──────
fields│name         │string
      │description  │string
      │documentation│string
      │license      │string
      │version      │string
      │type         │string
      │─────────────┴──────
──────┴────────────────────
```

### `$nu | typeof`
#### before
```nushell
──────┬───────────────────────────────────────────────
type  │record
      │──────────────────┬────────────────────────────
fields│default-config-dir│string
      │config-path       │string
      │env-path          │string
      │history-path      │string
      │loginshell-path   │string
      │plugin-path       │string
      │home-path         │string
      │temp-path         │string
      │pid               │int
      │                  │──────┬─────────────────────
      │os-info           │type  │record
      │                  │      │──────────────┬──────
      │                  │fields│name          │string
      │                  │      │arch          │string
      │                  │      │family        │string
      │                  │      │kernel_version│string
      │                  │      │──────────────┴──────
      │                  │──────┴─────────────────────
      │startup-time      │duration
      │is-interactive    │bool
      │is-login          │bool
      │current-exe       │string
      │──────────────────┴────────────────────────────
──────┴───────────────────────────────────────────────
```

#### after
```nushell
──────┬───────────────────────────────────────────────
      │──────────────────┬────────────────────────────
record│default-config-dir│string
      │config-path       │string
      │env-path          │string
      │history-path      │string
      │loginshell-path   │string
      │plugin-path       │string
      │home-path         │string
      │temp-path         │string
      │pid               │int
      │                  │──────┬─────────────────────
      │os-info           │      │──────────────┬──────
      │                  │record│name          │string
      │                  │      │arch          │string
      │                  │      │family        │string
      │                  │      │kernel_version│string
      │                  │      │──────────────┴──────
      │                  │──────┴─────────────────────
      │startup-time      │duration
      │is-interactive    │bool
      │is-login          │bool
      │current-exe       │string
      │──────────────────┴────────────────────────────
──────┴───────────────────────────────────────────────
```
