### PR TITLE
:sparkles: add completion to `gh pr checkout <tab>`

### DIFF
--- a/custom-completions/gh/gh-completions.nu
+++ b/custom-completions/gh/gh-completions.nu
@@ -2,7 +2,7 @@
 def "nu-complete gh" [] {
     ^gh --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -16,7 +16,7 @@ export extern "gh" [
 def "nu-complete gh auth" [] {
     ^gh auth --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -43,7 +43,7 @@ export extern "gh browse" [
 def "nu-complete gh codespace" [] {
     ^gh codespace --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -57,7 +57,7 @@ export extern "gh codespace" [
 def "nu-complete gh gist" [] {
     ^gh gist --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -71,7 +71,7 @@ export extern "gh gist" [
 def "nu-complete gh issue" [] {
     ^gh issue --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -86,7 +86,7 @@ export extern "gh issue" [
 def "nu-complete gh org" [] {
     ^gh org --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -98,7 +98,7 @@ export extern "gh org" [
 ]
 
 def "nu-complete gh pr" [] {
-    ^gh pr --help | lines | filter {|line| str starts-with "  " } | skip 1 | parse "{value}: {description}" | str trim
+    ^gh pr --help | lines | filter { str starts-with "  " } | skip 1 | parse "{value}: {description}" | str trim
 }
 
 export extern "gh pr" [
@@ -108,16 +108,7 @@ export extern "gh pr" [
 ]
 
 def "nu-complete gh list prs" [] {
-    gh pr list --json title,number,author,updatedAt 
-    | from json 
-    | update author {|row| $row.author.login } 
-    | rename --column { number: value } 
-    | insert description {
-        |row| ( $row.updatedAt | date humanize) 
-        + " - " + $row.title 
-        + " by " + $row.author 
-        } 
-    | select value description
+    gh pr list --json title,number,author,updatedAt | from json | update author {|row| $row.author.login } | rename --column { number: value } | insert description { |row| ( $row.updatedAt | date humanize) + " - " + $row.title + " by " + $row.author } | select value description 
 }
 
 export extern "gh pr checkout" [
@@ -133,7 +124,7 @@ export extern "gh pr checkout" [
 def "nu-complete gh project" [] {
     ^gh project --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -147,7 +138,7 @@ export extern "gh project" [
 def "nu-complete gh release" [] {
     ^gh release --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -162,7 +153,7 @@ export extern "gh release" [
 def "nu-complete gh repo" [] {
     ^gh repo --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -231,7 +222,7 @@ export extern "gh repo fork" [
 def "nu-complete gh cache" [] {
     ^gh cache --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -246,7 +237,7 @@ export extern "gh cache" [
 def "nu-complete gh run" [] {
     ^gh run --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -260,7 +251,7 @@ export extern "gh run" [
 def "nu-complete gh workflow" [] {
     ^gh workflow --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -275,7 +266,7 @@ export extern "gh workflow" [
 def "nu-complete gh alias" [] {
     ^gh alias --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -324,7 +315,7 @@ export extern "gh completion" [
 def "nu-complete gh config" [] {
     ^gh config --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -338,7 +329,7 @@ export extern "gh config" [
 def "nu-complete gh extension" [] {
     ^gh extension --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -352,7 +343,7 @@ export extern "gh extension" [
 def "nu-complete gh gpg-key" [] {
     ^gh gpg-key --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -366,7 +357,7 @@ export extern "gh gpg-key" [
 def "nu-complete gh label" [] {
     ^gh label --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -381,7 +372,7 @@ export extern "gh label" [
 def "nu-complete gh ruleset" [] {
     ^gh ruleset --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -396,7 +387,7 @@ export extern "gh ruleset" [
 def "nu-complete gh search" [] {
     ^gh search --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -422,7 +413,7 @@ export extern "gh search" [
 def "nu-complete gh secret" [] {
     ^gh secret --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -437,7 +428,7 @@ export extern "gh secret" [
 def "nu-complete gh ssh-key" [] {
     ^gh ssh-key --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim
@@ -458,7 +449,7 @@ export extern "gh status" [
 def "nu-complete gh variable" [] {
     ^gh variable --help 
     | lines 
-    | filter {|line| str starts-with "  " } 
+    | filter { str starts-with "  " } 
     | skip 1 
     | parse "{value}: {description}" 
     | str trim


### PR DESCRIPTION
Hi! I added completion to `gh pr checkout <tab>`
It grabs the first 30 open prs 

![image](https://github.com/nushell/nu_scripts/assets/30557287/755fe63b-dc22-49ef-89c3-27e1ba115d68)

### I tried some things
`gh pr checkout` can accept
- a pr number
- a url
- or a branch

before I tried
- Incrementing the limit of PRs from 30 (default) to 50, but I takes considerably longer to query, and _gotta go fast_
- using the `extra` field in autocomplete [`Suggestion`](https://github.com/nushell/reedline/blob/a4bfaa512be8b7214b80c63327930155da86978a/src/completion/base.rs#L58). But I couldn't make it
- tried to use the `title` in the `value`, like this below, but when you select a row, it pastes the title into the cli, so `gh pr checkout <title>` doesn't make sense
![image](https://github.com/nushell/nu_scripts/assets/30557287/1c5caf7c-4653-49ba-afc2-ec8ba155b00f)



So, selecting the pr number is the closest I can get to