### PR TITLE
fix release scripts

### DIFF
--- a/make_release/release-note/create-pr
+++ b/make_release/release-note/create-pr
@@ -12,11 +12,11 @@ def open-pr [
     >
 ] {
     cd $repo
-    gh repo set-default $remote
+    ^gh repo set-default $remote
 
     log info "mock up pr"
     (
-        gh pr create
+        ^gh pr create
             --head $pr.branch
             --base main
             --title $pr.title
@@ -112,7 +112,7 @@ by opening PRs against the `release-notes-($version)` branch.
     log info "pushing release note to nushell"
     git -C $repo push nushell $branch
 
-    let out = (do -i { gh auth status } | complete)
+    let out = (do -i { ^gh auth status } | complete)
     if $out.exit_code != 0 {
         clean $repo
 

--- a/make_release/release-note/get-full-changelog
+++ b/make_release/release-note/get-full-changelog
@@ -3,6 +3,8 @@
 def main [
     date?: datetime  # the date of the last release (default to 4 weeks ago, excluded)
 ] {
+    let date = $date | default ((date now) - 4wk) | format date "%Y-%m-%d"
+
     let list_merged_prs_script = (
         $env.CURRENT_FILE | path dirname | path join "list-merged-prs"
     )

--- a/make_release/release-note/gh-release-excerpt
+++ b/make_release/release-note/gh-release-excerpt
@@ -15,6 +15,17 @@ def main [
     let repo = "nushell/nushell"
     let query = $"merged:>($date)"
 
+    let gh_version = gh --version
+        | lines
+        | parse "gh version {version} ({date})"
+        | into record
+        | get version
+    if $gh_version != "2.38.0" {
+        error make --unspanned {
+            msg: $"expected gh version 2.38.0, found ($gh_version)"
+        }
+    }
+
     let prs = (
         gh --repo $repo pr list
             --state merged

--- a/make_release/release-note/gh-release-excerpt
+++ b/make_release/release-note/gh-release-excerpt
@@ -15,7 +15,7 @@ def main [
     let repo = "nushell/nushell"
     let query = $"merged:>($date)"
 
-    let gh_version = gh --version
+    let gh_version = ^gh --version
         | lines
         | parse "gh version {version} ({date})"
         | into record
@@ -27,7 +27,7 @@ def main [
     }
 
     let prs = (
-        gh --repo $repo pr list
+        ^gh --repo $repo pr list
             --state merged
             --limit (inf | into int)
             --json author,title,number,mergedAt,url

--- a/make_release/release-note/list-merged-prs
+++ b/make_release/release-note/list-merged-prs
@@ -27,7 +27,7 @@ export def main [
         $"merged:>($date) label:($label)"
     }
 
-    let gh_version = gh --version
+    let gh_version = ^gh --version
         | lines
         | parse "gh version {version} ({date})"
         | into record
@@ -39,7 +39,7 @@ export def main [
     }
 
     let prs = (
-        gh --repo $repo pr list
+        ^gh --repo $repo pr list
             --state merged
             --limit (inf | into int)
             --json author,title,number,mergedAt,url

--- a/make_release/release-note/list-merged-prs
+++ b/make_release/release-note/list-merged-prs
@@ -64,11 +64,12 @@ export def main [
             $prs
             | group-by author
             | transpose author prs
+            | sort-by --ignore-case author
             | each {|line|
                 let author = (md-link $line.author $"https://github.com/($line.author)")
 
                 $"- ($author) created" | append (
-                    $line.prs | each {|pr|
+                    $line.prs | sort-by number | each {|pr|
                         let link = (md-link $pr.title $pr.url)
                         $"    - ($link)"
                     }

--- a/make_release/release-note/list-merged-prs
+++ b/make_release/release-note/list-merged-prs
@@ -27,6 +27,17 @@ export def main [
         $"merged:>($date) label:($label)"
     }
 
+    let gh_version = gh --version
+        | lines
+        | parse "gh version {version} ({date})"
+        | into record
+        | get version
+    if $gh_version != "2.38.0" {
+        error make --unspanned {
+            msg: $"expected gh version 2.38.0, found ($gh_version)"
+        }
+    }
+
     let prs = (
         gh --repo $repo pr list
             --state merged

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -42,6 +42,8 @@ As part of this release, we also publish a set of optional plugins you can insta
     ```nushell
     rg '^#+ ' blog/...
         | lines
+        | where ($it | str ends-with " [[toc](#table-of-content)]")
+        | str replace " [[toc](#table-of-content)]" ''
         | each {
             str replace '# ' '- '
                 | str replace --all '#' '    '

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -40,10 +40,11 @@ As part of this release, we also publish a set of optional plugins you can insta
     the following command should help pre-generate a great deal of the table of content.
     be careful with the format and false-positives :wink:
     ```nushell
+    const TOC_MARKER = "[[toc](#table-of-content)]"
     rg '^#+ ' blog/...
         | lines
-        | where ($it | str ends-with " [[toc](#table-of-content)]")
-        | str replace " [[toc](#table-of-content)]" ''
+        | where ($it | str ends-with $" ($TOC_MARKER)")
+        | str replace $" ($TOC_MARKER)" ''
         | each {
             str replace '# ' '- '
                 | str replace --all '#' '    '

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -29,6 +29,7 @@ As part of this release, we also publish a set of optional plugins you can insta
     - [*Hall of fame*](#hall-of-fame-toc)
         - [*Bug fixes*](#bug-fixes-toc)
         - [*Enhancing the documentation*](#enhancing-the-documentation-toc)
+        - [*Working on internals*](#working-on-internals-toc)
     - [*Our set of commands is evolving*](#our-set-of-commands-is-evolving-toc)
         - [*New commands*](#new-commands-toc)
         - [*Changes to existing commands*](#changes-to-existing-commands-toc)
@@ -76,6 +77,12 @@ Thanks to all the contributors below for helping us solve issues and bugs :pray:
 
 ### Enhancing the documentation [[toc](#table-of-content)]
 Thanks to all the contributors below for helping us making the documentation of Nushell commands better :pray:
+| author                               | description | url                                                     |
+| ------------------------------------ | ----------- | ------------------------------------------------------- |
+| [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
+
+### Working on internals [[toc](#table-of-content)]
+Thanks to all the contributors below for working on internals of Nushell, such as refactoring the code :pray:
 | author                               | description | url                                                     |
 | ------------------------------------ | ----------- | ------------------------------------------------------- |
 | [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |


### PR DESCRIPTION
related to 
- https://github.com/nushell/nushell.github.io/pull/1146

## description
i was writing https://github.com/nushell/nushell.github.io/pull/1146 and trying to get the breaking changes and the full changelog when i hit a wall with `gh` and the `date?` of `get-full-changelog`...
this PR should fix them :eyes: 

### the bugs and their solution
- bad `gh` version (`2.39.2` from Nix) => fixed by 26356a5
```nushell
./make_release/release-note/list-merged-prs nushell/nushell --label breaking-change --pretty --no-author
```
will give
```
2023-12-09T14:49:58.977|INF|listing PRs in nushell/nushell since 2023-11-11 (4wk ago)
unknown argument "label:breaking-change"; please quote all values that have spaces

Usage:  gh pr list [flags]

Flags:
      --app string        Filter by GitHub App author
  -a, --assignee string   Filter by assignee
  -A, --author string     Filter by author
  -B, --base string       Filter by base branch
  -d, --draft             Filter by draft state
  -H, --head string       Filter by head branch
  -q, --jq expression     Filter JSON output using a jq expression
      --json fields       Output JSON with the specified fields
  -l, --label strings     Filter by label
  -L, --limit int         Maximum number of items to fetch (default 30)
  -S, --search query      Search pull requests with query
  -s, --state string      Filter by state: {open|closed|merged|all} (default "open")
  -t, --template string   Format JSON output using a Go template; see "gh help formatting"
  -w, --web               List pull requests in the web browser

Error: nu::shell::only_supports_this_input_type

  × Input type not supported.
    ╭─[/home/amtoine/documents/repos/github.com/amtoine/nu_scripts/make_release/release-note/list-merged-prs:30:1]
 30 │     let prs = (
 31 │         gh --repo $repo pr list
    ·         ─┬
    ·          ╰── input type: nothing
 32 │             --state merged
 33 │             --limit (inf | into int)
 34 │             --json author,title,number,mergedAt,url
 35 │             --search $query
 36 │         | from json
 37 │         | sort-by mergedAt --reverse
    ·           ───┬───
    ·              ╰── only list, binary, raw data or range input data is supported
 38 │         | update author { get login }
    ╰────
```
- no date to `get-full-changelog` => fixed by a69b947
```nushell
./make_release/release-note/get-full-changelog
```
will give
```
Error: nu::shell::eval_block_with_input

  × Eval block failed with pipeline input
    ╭─[/home/amtoine/documents/repos/github.com/amtoine/nu_scripts/make_release/release-note/get-full-changelog:9:1]
  9 │
 10 │ ╭─▶     let changelogs = [
 11 │ │           [title repo];
 12 │ │
 13 │ │           [Nushell nushell/nushell]
 14 │ │           [Extension nushell/vscode-nushell-lang]
 15 │ │           [Documentation nushell/nushell.github.io]
 16 │ │           [Nu_Scripts nushell/nu_scripts]
 17 │ │           [Reedline nushell/reedline]
 18 │ ├─▶     ]
    · ╰──── source value
 19 │
    ╰────

Error: nu::shell::external_command

  × External command failed
    ╭─[/home/amtoine/documents/repos/github.com/amtoine/nu_scripts/make_release/release-note/get-full-changelog:22:1]
 22 │             $"## ($changelog.title)"
 23 │             (^$list_merged_prs_script $changelog.repo --pretty $date)
    ·                                                                ──┬──
    ·                                                                  ╰── Cannot convert nothing to a string
 24 │         ] | str join "\n"
    ╰────
  help: All arguments to an external command need to be string-compatible
```
