### PR TITLE
use `fill -c` instead of `str repeat`

### DIFF
--- a/modules/comma/comma_test.nu
+++ b/modules/comma/comma_test.nu
@@ -62,7 +62,7 @@ $env.comma = {|_|{
                 $_.act: {, -c example a b c e }
                 $_.x: [
                     {|r,a,s| $r | where value == 'f' | not ($in | is-empty) }
-                    (do $_.T {|r,a,s| $s | lg 'expect'})
+                    (do $_.T {|r,a,s| $s | show 'expect'})
                     {|r,a| 'q1|q2|q3|q4| open a file' == ($r | get 1.description) }
                 ]
             }


### PR DESCRIPTION
Sorry, I forgot to use `fill -c` and implemented `str repeat` with similar function. Now change it back
Added a `log` helper function to avoid the frequent need to adjust the output format
The original `lg` with a similar name was changed to `show`, but it is basically only used for internal debugging.
I'm not sure if these should be merged, feel free to do whatever you want