### PR TITLE
Some improvements to task.nu

### DIFF
--- a/modules/background_task/task.nu
+++ b/modules/background_task/task.nu
@@ -66,7 +66,21 @@ export def spawn [
 # Running or paused tasks need to be killed first.
 export def remove [
   ...ids: int # IDs of the tasks to remove from the status list.
+  --group (-g): string # Remove all tasks from the specified group.
 ] {
+  if $group != null {
+    let group_ids = (status | where group == $group | get id)
+    if ($group_ids | length) == 0 {
+      print $"(ansi red)No tasks found for group: ($group)(ansi reset)"
+      return
+    }
+    pueue remove $group_ids
+  
+  } else if ($ids | length) == 0 {
+        print $"(ansi red)No task IDs or group specified.(ansi reset)"
+        return
+  }
+
   pueue remove $ids
 }
 

--- a/modules/background_task/task.nu
+++ b/modules/background_task/task.nu
@@ -296,6 +296,7 @@ export def "group add" [
 }
 
 # Remove a group with a name.
+# This will move all tasks in this group to the default group!
 export def "group remove" [
   name: string # The name of the group to be removed.
 ] {

--- a/modules/background_task/task.nu
+++ b/modules/background_task/task.nu
@@ -54,6 +54,7 @@ export def spawn [
       
       let tmp_file = (mktemp -t --suffix ".nu")
       let scripts = ($source_code | save -f $tmp_file)
+      $tmp_file
   } else {
       $command
   }


### PR DESCRIPTION
It all started when I tried to run:

```sh
task spawn {
   mut sec = 0
   while true {
     print $"Runned ($env.PUEUE_WORKER_ID) for (ansi blue)($sec)(ansi reset)"
     $sec = $sec + 1
     sleep 1sec
  }
}
```

This currently fails because of escaping, we could do complex `str replace` / regex etc but I think the idea by @RGBCube of using a tmp file is better, this PR implements the ideas based on the issue I faced when configuring pueue/tasks:

- Escaping (using a temp file 20a55723bba47e8612c413ad897067c7bbf21da4)
- Adds a `--group` flag to `group remove`  (@RGBCube did not like my code 😋 8d6dd2c36adf893c4f685be0ca2802f204662215)
