### PR TITLE
Add `str append`  to stdlib-candidate

### DIFF
--- a/stdlib-candidate/README.md
+++ b/stdlib-candidate/README.md
@@ -1,0 +1,4 @@
+# std-lib candidate
+
+This folder is where we can add scripts that might want to be in std-lib at some point. It can serve both as a holding place for scripts that are waiting on nushell changes, as well as a place to develop and discuss such scripts.
+

--- a/stdlib-candidate/str.nu
+++ b/stdlib-candidate/str.nu
@@ -1,0 +1,16 @@
+def "str append" [tail: string]: [string -> string, list<string> -> list<string>] {
+    let input = $in
+    match ($input | describe | str replace --regex '<.*' '') {
+        "string" => { $input ++ $tail },
+        "list" => { $input | each {|el| $el ++ $tail} },
+        _ => $input
+    }
+}
+def "str prepend" [head: string]: [string -> string, list<string> -> list<string>] {
+    let input = $in
+    match ($input | describe | str replace --regex '<.*' '') {
+        "string" => { $head ++ $input },
+        "list" => { $input | each {|el| $head ++ $el } },
+        _ => $input
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/nushell/nushell/issues/10486 I've added an stdlib-candidate folder where we can add scripts that might want to be in std-lib at some point. Currently it only contains `str append` and `str prepend` which work about how you'd expect. Thanks to @amtoine  for writing the initial function. I added a default branch that just returns the input unaltered so it can be used more easily in the middle of a pipe.