### PR TITLE
fix removed commands

### DIFF
--- a/benchmarks/random-bytes.nu
+++ b/benchmarks/random-bytes.nu
@@ -2,7 +2,7 @@ use std bench
 
 def "random bytes" [n: int]: nothing -> binary {
     seq 1 ($n / 8 + 1)
-        | each { random integer }
+        | each { random int }
         | into binary
         | enumerate
         | reduce -f 0x[] {|it, acc|

--- a/modules/fun/wordle.nu
+++ b/modules/fun/wordle.nu
@@ -8,7 +8,7 @@ export def main [
   --alternative_source(-a) : string = "https://raw.githubusercontent.com/charlesreid1/five-letter-words/master/sgb-words.txt" # Alternative link to provide as a word source
 ] {
   let words = (if ($alternative_source | str substring 0..4 | str contains "http") {http get $alternative_source} else {open $alternative_source} | from ssv -n)
-  let word = ($words | get (random integer 0..($words | length)) | get column1)
+  let word = ($words | get (random int 0..($words | length)) | get column1)
   if ((($words | each {|it| ($it.column1 | str length)}) | where $it != 5 | length) != 0 ) {
     echo $"(ansi rb)Warning:(ansi reset) The words list contains words that are not length 5"
   }

--- a/modules/random-list/random-list.nu
+++ b/modules/random-list/random-list.nu
@@ -82,7 +82,7 @@ export def "random-list dice" [
     }
 }
 
-# Generate a random int list.
+# Generate a random integer list.
 export def "random-list integer" [
     list_length: int # A length of the list
     --range (-r): range # A range of the value

--- a/modules/random-list/random-list.nu
+++ b/modules/random-list/random-list.nu
@@ -82,7 +82,7 @@ export def "random-list dice" [
     }
 }
 
-# Generate a random integer list.
+# Generate a random int list.
 export def "random-list integer" [
     list_length: int # A length of the list
     --range (-r): range # A range of the value
@@ -92,7 +92,7 @@ export def "random-list integer" [
     }
 
     1..$list_length | each {|it|
-        random integer $range
+        random int $range
     }
 }
 

--- a/modules/random-list/random-list.nu
+++ b/modules/random-list/random-list.nu
@@ -83,7 +83,7 @@ export def "random-list dice" [
 }
 
 # Generate a random integer list.
-export def "random-list integer" [
+export def "random-list int" [
     list_length: int # A length of the list
     --range (-r): range # A range of the value
 ] {

--- a/sourced/misc/password_generator/nupass.nu
+++ b/sourced/misc/password_generator/nupass.nu
@@ -40,7 +40,7 @@ export def main [
   let random_symbols = (1..$words | par-each { |i| $symbols | get-random-symbol $symbols $symbols_len } --threads $threads)
 
   # Get some random numbers 
-  let random_numbers = (1..$words | par-each { |i| (random integer 0..99) } --threads $threads)
+  let random_numbers = (1..$words | par-each { |i| (random int 0..99) } --threads $threads)
 
   # Print some vars if debug flag is set
   if $debug { 
@@ -68,7 +68,7 @@ export def main [
     return (($random_words ++ $random_symbols ++ $random_numbers | shuffle) | reduce { |it, acc| ($acc | into string) + ($it | into string) })
   } else if $variant == "alphanum" {
     # Combined random int and random word, reduce to string
-    return (0..($words - 1) | each { |it| (random integer 0..99 | into string) + ($random_words | get $it) } | reduce { |it, acc| $acc + $it })
+    return (0..($words - 1) | each { |it| (random int 0..99 | into string) + ($random_words | get $it) } | reduce { |it, acc| $acc + $it })
   } else if $variant == "alpha" {
     # Reduce random words only to string
     return ($random_words | reduce { |it, acc| $acc + $it })
@@ -89,14 +89,14 @@ def get-random-word [
     | wrap word
     | upsert len {|it| $it.word | str length}
     | where len <= ($wordlength)
-    | get (random integer 1..($numlines))
+    | get (random int 1..($numlines))
     | get word
 }
 
 # Function to format a word randomly
 def random-format-word [] {
     par-each {|it| 
-        let rint = (random integer 1..4)
+        let rint = (random int 1..4)
         if $rint == 1 {
             ($it | str capitalize)
         } else if $rint == 2 {
@@ -116,5 +116,5 @@ def get-random-symbol [
 ] {
     $symbolchars
     | split chars
-    | get (random integer 0..($symbolcharslen - 1))
+    | get (random int 0..($symbolcharslen - 1))
 }


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/10567
- https://github.com/nushell/nushell/pull/10668
- https://github.com/nushell/nushell/pull/10568

this PR removes mentions to removed commands from https://github.com/nushell/nushell/pull/10567, https://github.com/nushell/nushell/pull/10668 and https://github.com/nushell/nushell/pull/10568.

the main change has been introduced with
```nushell
sd 'random integer' 'random int' **/*.nu
```

running `rg "$nothing|random integer|to xml .* --pretty"` gives
- before
```
modules/random-list/random-list.nu
85:# Generate a random integer list.
95:        random integer $range

modules/fun/wordle.nu
11:  let word = ($words | get (random integer 0..($words | length)) | get column1)

benchmarks/random-bytes.nu
5:        | each { random integer }

sourced/misc/password_generator/ReadMe.md
84:Obviously you can just use the `random chars` or `random integers` commands but I like to have words I can read in my passwords, and I think those generated by this script have sufficient entropy.

sourced/misc/password_generator/nupass.nu
43:  let random_numbers = (1..$words | par-each { |i| (random integer 0..99) } --threads $threads)
71:    return (0..($words - 1) | each { |it| (random integer 0..99 | into string) + ($random_words | get $it) } | reduce { |it
, acc| $acc + $it })
92:    | get (random integer 1..($numlines))
99:        let rint = (random integer 1..4)
119:    | get (random integer 0..($symbolcharslen - 1))
```
- after
```
modules/random-list/random-list.nu
85:# Generate a random integer list.

sourced/misc/password_generator/ReadMe.md
84:Obviously you can just use the `random chars` or `random integers` commands but I like to have words I can read in my passwords, and I think those generated by this script have sufficient entropy.
```