### PR TITLE
make_release: do not annotate boolean switches in public API

### DIFF
--- a/make_release/bump-version.nu
+++ b/make_release/bump-version.nu
@@ -3,7 +3,7 @@ use std log
 
 # bump the minor or patch version of the Nushell project
 def main [
-    --patch: bool  # update the minor version instead of the minor
+    --patch # update the minor version instead of the minor
 ]: nothing -> nothing {
     let version = open Cargo.toml
         | get package.version

--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -2,7 +2,7 @@ use std log
 
 def publish [
     crate: path # the path to the crate to publish.
-    --no-verify: bool # don’t verify the contents by building them. Can be useful for crates with a `build.rs`.
+    --no-verify # don’t verify the contents by building them. Can be useful for crates with a `build.rs`.
 ] {
     cd $crate
 

--- a/make_release/release-note/list-merged-prs
+++ b/make_release/release-note/list-merged-prs
@@ -13,8 +13,8 @@ def main [
     repo: string  # the name of the repo, e.g. `nushell/nushell`
     date?: datetime  # the date of the last release (default to 4 weeks ago, excluded)
     --label: string  # the label to filter the PRs by, e.g. `good-first-issue`
-    --pretty: bool  # pretty-print for the MarkDown release not
-    --no-author: bool  # do not group the contributions by author
+    --pretty # pretty-print for the MarkDown release not
+    --no-author # do not group the contributions by author
 ] {
     let date = $date | default ((date now) - 4wk) | format date "%Y-%m-%d"
 


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/10456
- https://github.com/nushell/nushell.github.io/pull/1071

## description
after the changes on boolean switches from https://github.com/nushell/nushell/pull/10456, we need to not annotate then with `: bool` when part of a public API.

this PR is required for https://github.com/nushell/nushell.github.io/pull/1071 to move forward.