### PR TITLE
:bug: fix `(default)` and `(installed)` on rustup completions

### DIFF
--- a/custom-completions/rustup/rustup-completions.nu
+++ b/custom-completions/rustup/rustup-completions.nu
@@ -22,6 +22,7 @@ def "nu-complete rustup toolchain" [] {
 def "nu-complete rustup toolchain list" [] {
   ^rustup toolchain list
   | lines
+  | str replace " (default)" ""
   | append 'stable'
   | append 'beta'
   | append 'nightly'
@@ -39,6 +40,7 @@ def "nu-complete rustup target" [] {
 def "nu-complete rustup target list" [] {
   ^rustup target list
   | lines
+  | str replace " (installed)" ""
 }
 
 def "nu-complete rustup target list --installed" [] {
@@ -47,8 +49,9 @@ def "nu-complete rustup target list --installed" [] {
 }
 
 def "nu-complete rustup update" [] {
-  ^rustup toolchain list
-  | lines
+  ^rustup toolchain list 
+  | lines 
+  | str replace " (default)" ""
 }
 
 def "nu-complete rustup component" [] {
@@ -63,6 +66,7 @@ def "nu-complete rustup component" [] {
 def "nu-complete rustup component list" [] {
   ^rustup component list
   | lines
+  | str replace " (installed)" ""
 }
 
 def "nu-complete rustup component list installed" [] {


### PR DESCRIPTION
Updating rust by
```
rustup update <tab>
```
gives you:

![image](https://github.com/nushell/nu_scripts/assets/30557287/fe65bebc-c593-46b2-b696-bc1d093ee0b6)

and when you press enter on stable:
![image](https://github.com/nushell/nu_scripts/assets/30557287/59b98da7-f174-4518-b30b-88e6a9462603)

the ` (default)` part is piped into the cmdline. This is unintended.
I fixed components, toolchains & targets 💪🏼 
