### PR TITLE
:rotating_light: fix linter errors for the CI of the PR #771

### DIFF
--- a/sourced/webscraping/shell_stars.nu
+++ b/sourced/webscraping/shell_stars.nu
@@ -39,4 +39,4 @@ $shell_list | each { |r|
         print $" ($count)"
         [[shell repo stars]; [($r.name) ($r.repo) ($count)]]
     }
-} | flatten | sort-by -r stars | table -n 1
+} | flatten | sort-by -r stars | table --index 1


### PR DESCRIPTION
Hi! this is another PR fixing the lints so the CI I'm building in #771 doesn't go red
I have lots of files, so it will take me a while