### PR TITLE
add `clip` from standard library

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -20,6 +20,7 @@
   - [nvim](#nvim)
   - [progress\_bar](#progress_bar)
   - [rbenv](#rbenv)
+  - [system](#system)
   - [virtual\_environments](#virtual_environments)
   - [weather](#weather)
   - [webscraping](#webscraping)
@@ -166,6 +167,12 @@ It is basically a join of the tables produced by the `lsof` command, and the nus
   
 ## [rbenv](./rbenv/)
 ??? (not sure how universal this is) This script provides minimal working rbenv setup.
+
+## [system](./system/)
+Currently holds the `clip` command which was previously incorrectly in the standard library of Nushell.
+```nushell
+use modules/system *  # will bring `clip` into scope
+```
 
 ## [virtual_environments](./virtual_environments/)
 The scripts in this directory activate virtual environments for Conda environments.

--- a/modules/system/mod.nu
+++ b/modules/system/mod.nu
@@ -1,0 +1,116 @@
+# print a command name as dimmed and italic
+def pretty-command [] {
+    let command = $in
+    return $"(ansi default_dimmed)(ansi default_italic)($command)(ansi reset)"
+}
+
+# give a hint error when the clip command is not available on the system
+def check-clipboard [
+    clipboard: string  # the clipboard command name
+    --system: string  # some information about the system running, for better error
+] {
+    if (which $clipboard | is-empty) {
+        error make --unspanned {
+            msg: $"(ansi red)clipboard_not_found(ansi reset):
+    you are running ($system)
+    but
+    the ($clipboard | pretty-command) clipboard command was not found on your system."
+        }
+    }
+}
+
+# put the end of a pipe into the system clipboard.
+#
+# Dependencies:
+#   - xclip on linux x11
+#   - wl-copy on linux wayland
+#   - clip.exe on windows
+#   - termux-api on termux
+#
+# Examples:
+#     put a simple string to the clipboard, will be stripped to remove ANSI sequences
+#     >_ "my wonderful string" | clip
+#     my wonderful string
+#     saved to clipboard (stripped)
+#
+#     put a whole table to the clipboard
+#     >_ ls *.toml | clip
+#     ╭───┬─────────────────────┬──────┬────────┬───────────────╮
+#     │ # │        name         │ type │  size  │   modified    │
+#     ├───┼─────────────────────┼──────┼────────┼───────────────┤
+#     │ 0 │ Cargo.toml          │ file │ 5.0 KB │ 3 minutes ago │
+#     │ 1 │ Cross.toml          │ file │  363 B │ 2 weeks ago   │
+#     │ 2 │ rust-toolchain.toml │ file │ 1.1 KB │ 2 weeks ago   │
+#     ╰───┴─────────────────────┴──────┴────────┴───────────────╯
+#
+#     saved to clipboard
+#
+#     put huge structured data in the clipboard, but silently
+#     >_ open Cargo.toml --raw | from toml | clip --silent
+#
+#     when the clipboard system command is not installed
+#     >_ "mm this is fishy..." | clip
+#     Error:
+#       × clipboard_not_found:
+#       │     you are using xorg on linux
+#       │     but
+#       │     the xclip clipboard command was not found on your system.
+export def clip [
+    --silent # do not print the content of the clipboard to the standard output
+    --no-notify  # do not throw a notification (only on linux)
+    --no-strip # do not strip ANSI escape sequences from a string
+    --expand (-e) # auto-expand the data given as input
+    --codepage (-c): int  # the id of the codepage to use (only on Windows), see https://en.wikipedia.org/wiki/Windows_code_page, e.g. 65001 is for UTF-8
+] {
+    let input = (
+        $in
+        | if $expand { table --expand } else { table }
+        | into string
+        | if $no_strip {} else { ansi strip }
+    )
+
+    match $nu.os-info.name {
+        "linux" => {
+            if ($env.WAYLAND_DISPLAY? | is-empty) {
+                check-clipboard xclip --system $"('xorg' | pretty-command) on linux"
+                $input | xclip -sel clip
+            } else {
+                check-clipboard wl-copy --system $"('wayland' | pretty-command) on linux"
+                $input | wl-copy
+            }
+        },
+        "windows" => {
+            if $codepage != null {
+                chcp $codepage
+            }
+            check-clipboard clip.exe --system "Windows"
+            $input | clip.exe
+        },
+        "macos" => {
+            check-clipboard pbcopy --system "MacOS"
+            $input | pbcopy
+        },
+        "android" => {
+            check-clipboard termux-clipboard-set --system "Termux"
+            $input | termux-clipboard-set
+        },
+        _ => {
+            error make --unspanned {
+                msg: $"(ansi red)unknown_operating_system(ansi reset):
+    '($nu.os-info.name)' is not supported by the ('clip' | pretty-command) command.
+
+    please open a feature request in the [issue tracker](char lparen)https://github.com/nushell/nushell/issues/new/choose(char rparen) to add your operating system to the standard library."
+            }
+        },
+    }
+
+    if not $silent {
+        print $input
+        print $"(ansi white_italic)(ansi white_dimmed)saved to clipboard(ansi reset)"
+    }
+
+    if (not $no_notify) and ($nu.os-info.name == linux) {
+        notify-send "std clip" "saved to clipboard"
+    }
+}
+


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/11097

## description
this PR is a companion to https://github.com/nushell/nushell/pull/11097 and moves the `std clip` command from the standard library to the new `modules/system` directory module.

a [new section](https://github.com/amtoine/nu_scripts/tree/move-clip-from-std/modules#system) has been added to the README of `modules/`.