### PR TITLE
Use 0.85 syntax in `direnv` module

### DIFF
--- a/hooks/direnv/config.nu
+++ b/hooks/direnv/config.nu
@@ -6,7 +6,7 @@ $env.config = {
     pre_prompt: [{
       code: "
         let direnv = (direnv export json | from json)
-        let direnv = if ($direnv | length) == 1 { $direnv } else { {} }
+        let direnv = if not ($direnv | is-empty) { $direnv } else { {} }
         $direnv | load-env
       "
     }]


### PR DESCRIPTION
To fix this error:
```
**  × Input type not supported.
    ╭─[/Users/m.manzanares/.config/nushell/config.nu:18:1]
 18 │       let direnv = (direnv export json | from json)
 19 │       let direnv = if ($direnv | length) == 1 { $direnv } else { {} }
    ·                        ───┬───   ───┬──
    ·                           │         ╰── only list, and table input data is supported
    ·                           ╰── input type: record
 20 │       $direnv | load-env
    ╰────**
```