### PR TITLE
:bug: rename `yarn` for `yarn-v4` and add `run` cmpl

### DIFF
--- a/custom-completions/yarn/yarn-v4-completions.nu
+++ b/custom-completions/yarn/yarn-v4-completions.nu
@@ -382,14 +382,16 @@ export extern "yarn remove" [
 ]
 
 def "nu-complete yarn run" [] {
-    let userScripts = (open ./package.json
-    |get scripts
-    |columns)
+    let userScripts = open ./package.json 
+      | get scripts 
+      | transpose 
+      | rename value description
 
-    let binaries = (yarn bin --json
-    |lines
-    |each { |it| $it | from json}
-    |get name)
+    let binaries = yarn bin --json 
+      | lines 
+      | each { |it| $it | from json } 
+      | select name source 
+      | rename value description
 
     $userScripts | append $binaries
 }


### PR DESCRIPTION
Heya!

This `yarn` file is aimed at the latest yarn v4, which has different commands than yarn classic (v1)

I renamed the file to make that difference

```
custom-completions/yarn/yarn-completion.nu
#to
custom-completions/yarn/yarn-v4-completions.nu
```

 and also added an improvement on `yarn run` which I have on `pnpm`, changing this

![image](https://github.com/nushell/nu_scripts/assets/30557287/d7a6a040-95f3-4ab5-8ab8-b59ea4a53433)

into this
![image](https://github.com/nushell/nu_scripts/assets/30557287/95bd2edd-f633-4f37-8f4f-d511f037c270)

(note that the new yarn adds the binaries in addition to the package.json scripts values)