### PR TITLE
make `list-merged-prs` a module and add template example

### DIFF
--- a/make_release/release-note/list-merged-prs
+++ b/make_release/release-note/list-merged-prs
@@ -9,7 +9,7 @@ def md-link [
 }
 
 # list all merged PRs since last release
-def main [
+export def main [
     repo: string  # the name of the repo, e.g. `nushell/nushell`
     date?: datetime  # the date of the last release (default to 4 weeks ago, excluded)
     --label: string  # the label to filter the PRs by, e.g. `good-first-issue`

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -44,6 +44,24 @@ As part of this release, we also publish a set of optional plugins you can insta
 ### Deprecated commands
 ### Removed commands
 
+<!-- NOTE: to start investigating the contributions of last release, i like to list them all in a raw table.
+    to achieve this, one can use the [`list-merged-prs` script from `nu_scripts`](https://github.com/nushell/nu_scripts/blob/main/make_release/release-note/list-merged-prs)
+    as follows:
+
+    ```nushell
+    use ./make_release/release-note/list-merged-prs
+
+    list-merged-prs nushell/nushell <last-release-date>
+        | where author != "app/dependabot"
+        | sort-by mergedAt
+        | update url {|it| $"[#($it.number)]\(($it.url)\)" }
+        | update author { $"[@($in)]\(https://github.com/($in)\)" }
+        | select author title url
+        | rename -c {url: pr}
+        | to md --pretty
+    ```
+-->
+
 # Breaking changes
 <!-- TODO:
     paste the output of


### PR DESCRIPTION
to help writing the release notes, i think being able to list all the PRs between the last two releases and format them directly to a raw table is really nice.
this PR
- `export`s the `main` command from `list-merged-prs`
- adds an example to the `template.md` file of the release notes

the example:
```nushell
use ./make_release/release-note/list-merged-prs

list-merged-prs nushell/nushell <last-release-date>
    | where author != "app/dependabot"
    | sort-by mergedAt
    | update url {|it| $"[#($it.number)]\(($it.url)\)" }
    | update author { $"[@($in)]\(https://github.com/($in)\)" }
    | select author title url
    | rename -c {url: pr}
    | to md --pretty
```
will dump all the PRs in a `table<author: string, title: string, pr: string>` in `md` format:
- `author` is a mardown link to the GitHub page of each author
- `title` is the title of the PRs
- `pr` is a markdown link to the GitHub page of each PR

this pipeline will omit the contributions from @app/dependabot.