### PR TITLE
:bug: fix `winget-completions`

### DIFF
--- a/custom-completions/winget/winget-completions.nu
+++ b/custom-completions/winget/winget-completions.nu
@@ -25,7 +25,7 @@ def "nu-complete winget source type" [] {
     ["Microsoft.PreIndexed.Package"]
 }
 
-def "nu-complete winget flagify" [name: string, value: any, --short(-s): bool] {
+def "nu-complete winget flagify" [name: string, value: any, --short(-s)] {
   let flag_start = if $short { '-' } else { '--' }
   if $value == null or $value == false {
     ""
@@ -128,9 +128,9 @@ def "nu-complete winget parse table" [lines: any] {
 }
 
 export extern winget [
-    --version(-v): bool, # Display the version of the tool
-    --info: bool, # Display general info of the tool
-    --help(-?): bool, # Display the help for this command
+    --version(-v), # Display the version of the tool
+    --info, # Display general info of the tool
+    --help(-?), # Display the help for this command
 ]
 
 # Installs the given package
@@ -144,18 +144,18 @@ export extern "winget install" [
     --version(-v): string, # Use the specified version; default is the latest version
     --source(-s): string@"nu-complete winget install source", # Find package using the specified source
     --scope: string@"nu-complete winget install scope", # Select install scope (user or machine)
-    --exact(-e): bool, # Find package using exact match
-    --interactive(-i): bool, # Request interactive installation; user input may be needed
-    --silent(-h): bool, # Request silent installation
+    --exact(-e), # Find package using exact match
+    --interactive(-i), # Request interactive installation; user input may be needed
+    --silent(-h), # Request silent installation
     --locale: string@"nu-complete winget install locale", # Locale to use (BCP47 format)
     --log(-o): path, # Log location (if supported)
     --override: string, # Override arguments to be passed on to the installer
     --location(-l): path, # Location to install to (if supported)
-    --force: bool, # Override the installer hash check
-    --accept_package_agreements: bool, # Accept all licence agreements for packages
+    --force, # Override the installer hash check
+    --accept_package_agreements, # Accept all licence agreements for packages
     --header: string, # Optional Windows-Package-Manager REST source HTTP header
-    --accept_source_agreements: bool, # Accept all source agreements during source operations
-    --help(-?): bool # Display the help for this command
+    --accept_source_agreements, # Accept all source agreements during source operations
+    --help(-?) # Display the help for this command
 ]
 
 def "winget show" [
@@ -167,19 +167,19 @@ def "winget show" [
     --version(-v): string, # Use the specified version; default is the latest version
     --source(-s): string@"nu-complete winget install source", # Find package using the specified source
     --scope: string@"nu-complete winget install scope", # Select install scope (user or machine). Doesn't work rn, use ^winget
-    --exact(-e): bool, # Find package using exact match
-    --interactive(-i): bool, # Request interactive installation; user input may be needed
-    --silent(-h): bool, # Request silent installation
+    --exact(-e), # Find package using exact match
+    --interactive(-i), # Request interactive installation; user input may be needed
+    --silent(-h), # Request silent installation
     --locale: string@"nu-complete winget install locale", # Locale to use (BCP47 format)
     --log(-o): path, # Log location (if supported)
     --override: string, # Override arguments to be passed on to the installer
     --location(-l): path, # Location to install to (if supported)
-    --force: bool, # Override the installer hash check
-    --accept_package_agreements: bool, # Accept all licence agreements for packages
+    --force, # Override the installer hash check
+    --accept_package_agreements, # Accept all licence agreements for packages
     --header: string, # Optional Windows-Package-Manager REST source HTTP header
-    --accept_source_agreements: bool, # Accept all source agreements during source operations
-    --raw: bool, # Output the raw CLI output instead of structured data
-    --help(-?): bool, # Display the help for this command
+    --accept_source_agreements, # Accept all source agreements during source operations
+    --raw, # Output the raw CLI output instead of structured data
+    --help(-?), # Display the help for this command
 ] {
     let flagify = { |name, value| nu-complete winget flagify $name $value }
 
@@ -226,7 +226,7 @@ def "winget show" [
 
 # Manage sources of packages
 export extern "winget source" [
-    --help(-?): bool # Display the help for this command
+    --help(-?) # Display the help for this command
 ]
 
 # Add a new source
@@ -235,16 +235,16 @@ export extern "winget source add" [
     --arg(-a): string, # Argument given to the source
     --type(-t): string@"nu-complete winget source type", # Type of the source
     --header: string, # Optional Windows-Package-Manager REST source HTTP header
-    --accept_source_agreements: bool, # Accept all source agreements during source operations
-    --help(-?): bool # Display the help for this command
+    --accept_source_agreements, # Accept all source agreements during source operations
+    --help(-?) # Display the help for this command
 ]
 
 # List current sources
 def "winget source list" [
     pos_name?: string, # Name of the source
     --name(-n): string, # Name of the source
-    --raw: bool, # Output the raw CLI output instead of structured data
-    --help(-?): bool # Display the help for this command
+    --raw, # Output the raw CLI output instead of structured data
+    --help(-?) # Display the help for this command
 ] {
     let flagify = { |name, value| nu-complete winget flagify $name $value }
 
@@ -270,26 +270,26 @@ def "winget source list" [
 # Update current sources
 export extern "winget source update" [
     --name(-n): string, # Name of the source
-    --help(-?): bool # Display the help for this command
+    --help(-?) # Display the help for this command
 ]
 
 # Remove current sources
 export extern "winget source remove" [
     --name(-n): string, # Name of the source
-    --help(-?): bool # Display the help for this command
+    --help(-?) # Display the help for this command
 ]
 
 # Reset sources
 export extern "winget source reset" [
     --name(-n): string, # Name of the source
-    --force: bool, # Forces the reset of the sources
-    --help(-?): bool # Display the help for this command
+    --force, # Forces the reset of the sources
+    --help(-?) # Display the help for this command
 ]
 
 # Export current sources
 export extern "winget source export" [
     --name(-n): string, # Name of the source
-    --help(-?): bool # Display the help for this command
+    --help(-?) # Display the help for this command
 ]
 
 # Find and show basic info of packages
@@ -303,11 +303,11 @@ def "winget search" [
     --command: string, # Filter results by command
     --source(-s): string@"nu-complete winget install source", # Find package using the specified source
     --count(-n): int, # Show no more than specified number of results
-    --exact(-e): bool, # Find package using exact match
+    --exact(-e), # Find package using exact match
     --header: string, # Optional Windows-Package-Manager REST source HTTP header
-    --accept_source_agreements: bool, # Accept all source agreements during source operations
-    --raw: bool, # Output the raw CLI output instead of structured data
-    --help(-?): bool # Display the help for this command
+    --accept_source_agreements, # Accept all source agreements during source operations
+    --raw, # Output the raw CLI output instead of structured data
+    --help(-?) # Display the help for this command
 ] {
     let flagify = { |name, value| nu-complete winget flagify $name $value }
 
@@ -351,11 +351,11 @@ def "winget list" [
     --command: string, # Filter results by command
     --source(-s): string@"nu-complete winget install source", # Find package using the specified source
     --count(-n): int, # Show no more than specified number of results
-    --exact(-e): bool, # Find package using exact match
+    --exact(-e), # Find package using exact match
     --header: string, # Optional Windows-Package-Manager REST source HTTP header
-    --accept_source_agreements: bool, # Accept all source agreements during source operations
-    --raw: bool, # Output the raw CLI output instead of structured data
-    --help(-?): bool # Display the help for this command
+    --accept_source_agreements, # Accept all source agreements during source operations
+    --raw, # Output the raw CLI output instead of structured data
+    --help(-?) # Display the help for this command
 ] {
     let flagify = { |name, value| nu-complete winget flagify $name $value }
 
@@ -398,18 +398,18 @@ export extern "winget upgrade" [
     --moniker: string, # Filter results by moniker
     --version(-v): string, # Use the specified version; default is the latest version
     --source(-s): string@"nu-complete winget install source", # Find package using the specified source
-    --exact(-e): bool, # Find package using exact match
-    --interactive(-i): bool, # Request interactive installation; user input may be needed
-    --silent(-h): bool, # Request silent installation
+    --exact(-e), # Find package using exact match
+    --interactive(-i), # Request interactive installation; user input may be needed
+    --silent(-h), # Request silent installation
     --log(-o): path, # Log location (if supported)
     --override: string, # Override arguments to be passed on to the installer
     --location(-l): path, # Location to install to (if supported)
-    --force: bool, # Override the installer hash check
-    --accept_package_agreements: bool, # Accept all licence agreements for packages
+    --force, # Override the installer hash check
+    --accept_package_agreements, # Accept all licence agreements for packages
     --header: string, # Optional Windows-Package-Manager REST source HTTP header
-    --accept_source_agreements: bool, # Accept all source agreements during source operations
-    --all: bool, # Update all installed packages to latest if available
-    --help(-?): bool # Display the help for this command
+    --accept_source_agreements, # Accept all source agreements during source operations
+    --all, # Update all installed packages to latest if available
+    --help(-?) # Display the help for this command
 ]
 
 # Uninstalls the given package
@@ -422,38 +422,38 @@ export extern "winget uninstall" [
     --moniker: string, # Filter results by moniker
     --version(-v): string, # Use the specified version; default is the latest version
     --source(-s): string@"nu-complete winget install source", # Find package using the specified source
-    --exact(-e): bool, # Find package using exact match
-    --interactive(-i): bool, # Request interactive installation; user input may be needed
-    --silent(-h): bool, # Request silent installation
+    --exact(-e), # Find package using exact match
+    --interactive(-i), # Request interactive installation; user input may be needed
+    --silent(-h), # Request silent installation
     --log(-o): path, # Log location (if supported)
-    --help(-?): bool # Display the help for this command
+    --help(-?) # Display the help for this command
 ]
 
 # Helper to hash installer files
 export extern "winget hash" [
     file?: path, # File to be hashed
     --file(-f): path, # File to be hashed
-    --msix(-m): bool, # Input file will be treated as msix; signature hash will be provided if signed
-    --help(-?): bool # Display the help for this command
+    --msix(-m), # Input file will be treated as msix; signature hash will be provided if signed
+    --help(-?) # Display the help for this command
 ]
 
 # Validates a manifest file
 export extern "winget validate" [
     manifest?: path, # The path to the manifest to be validated
     --manifest: path,  # The path to the manifest to be validated
-    --help(-?): bool # Display the help for this command
+    --help(-?) # Display the help for this command
 ]
 
 # Open settings or set administrator settings
 export extern "winget settings" [
     --enable: string, # Enables the specific administrator setting
     --disable: string, # Disables the specific administrator setting
-    --help(-?): bool # Display the help for this command
+    --help(-?) # Display the help for this command
 ]
 
 # Shows the status of experimental features
 export extern "winget features" [
-    --help(-?): bool # Display the help for this command
+    --help(-?) # Display the help for this command
 ]
 
 # Exports a list of the installed packages
@@ -461,16 +461,16 @@ export extern "winget export" [
     output?: path, # File where the result is to be written
     --output(-o): path, # File where the result is to be written
     --source(-s): string@"nu-complete winget install source", # Export packages from the specified source
-    --include-versions: bool, # Include package versions in produced file
-    --accept_source_agreements: bool, # Accept all source agreements during source operations
-    --help(-?): bool # Display the help for this command
+    --include-versions, # Include package versions in produced file
+    --accept_source_agreements, # Accept all source agreements during source operations
+    --help(-?) # Display the help for this command
 ]
 
 export extern "winget import" [
     import_file?: path, # File describing the packages to install
     --import-file(-i): path, # File describing the packages to install
-    --ignore-unavailable: bool, # Ignore unavailable packages
-    --ignore-versions: bool, # Ignore package versions
-    --accept_package_agreements: bool, # Accept all licence agreements for packages
-    --accept_source_agreements: bool # Accept all source agreements during source operations
+    --ignore-unavailable, # Ignore unavailable packages
+    --ignore-versions, # Ignore package versions
+    --accept_package_agreements, # Accept all licence agreements for packages
+    --accept_source_agreements # Accept all source agreements during source operations
 ]


### PR DESCRIPTION
Parser did a good job here, explaining
```
Error:   × Deprecated: --flag: bool
    ╭─[C:\...\nu_scripts\custom-completions\winget\winget-completions.nu:27:1]
 27 │
 28 │ def "nu-complete winget flagify" [name: string, value: any, --short(-s): bool] {
    ·                                                                          ──┬─
    ·                                                                            ╰── `--flag: bool` is deprecated and will be removed in 0.90. Please use `--flag` instead, more info: https://www.nushell.sh/book/custom_commands.html
 29 │   let flag_start = if $short { '-' } else { '--' }
    ╰────
```
is not possible anymore, so I removed all the `: bool`s and sourced the script correctly!