### PR TITLE
Move `random/into decimal` to `random/into float`

### DIFF
--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -883,8 +883,8 @@ export def ktp [
             {
                 namespace: $x.namespace
                 name: $x.name
-                cpu: ($x.cpu| str substring ..-1 | into decimal)
-                mem: ($x.mem | str substring ..-2 | into decimal)
+                cpu: ($x.cpu| str substring ..-1 | into float)
+                mem: ($x.mem | str substring ..-2 | into float)
             }
         }
     } else {
@@ -893,8 +893,8 @@ export def ktp [
         | each {|x|
             {
                 name: $x.name
-                cpu: ($x.cpu| str substring ..-1 | into decimal)
-                mem: ($x.mem | str substring ..-2 | into decimal)
+                cpu: ($x.cpu| str substring ..-1 | into float)
+                mem: ($x.mem | str substring ..-2 | into float)
             }
         }
     }
@@ -905,10 +905,10 @@ export def ktno [] {
     kubectl top node | from ssv -a | rename name cpu pcpu mem pmem
     | each {|x| {
         name: $x.name
-        cpu: ($x.cpu| str substring ..-1 | into decimal)
-        cpu%: (($x.pcpu| str substring ..-1 | into decimal) / 100)
-        mem: ($x.mem | str substring ..-2 | into decimal)
-        mem%: (($x.pmem | str substring ..-1 | into decimal) / 100)
+        cpu: ($x.cpu| str substring ..-1 | into float)
+        cpu%: (($x.pcpu| str substring ..-1 | into float) / 100)
+        mem: ($x.mem | str substring ..-2 | into float)
+        mem%: (($x.pmem | str substring ..-1 | into float) / 100)
     } }
 }
 

--- a/modules/random-list/random-list.nu
+++ b/modules/random-list/random-list.nu
@@ -47,8 +47,8 @@ export def "random-list chars" [
     }
 }
 
-# Generate a random decimal list.
-export def "random-list decimal" [
+# Generate a random float list.
+export def "random-list float" [
     list_length: int, # A length of the list
     --range (-r): range # A range of the value
 ] {
@@ -57,7 +57,7 @@ export def "random-list decimal" [
     }
 
     1..$list_length | each {|it|
-        random decimal $range
+        random float $range
     }
 }
 

--- a/sourced/misc/password_generator/nupass.nu
+++ b/sourced/misc/password_generator/nupass.nu
@@ -102,7 +102,7 @@ def random-format-word [] {
         } else if $rint == 2 {
             ($it | str upcase)
         } else if $rint == 3 {
-            ($it | split chars | each {|c| if (random decimal) < 0.2 { $c | str upcase } else { $c }} | str join "")
+            ($it | split chars | each {|c| if (random float) < 0.2 { $c | str upcase } else { $c }} | str join "")
         } else {
             ($it | str downcase)
         }

--- a/sourced/temp.nu
+++ b/sourced/temp.nu
@@ -5,7 +5,7 @@ export def f-to-c [
      --round(-r): int = 2 # Digits of precision to round to
     ] {
     # (100°F − 32) × 5/9 = 37.778°C
-    let $n = if ($fahren | describe) == "float" {$fahren} else {$fahren | into decimal }
+    let $n = if ($fahren | describe) == "float" {$fahren} else {$fahren | into float }
     let celcius = ((( $n - 32.) * 5 / 9. ) | math round -p $round )
     $"($fahren) °F is ($celcius) °C"
 }
@@ -17,7 +17,7 @@ export def f-to-k [
     ] {
     # (100°F − 32) × 5/9 + 273.15 = 310.928K
 
-    let $n = if ($fahren | describe) == "float" {$fahren} else {$fahren | into decimal }
+    let $n = if ($fahren | describe) == "float" {$fahren} else {$fahren | into float }
     let kelvin = ((($n - 32) * 5 / 9 + 273.15)| math round -p $round )
     $"($fahren) °F is ($kelvin) °K"
 }
@@ -29,7 +29,7 @@ export def c-to-f [
     ] {
     # (100°C × 9/5) + 32 = 212°F
 
-    let $n = if ($celcius | describe) == "float" {$celcius} else {$celcius | into decimal }
+    let $n = if ($celcius | describe) == "float" {$celcius} else {$celcius | into float }
     let fahren = ((($n * 9 / 5) + 32) | math round -p $round )
     $"($celcius) °C is ($fahren) °F"
 }
@@ -42,7 +42,7 @@ export def c-to-k [
     # 100°C + 273.15 = 373.15K
 
 
-    let $n = if ($celcius | describe) == "float" {$celcius} else {$celcius | into decimal }
+    let $n = if ($celcius | describe) == "float" {$celcius} else {$celcius | into float }
     let kelvin = (($n + 273.15) | math round -p $round )
     $"($celcius) °C is ($kelvin) °K"
 }
@@ -54,7 +54,7 @@ export def k-to-f [
     ] {
     # (100K − 273.15) × 9/5 + 32 = -279.7°F
 
-    let $n = if ($kelvin | describe) == "float" {$kelvin} else {$kelvin | into decimal }
+    let $n = if ($kelvin | describe) == "float" {$kelvin} else {$kelvin | into float }
     let fahren = ((($n - 273.15) * 9 / 5 + 32) | math round -p $round )
     $"($kelvin) °K is ($fahren) °F"
 }
@@ -66,7 +66,7 @@ export def k-to-c [
     ] {
     # 100K − 273.15 = -173.1°C
 
-    let $n = if ($kelvin | describe) == "float" {$kelvin} else {$kelvin | into decimal }
+    let $n = if ($kelvin | describe) == "float" {$kelvin} else {$kelvin | into float }
     let celcius = (($n - 273.15) | math round -p $round )
     $"($kelvin) °K is ($celcius) °C"
 }


### PR DESCRIPTION
# Wait for `0.85` release (scheduled for 2023-09-19)

As we renamed those commands (the old ones will raise a deprecation warning) update the scripts.

`into decimal` -> `into float` (https://github.com/nushell/nushell/pull/9979)
`random decimal` -> `random float` (https://github.com/nushell/nushell/pull/10320)

- Move `random-list decimal` to `random-list float`
- Update kubernetes wrapper to `into float`
- Update temp script to `into float`
- Update `nupass` to `random float`
