### PR TITLE
Fix gh status completion

### DIFF
--- a/custom-completions/gh/gh-completions.nu
+++ b/custom-completions/gh/gh-completions.nu
@@ -440,7 +440,6 @@ export extern "gh ssh-key" [
 ]
 
 export extern "gh status" [
-    command 
     --exclude(-e)   # Comma separated list of repos to exclude in owner/name format
     --org(-o)       # Report status within an organization
     --help          # Show help for command


### PR DESCRIPTION
This is a (probably crude) attempt to address an issue where using the `gh status` command with gh completions installed would yield the following error:

```
> gh status
Error: nu::parser::missing_positional

  × Missing required positional argument.
   ╭─[entry #1:1:1]
 1 │ gh status
   ╰────
  help: Usage: gh status {flags} <command> . Use `--help` for more information.
```