### PR TITLE
Change uses of `size` to `str size`

### DIFF
--- a/sourced/misc/nu_defs.nu
+++ b/sourced/misc/nu_defs.nu
@@ -93,7 +93,7 @@ def 'nu-sloc' [] {
   let stats = (
     ls **/*.nu
       | select name
-      | insert lines { |it| open $it.name | size | get lines }
+      | insert lines { |it| open $it.name | str size | get lines }
       | insert blank {|s| $s.lines - (open $s.name | lines | find --regex '\S' | length) }
       | insert comments {|s| open $s.name | lines | find --regex '^\s*#' | length }
       | sort-by lines -r


### PR DESCRIPTION
Deprecation will be released with `0.87`
- https://github.com/nushell/nushell/pull/10772
Final removal in `0.88`
