### PR TITLE
Fix: Completions Broken '-s' flag in man-completions

### DIFF
--- a/custom-completions/man/man-completions.nu
+++ b/custom-completions/man/man-completions.nu
@@ -8,7 +8,7 @@ def "manpages" [] {
 	| par-each { ls $in | get name }
     | flatten
 	| path basename
-	| str replace -s ".gz" ""
+	| str replace ".gz" ""
 }
 
 export extern "man" [


### PR DESCRIPTION
With 85.0 the deprecated `-s` flag in `str replace` was removed because its matched against a substring automatically now.