### PR TITLE
fix: update deprecated spread operator in just

### DIFF
--- a/custom-completions/just/just-completions.nu
+++ b/custom-completions/just/just-completions.nu
@@ -39,6 +39,6 @@ export def just [
     if ($recipes | is-empty) {
         ^just
     } else {
-        ^just $recipes $args
+        ^just $recipes ...$args
     }
 }


### PR DESCRIPTION
As per https://github.com/nushell/nushell/pull/11289, this should be supported in `0.89.0` and should be updated prior to `0.91.0`.

I admittedly didn't check if there were more spots, this was the one that popped up when I updated. :slightly_smiling_face: 

Feel free to close and absorb in a larger PR.