### PR TITLE
rename `cmd parse` to `argx` to improve importing

### DIFF
--- a/modules/argx/argx.nu
+++ b/modules/argx/argx.nu
@@ -34,8 +34,8 @@ export def get-sign [cmd] {
     { switch: $s, name: $n, positional: ($p ++ $pr), rest: $r }
 }
 
-# "test -h [123 (3213 3)] 123 `a sdf` --cd --ef sadf -g" | cmd token
-export def "cmd token" [] {
+# "test -h [123 (3213 3)] 123 `a sdf` --cd --ef sadf -g" | token
+export def token [] {
     let s = ($in | split row '' | range 1..-2)
     let s = if ($s | last) == ' ' { $s } else { $s | append ' ' }
     mut par = []
@@ -76,8 +76,8 @@ export def "cmd token" [] {
     return $res
 }
 
-export def "cmd parse" [] {
-    let token = ($in | cmd token)
+export def parse [] {
+    let token = ($in | token)
     let sign = (get-sign $token.0)
     mut sw = ''
     mut pos = []

--- a/modules/git/git-v2.nu
+++ b/modules/git/git-v2.nu
@@ -1,4 +1,4 @@
-use cmd_parse.nu *
+use argx.nu
 
 def agree [
     prompt
@@ -632,7 +632,7 @@ export def remote_braches [] {
 }
 
 def "nu-complete git remote branches" [context: string, offset: int] {
-    let ctx = ($context | cmd parse)
+    let ctx = ($context | argx parse)
     let rb = (remote_braches)
     if ($ctx._args | length) < 3 {
         $rb | each {|x| {value: $x.1, description: $x.0} }

--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -1,4 +1,4 @@
-use cmd_parse.nu *
+use argx.nu
 
 export def ensure-cache-by-lines [cache path action] {
     let ls = (do -i { open $path | lines | length })
@@ -126,12 +126,12 @@ export def kgh [
 }
 
 def "nu-complete helm list" [context: string, offset: int] {
-    let ctx = ($context | cmd parse)
+    let ctx = ($context | argx parse)
     kgh -n $ctx.namespace? | each {|x| {value: $x.name  description: $x.updated} }
 }
 
 def "nu-complete helm charts" [context: string, offset: int] {
-    let ctx = ($context | cmd parse)
+    let ctx = ($context | argx parse)
     let path = ($ctx | get _pos.chart)
     let path = if ($path | is-empty) { '.' } else { $path }
     let paths = (do -i { ls $"($path)*" | each {|x| if $x.type == dir { $"($x.name)/"} else { $x.name }} })
@@ -378,21 +378,21 @@ def "nu-complete kube kind" [] {
 }
 
 def "nu-complete kube res" [context: string, offset: int] {
-    let ctx = ($context | cmd parse)
+    let ctx = ($context | argx parse)
     let kind = ($ctx | get _args.1)
     let ns = if ($ctx.namespace? | is-empty) { [] } else { [-n $ctx.namespace] }
     kubectl get $ns $kind | from ssv -a | get NAME
 }
 
 def "nu-complete kube res via name" [context: string, offset: int] {
-    let ctx = ($context | cmd parse)
+    let ctx = ($context | argx parse)
     let kind = ($env.KUBERNETES_RESOURCE_ABBR | get ($ctx | get _args.0 | str substring (-1..)))
     let ns = if ($ctx.namespace? | is-empty) { [] } else { [-n $ctx.namespace] }
     kubectl get $ns $kind | from ssv -a | get NAME
 }
 
 def "nu-complete kube jsonpath" [context: string] {
-    let ctx = ($context | cmd parse)
+    let ctx = ($context | argx parse)
     let kind = ($ctx | get _args.1)
     let res = ($ctx | get _args.2)
     let path = $ctx.jsonpath?
@@ -542,14 +542,14 @@ export def kgno [] {
 }
 
 def "nu-complete kube pods" [context: string, offset: int] {
-    let ctx = ($context | cmd parse)
+    let ctx = ($context | argx parse)
     let ns = (do -i { $ctx | get namespace })
     let ns = (spr [-n $ns])
     kubectl get $ns pods | from ssv -a | get NAME
 }
 
 def "nu-complete kube ctns" [context: string, offset: int] {
-    let ctx = ($context | cmd parse)
+    let ctx = ($context | argx parse)
     let ns = (do -i { $ctx | get namespace })
     let ns = (spr [-n $ns])
     let ctn = (do -i { $ctx | get container })
@@ -660,7 +660,7 @@ def "nu-complete port forward type" [] {
 }
 
 def "nu-complete kube port" [context: string, offset: int] {
-    let ctx = ($context | cmd parse)
+    let ctx = ($context | argx parse)
     let kind = ($ctx | get _args.1)
     let ns = if ($ctx.namespace? | is-empty) { [] } else { [-n $ctx.namespace] }
     let res = ($ctx | get _args.2)
@@ -689,7 +689,7 @@ export def kpf [
 }
 
 def "nu-complete kube cp" [cmd: string, offset: int] {
-    let ctx = ($cmd | str substring ..$offset | cmd parse)
+    let ctx = ($cmd | str substring ..$offset | argx parse)
     let p = ($ctx._args | get (($ctx._args | length) - 1))
     let ns = (do -i { $ctx | get namespace })
     let ns = (spr [-n $ns])


### PR DESCRIPTION
- imports `*` are unnecessary
- shorter names for easier reference in task scripts
- `cmd` is too common and may cause potential conflicts