### PR TITLE
do not require stash in git stash drop

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -444,7 +444,7 @@ export extern "git stash show" [
 
 # Drop a stashed change
 export extern "git stash drop" [
-  stash: string@"nu-complete git stash-list"
+  stash?: string@"nu-complete git stash-list"
 ]
 
 # Create a new git repository


### PR DESCRIPTION
This fixes a small bug so that `git stash drop` doesn't _require_ a stash