### PR TITLE
:bug: fix optional arg in `git stash show`

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -438,7 +438,7 @@ export extern "git stash list" [
 
 # Show a stashed change
 export extern "git stash show" [
-  stash: string@"nu-complete git stash-list"
+  stash?: string@"nu-complete git stash-list"
   -U                                                  # show diff
 ]
 


### PR DESCRIPTION
Hi! Another bug I found, in `git`, you can
```bash
git stash show
```
with no args and should be alright, but the .nu script is requiring a git name. (maybe for a previous version of git it was needed)