### PR TITLE
fix: output format changed in `zellij ls`

### DIFF
--- a/custom-completions/zellij/zellij-completions.nu
+++ b/custom-completions/zellij/zellij-completions.nu
@@ -78,7 +78,7 @@ def "nu-complete zellij attach" [] {
 }
 
 def "nu-complete sessions" [] {
-  ^zellij ls | lines | str replace '\(current\)' "" | str trim
+  ^zellij ls -n | lines | parse "{value} {description}"
 }
 
 # Turned off since it messes with sub-commands


### PR DESCRIPTION
Hi. In the latest zellij (0.39.2), the output of `zellij ls` has been changed into the following example:
```bash
rectangular-galaxy [Created 9h 21m 46s ago] (EXITED - attach to resurrect)
gregarious-triceratops [Created 22h 48m 32s ago] (EXITED - attach to resurrect)
```
I updated the corresponding parsing code.