### PR TITLE
Fix git-completions.nu

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -24,7 +24,7 @@ def "nu-complete git commits current branch" [] {
 
 # Yield local branches like `main`, `feature/typo_fix`
 def "nu-complete git local branches" [] {
-  ^git branch | lines | each { |line| $line | str replace '\* ' "" | str trim }
+  ^git branch | lines | each { |line| $line | str replace '* ' "" | str trim }
 }
 
 # Yield remote branches like `origin/main`, `upstream/feature-a`


### PR DESCRIPTION
The parsing of local git branches accidentally escaped an asterisks because it had been used as an regular expression in the past.