### PR TITLE
Change nu_conda list to output active status of environment as well (#604)

### DIFF
--- a/modules/virtual_environments/nu_conda/nu_conda.nu
+++ b/modules/virtual_environments/nu_conda/nu_conda.nu
@@ -56,7 +56,12 @@ export def-env deactivate [] {
 }
 
 export def-env list [] {
-  print $env.CONDA_ENVS
+  $env.CONDA_ENVS | 
+    flatten | 
+    transpose | 
+    rename name path | 
+    insert active { |it| $it.name == $env.CONDA_CURR } | 
+    move path --after active
 }
 
 def update-path-linux [env_path: path] {


### PR DESCRIPTION
Changes `nu_config list` command to show which conda environment is activated and outputs a pipeable output instead of just printing `$env.CONDA_ENVS`.

Modification example. Old:
```nu
➜ nu_conda list
╭──────┬─────────────────────────────────────╮
│ base │ /home/marchall/.anaconda3           │
│ data │ /home/marchall/.anaconda3/envs/data │
╰──────┴─────────────────────────────────────╯
```
New:
```nu
➜ nu_conda list
╭───┬──────┬────────┬─────────────────────────────────────╮
│ # │ name │ active │                path                 │
├───┼──────┼────────┼─────────────────────────────────────┤
│ 0 │ base │ false  │ /home/marchall/.anaconda3           │
│ 1 │ data │ true   │ /home/marchall/.anaconda3/envs/data │
╰───┴──────┴────────┴─────────────────────────────────────╯
```