### PR TITLE
fix: missing regex flag

### DIFF
--- a/aliases/git/git-aliases.nu
+++ b/aliases/git/git-aliases.nu
@@ -8,7 +8,7 @@ def git_main_branch [] {
         | str trim
         | find --regex 'HEAD .*?[：: ].+'
         | first
-        | str replace 'HEAD .*?[：: ](.+)' '$1'
+        | str replace --regex 'HEAD .*?[：: ](.+)' '$1'
 }
 
 #

--- a/aliases/git/git-aliases.nu
+++ b/aliases/git/git-aliases.nu
@@ -8,7 +8,7 @@ def git_main_branch [] {
         | str trim
         | find --regex 'HEAD .*?[：: ].+'
         | first
-        | str replace --regex 'HEAD .*?[：: ](.+)' '$1'
+        | str replace --regex 'HEAD .*?[：: ]\s*(.+)' '$1'
 }
 
 #


### PR DESCRIPTION
- `str replace` for git main branch alias is missing regex flag
- also missing removal of leading white space