### PR TITLE
fix: replace `-c ['name' 'connection']` by `--column { name: connection }`

### DIFF
--- a/modules/network/sockets/sockets.nu
+++ b/modules/network/sockets/sockets.nu
@@ -10,7 +10,7 @@ export def sockets [--abbreviate-java-class-paths (-j)] {
             | to text
             | detect columns
             | upsert 'pid' { |r| $r.pid | into int }
-            | rename -c ['name' 'connection']
+            | rename --column { name: connection }
             | reject 'command'
             | join-table (ps -l) 'pid' 'pid'
             | if $abbreviate_java_class_paths {


### PR DESCRIPTION
The documentation states that the flag `-c`/`--column` now takes a record as argument instead of an array: https://www.nushell.sh/commands/docs/rename.html#flags.

I have made the change, and you can check in a nu prompt that it works as intended:
```nu
let input = (^lsof +c 0xFFFF -i -n -P)
let header = ($input | lines
	| take 1
	| each { str downcase | str replace ' name$' ' name state' })
let body = ($input | lines
	| skip 1
	| each { str replace '([^)])$' '$1 (NONE)' | str replace ' \((.+)\)$' ' $1' })
[$header] | append $body
	| to text
	| detect columns
	| upsert 'pid' { |r| $r.pid | into int }
	| rename --column { name: connection }
```