### PR TITLE
add a command to get last release date in the release note template

### DIFF
--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -94,8 +94,16 @@ As usual, new release rhyms with changes to commands!
 
     ```nushell
     use ./make_release/release-note/list-merged-prs
+    use std clip
 
-    list-merged-prs nushell/nushell <last-release-date>
+    let last_release_date = gh api /repos/nushell/nushell/releases
+        | from json
+        | into datetime published_at
+        | get published_at
+        | sort
+        | last
+
+    let prs = list-merged-prs nushell/nushell $last_release_date
         | where author != "app/dependabot"
         | sort-by mergedAt
         | update url {|it| $"[#($it.number)]\(($it.url)\)" }
@@ -103,6 +111,8 @@ As usual, new release rhyms with changes to commands!
         | select author title url
         | rename -c {url: pr}
         | to md --pretty
+
+    $prs | to md --pretty | clip
     ```
 -->
 

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -96,7 +96,7 @@ As usual, new release rhyms with changes to commands!
     use ./make_release/release-note/list-merged-prs
     use std clip
 
-    let last_release_date = gh api /repos/nushell/nushell/releases
+    let last_release_date = ^gh api /repos/nushell/nushell/releases
         | from json
         | into datetime published_at
         | get published_at


### PR DESCRIPTION
this PR adds
```nushell
let last_release_date = ^gh api /repos/nushell/nushell/releases
    | from json
    | into datetime published_at
    | get published_at
    | sort
    | last
```
to the relaease note template to get the date of the last release and list the PRs from there to now.