### PR TITLE
add a few enhancements to the `create-pr` script for releases

### DIFF
--- a/make_release/release-note/create-pr
+++ b/make_release/release-note/create-pr
@@ -94,7 +94,8 @@ by opening PRs against the `release-notes-($version)` branch.
     }
 
     log info "setting up nushell.github.io repo"
-    git clone git@github.com:nushell/nushell.github.io $repo --origin nushell --branch main --single-branch
+    git clone https://github.com/nushell/nushell.github.io $repo --origin nushell --branch main --single-branch
+    git -C $repo remote set-url nushell --push ssh://github.com/nushell/nushell.github.io
 
     log info "creating release branch"
     git -C $repo checkout -b $branch nushell/main

--- a/make_release/release-note/create-pr
+++ b/make_release/release-note/create-pr
@@ -70,7 +70,18 @@ by opening PRs against the `release-notes-($version)` branch.
     log info $"title: ($title)"
 
     match (["yes" "no"] | input list --fuzzy "Inspect the release note document? ") {
-        "yes" => { $release_note | explore },
+        "yes" => {
+            if $env.EDITOR? == null {
+                error make --unspanned {
+                    msg: $"(ansi red_bold)$env.EDITOR is not defined(ansi reset)"
+                }
+            }
+
+            let temp_file = $nu.temp-path | path join $"(random uuid).md"
+            $release_note | save --force $temp_file
+            ^$env.EDITOR $temp_file
+            rm --recursive --force $temp_file
+        },
         "no" | "" | _ => {},
     }
 

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -16,7 +16,7 @@ Today, we're releasing version {{VERSION}} of Nu. This release adds...
 
 # Where to get it
 
-Nu {{VERSION}} is available as [pre-built binaries](https://github.com/nushell/nushell/releases/tag/{{VERSION}}.0) or from [crates.io](https://crates.io/crates/nu). If you have Rust installed you can install it using `cargo install nu`.
+Nu {{VERSION}} is available as [pre-built binaries](https://github.com/nushell/nushell/releases/tag/{{VERSION}}) or from [crates.io](https://crates.io/crates/nu). If you have Rust installed you can install it using `cargo install nu`.
 
 NOTE: The optional dataframe functionality is available by `cargo install nu --features=dataframe`.
 


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell.github.io/pull/1114

i had to use `create-pr` to open https://github.com/nushell/nushell.github.io/pull/1114 and i thought the script could be improved in a few ways
- the template had a hardcoded `.0` path version in the semver, this PR removes is so that the CLI argument can be a full semver, e.g. `0.87.0`
- switch from `explore` to `$env.EDITOR` to preview the completed template: because it's valid markdown, it looks better in an editor
- fetch the website repo with HTTP and push with SSH: this allows to not enter the password of an SSH key in the clone step