### PR TITLE
null-stream.nu as stdlib-candidate

### DIFF
--- a/stdlib-candidate/null-stream.nu
+++ b/stdlib-candidate/null-stream.nu
@@ -1,0 +1,10 @@
+# Examples
+#     redirect to the null stream
+#     > echo foo out> (null-stream)
+def null-stream []: nothing -> string {
+    if $nu.os-info.name  == "windows" {
+        "NUL:"
+    } else {
+        "/dev/null"
+    }
+}


### PR DESCRIPTION
This is a way to redirect to a null stream with the same syntax regardless of platform.