### PR TITLE
Adding http oneliner and changing reference to renamed Discord channel.

### DIFF
--- a/sourced/cool-oneliners/README.md
+++ b/sourced/cool-oneliners/README.md
@@ -1,6 +1,6 @@
 # cool oneliners
 
-Capturing oneliners to and from the nushell Discourse channel `#cool-oneliners`.
+Capturing oneliners to and from the nushell community.
 
 Consider these a living library.
 Or an ongoing story of how people actually use `nu`.

--- a/sourced/cool-oneliners/simple_http_request.nu
+++ b/sourced/cool-oneliners/simple_http_request.nu
@@ -1,0 +1,2 @@
+# Makes an http request to a URL and gets the "value" field off the JSON response.
+(http get https://api.chucknorris.io/jokes/random).value


### PR DESCRIPTION
The [cookbook intro page](https://www.nushell.sh/cookbook/) gives an example of a oneliner that I recently changed to imply is one of the oneliners from this repo (nushell/nushell.github.io#1205), however that oneliner isn't actually in this repo. This adds that oneliner to the repo.

I also replaced the mention of the \#cool-oneliners channel that was renamed to \#cool-scripts to just mention the general Nushell community.