### PR TITLE
nu-complete kube deploys and pods

### DIFF
--- a/modules/docker/docker.nu
+++ b/modules/docker/docker.nu
@@ -7,30 +7,14 @@ export-env {
     }
 }
 
-def sprb [flag, args] {
-    if $flag {
-        $args
-    } else {
-        []
-    }
-}
-
-def spr [args] {
-    let lst = ($args | last)
-    if ($lst | is-empty) {
-        []
-    } else {
-        let init = ($args | range ..-2)
-        if ($init | is-empty) {
-            [ $lst ]
-        } else {
-            $init | append $lst
-        }
+def --wrapped with-flag [...ns] {
+    if ($in | is-empty) { [] } else {
+        [$ns $in] | flatten
     }
 }
 
 def local_image [name] {
-    let s = ($name | split row '/')
+    let s = $name | split row '/'
     if ($s | length) > 1 {
         $name
     } else {
@@ -57,20 +41,20 @@ export def container-process-list [-n: string@"nu-complete docker ns"] {
         ^$cli ps -a --format '{"id":"{{.ID}}", "image": "{{.Image}}", "name":"{{.Names}}", "cmd":{{.Command}}, "port":"{{.Ports}}", "status":"{{.Status}}", "created":"{{.CreatedAt}}"}'
         | lines
         | each {|x|
-            let r = ($x | from json)
-            let t = ($r.created | str substring ..25 | into datetime -f '%Y-%m-%d %H:%M:%S %z' )
+            let r = $x | from json
+            let t = $r.created | str substring ..25 | into datetime -f '%Y-%m-%d %H:%M:%S %z'
             $r | upsert created $t
         }
     } else if $cli == 'podman' {
         ^$cli ps -a --format '{"id":"{{.ID}}", "image": "{{.Image}}", "name":"{{.Names}}", "cmd":"{{.Command}}", "port":"{{.Ports}}", "status":"{{.Status}}", "created":"{{.Created}}"}'
         | lines
         | each {|x|
-            let r = ($x | from json)
-            let t = ($r.created | str substring ..32 | into datetime )
+            let r = $x | from json
+            let t = $r.created | str substring ..32 | into datetime
             $r | upsert created $t
         }
     } else {
-        ^$cli (spr [-n $n]) ps -a
+        ^$cli ($n | with-flag -n) ps -a
         | from ssv
         | rename id image cmd created status port name
     }
@@ -78,13 +62,13 @@ export def container-process-list [-n: string@"nu-complete docker ns"] {
 
 # list images
 export def image-list [-n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) images
+    ^$env.docker-cli ($n | with-flag -n) images
     | from ssv -a
     | each {|x|
-        let size = ($x.SIZE | into filesize)
-        let path = ($x.REPOSITORY | split row '/')
-        let image = ($path | last)
-        let repo = ($path | range ..(($path|length) - 2) | str join '/')
+        let size = $x.SIZE | into filesize
+        let path = $x.REPOSITORY | split row '/'
+        let image = $path | last
+        let repo = $path | range ..(($path|length) - 2) | str join '/'
         {
             repo: $repo
             image: $image
@@ -134,7 +118,7 @@ export def container-log-namespace [ctn: string@"nu-complete docker container"
     -n: string@"nu-complete docker ns" # namespace
 ] {
     let l = if $l == 0 { [] } else { [--tail $l] }
-    ^$env.docker-cli (spr [-n $n]) logs -f $l $ctn
+    ^$env.docker-cli ($n | with-flag -n) logs -f $l $ctn
 }
 
 # attach container
@@ -143,7 +127,7 @@ export def container-attach [
     -n: string@"nu-complete docker ns"
     ...args
 ] {
-    let ns = (spr [-n $n])
+    let ns = $n | with-flag -n
     if ($args|is-empty) {
         ^$env.docker-cli $ns exec -it $ctn /bin/sh -c "[ -e /bin/zsh ] && /bin/zsh || [ -e /bin/bash ] && /bin/bash || /bin/sh"
     } else {
@@ -152,23 +136,21 @@ export def container-attach [
 }
 
 def "nu-complete docker cp" [cmd: string, offset: int] {
-    let argv = ($cmd | str substring ..$offset | split row ' ')
+    let argv = $cmd | str substring ..$offset | split row ' '
     let p = if ($argv | length) > 2 { $argv | get 2 } else { $argv | get 1 }
-    let ctn = (
-        ^$env.docker-cli ps
+    let ctn = ^$env.docker-cli ps
         | from ssv -a
         | each {|x| {description: $x.'CONTAINER ID' value: $"($x.NAMES):" }}
-    )
-    let n = ($p | split row ':')
+    let n = $p | split row ':'
     if $"($n | get 0):" in ($ctn | get value) {
         ^$env.docker-cli exec ($n | get 0) sh -c $"ls -dp ($n | get 1)*"
         | lines
         | each {|x| $"($n | get 0):($x)"}
     } else {
-        let files = (do -i {
+        let files = do -i {
             ls -a $"($p)*"
             | each {|x| if $x.type == dir { $"($x.name)/"} else { $x.name }}
-        })
+        }
         $files | append $ctn
     }
 }
@@ -183,62 +165,62 @@ export def container-copy-file [
 
 # remove container
 export def container-remove [ctn: string@"nu-complete docker all container" -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) container rm -f $ctn
+    ^$env.docker-cli ($n | with-flag -n) container rm -f $ctn
 }
 
 # inspect
 export def container-inspect [img: string@"nu-complete docker images" -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) inspect $img
+    ^$env.docker-cli ($n | with-flag -n) inspect $img
 }
 
 # history
 export def container-history [img: string@"nu-complete docker images" -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) history --no-trunc $img | from ssv -a
+    ^$env.docker-cli ($n | with-flag -n) history --no-trunc $img | from ssv -a
 }
 
 # save images
 export def image-save [-n: string@"nu-complete docker ns" ...img: string@"nu-complete docker images"] {
-    ^$env.docker-cli (spr [-n $n]) save $img
+    ^$env.docker-cli ($n | with-flag -n) save $img
 }
 
 # load images
 export def image-load [-n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) load
+    ^$env.docker-cli ($n | with-flag -n) load
 }
 
 # system prune
 export def system-prune [-n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) system prune -f
+    ^$env.docker-cli ($n | with-flag -n) system prune -f
 }
 
 # system prune all
 export def system-prune-all [-n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) system prune --all --force --volumes
+    ^$env.docker-cli ($n | with-flag -n) system prune --all --force --volumes
 }
 
 # remove image
 export def image-remove [img: string@"nu-complete docker images" -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) rmi $img
+    ^$env.docker-cli ($n | with-flag -n) rmi $img
 }
 
 # add new tag
 export def image-tag [from: string@"nu-complete docker images"  to: string -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) tag $from $to
+    ^$env.docker-cli ($n | with-flag -n) tag $from $to
 }
 
 # push image
 export def image-push [img: string@"nu-complete docker images" -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) push $img
+    ^$env.docker-cli ($n | with-flag -n) push $img
 }
 
 # pull image
 export def image-pull [img -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) pull $img
+    ^$env.docker-cli ($n | with-flag -n) pull $img
 }
 
 ### list volume
 export def volume-list [-n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) volume ls | from ssv -a
+    ^$env.docker-cli ($n | with-flag -n) volume ls | from ssv -a
 }
 
 def "nu-complete docker volume" [] {
@@ -247,17 +229,17 @@ def "nu-complete docker volume" [] {
 
 # create volume
 export def volume-create [name: string -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) volume create
+    ^$env.docker-cli ($n | with-flag -n) volume create
 }
 
 # inspect volume
 export def volume-inspect [name: string@"nu-complete docker volume" -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) volume inspect $name
+    ^$env.docker-cli ($n | with-flag -n) volume inspect $name
 }
 
 # remove volume
 export def volume-remove [...name: string@"nu-complete docker volume" -n: string@"nu-complete docker ns"] {
-    ^$env.docker-cli (spr [-n $n]) volume rm $name
+    ^$env.docker-cli ($n | with-flag -n) volume rm $name
 }
 
 ### run
@@ -275,7 +257,7 @@ def "nu-complete docker run sshkey" [ctx: string, pos: int] {
 }
 
 def "nu-complete docker run proxy" [] {
-    let hostaddr = (do -i { hostname -I | split row ' ' | get 0 })
+    let hostaddr = do -i { hostname -I | split row ' ' | get 0 }
     [ $"http://($hostaddr):7890" $"http://($hostaddr):" ]
 }
 
@@ -312,22 +294,22 @@ export def container-create [
     img: string@"nu-complete docker images"             # image
     ...cmd                                              # command args
 ] {
-    let ns = (spr [-n $namespace])
-    let entrypoint = (spr [--entrypoint $entrypoint])
+    let ns = $namespace | with-flag -n
+    let entrypoint = $entrypoint | with-flag --entrypoint
     let daemon = if $daemon { [-d] } else { [--rm -it] }
-    let mnt = (spr [-v $mnt])
-    let workdir = (spr [-w $workdir])
+    let mnt = $mnt | with-flag -v
+    let workdir = $workdir | with-flag -w
     let vols = if ($vols|is-empty) { [] } else { $vols | transpose k v | each {|x| [-v $"(host-path $x.k):($x.v)"]} | flatten }
     let envs = if ($envs|is-empty) { [] } else { $envs | transpose k v | each {|x| [-e $"($x.k)=($x.v)"]} | flatten }
     let ports = if ($ports|is-empty) { [] } else { $ports | transpose k v | each {|x| [-p $"($x.k):($x.v)"] } | flatten }
-    let debug = (sprb $debug [--cap-add=SYS_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined])
-    #let appimage = (sprb $appimage [--device /dev/fuse --security-opt apparmor:unconfined])
-    let privileged = (sprb $privileged [--privileged])
-    let appimage = (sprb $appimage [--device /dev/fuse])
-    let netadmin = (sprb $netadmin [--cap-add=NET_ADMIN --device /dev/net/tun])
-    let clip = (sprb $with_x [-e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix])
+    let debug = if $debug {[--cap-add=SYS_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined]} else {[]}
+    #let appimage = if $appimage {[--device /dev/fuse --security-opt apparmor:unconfined]} else {[]}
+    let privileged = if $privileged {[--privileged]} else {[]}
+    let appimage = if $appimage {[--device /dev/fuse]} else {[]}
+    let netadmin = if $netadmin {[--cap-add=NET_ADMIN --device /dev/net/tun]} else {[]}
+    let clip = if $with_x {[-e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix]} else {[]}
     let ssh = if ($ssh|is-empty) { [] } else {
-        let sshkey = (cat ([$env.HOME .ssh $ssh] | path join) | split row ' ' | get 1)
+        let sshkey = cat ([$env.HOME .ssh $ssh] | path join) | split row ' ' | get 1
         [-e $"ed25519_($sshuser)=($sshkey)"]
     }
     let proxy = if ($proxy|is-empty) { [] } else {
@@ -337,13 +319,13 @@ export def container-create [
         let c = $"container:($attach)"
         [--uts $c --ipc $c --pid $c --network $c]
     }
-    let cache = (spr [-v $cache])
-    let args = ([
+    let cache = $cache | with-flag -v
+    let args = [
         $privileged $entrypoint $attach $daemon
         $ports $envs $ssh $proxy
         $debug $appimage $netadmin $clip
         $mnt $vols $workdir $cache
-    ] | flatten)
+    ] | flatten
     let name = $"($img | split row '/' | last | str replace ':' '-')_(date now | format date %m%d%H%M)"
     if $dry_run {
         echo $"docker ($ns | str join ' ') run --name ($name) ($args|str join ' ') ($img) ($cmd | flatten)"
@@ -358,11 +340,11 @@ def has [name] {
 }
 
 def "nu-complete registry show" [cmd: string, offset: int] {
-    let new = ($cmd | str ends-with ' ')
-    let cmd = ($cmd | split row ' ')
-    let url = (do -i { $cmd | get 2 })
-    let reg = (do -i { $cmd | get 3 })
-    let tag = (do -i { $cmd | get 4 })
+    let new = $cmd | str ends-with ' '
+    let cmd = $cmd | split row ' '
+    let url = do -i { $cmd | get 2 }
+    let reg = do -i { $cmd | get 3 }
+    let tag = do -i { $cmd | get 4 }
     let auth = if ($env | has 'REGISTRY_TOKEN') {
         [authorization $"Basic ($env.REGISTRY_TOKEN)"]
     } else {

--- a/modules/kubernetes/kubernetes.nu
+++ b/modules/kubernetes/kubernetes.nu
@@ -541,20 +541,15 @@ export def kgno [] {
     | rename name status roles age version internal-ip external-ip os kernel runtime
 }
 
-def "nu-complete kube pods" [context: string, offset: int] {
+def "nu-complete kube deploys and pods" [context: string, offset: int] {
     let ctx = ($context | argx parse)
     let ns = (do -i { $ctx | get namespace })
     let ns = (spr [-n $ns])
-    kubectl get $ns pods | from ssv -a | get NAME
-}
-
-def "nu-complete kube pods or deploys" [context: string, offset: int] {
-    let ctx = ($context | argx parse)
-    let ns = (do -i { $ctx | get namespace })
-    let ns = (spr [-n $ns])
-    let pods = (kubectl $ns get pods -o name|lines)
-    let deploys = (kubectl $ns get deploy -o name|lines)
-    $pods | append $deploys
+    if ($ctx._pos.pod? | default '' | str ends-with '-') {
+        kubectl get $ns pods | from ssv -a | get NAME
+    } else {
+        kubectl get $ns deployments | from ssv -a | get NAME | each {|x| $"($x)-"}
+    }
 }
 
 def "nu-complete kube ctns" [context: string, offset: int] {
@@ -610,14 +605,20 @@ export def kdp [
 
 # kubectl attach (exec -it)
 export def ka [
-    pod?: string@"nu-complete kube pods or deploys"
+    pod?: string@"nu-complete kube deploys and pods"
     --namespace (-n): string@"nu-complete kube ns"
     --container(-c): string@"nu-complete kube ctns"
     --selector(-l): string
     ...args
 ] {
     let n = (spr [-n $namespace])
-    let pod = if ($selector | is-empty) { $pod } else {
+    let pod = if ($selector | is-empty) {
+        if ($pod | str ends-with '-') {
+            $"deployment/($pod | str substring ..-1)"
+        } else {
+            $pod
+        }
+        } else {
         let pods = (
             kubectl get pods $n -o wide -l $selector
             | from ssv -a
@@ -651,7 +652,7 @@ export def ka [
 
 # kubectl logs
 export def kl [
-    pod: string@"nu-complete kube pods or deploys"
+    pod: string@"nu-complete kube deploys and pods"
     --namespace(-n): string@"nu-complete kube ns"
     --container(-c): string@"nu-complete kube ctns"
     --follow(-f)
@@ -661,7 +662,12 @@ export def kl [
     let c = (spr [-c $container])
     let f = (sprb $follow [-f])
     let p = (sprb $previous [-p])
-    kubectl logs $n $f $p $pod $c
+    let trg = if ($pod | str ends-with '-') {
+        $"deployment/($pod | str substring ..-1)"
+        } else {
+            $pod
+        }
+    kubectl logs $n $f $p $trg $c
 }
 
 def "nu-complete port forward type" [] {
@@ -891,7 +897,8 @@ export def "kclean stucked ns" [ns: string] {
 
 export alias "kclean finalizer" = kubectl patch -p '{\"metadata\":{\"finalizers\":null}}'
 
-export alias "kadm renew" = kubeadm alpha certs renew all
+export alias "kadm check" = kubeadm certs check-expiration
+export alias "kadm renew" = kubeadm certs renew all
 
 ### cert-manager
 export def kgcert [] {


### PR DESCRIPTION
- update `kadm check` and `kadm renew`
- refactor `nu-complete kube pods or deploys` to `nu-complete kube deploys and pods`

in #680, `nu-complete kube pods` changed to `pods or deploys`, This has caused some problems:
- double the number of candidates, and candidates with prefix `pods/` and `deployment.apps/`, looks a little confused
- two requests in one completion, slower

i wrote `nu-complete kube deploys and pods`, it's completed in two stages
- first it will complete the `deployment` and add a suffix `-` when token not ends-with `-`
  - when `ka` or `kl` accepts an argument with suffix `-`, it'll be rewritten as `$"deployment/($pod | str substring ..-1)"`
- if token ends-with `-`, it's considered unfinished `pod` and continues
