### PR TITLE
[stdlib-candidate] set-env

### DIFF
--- a/stdlib-candidate/set-env.nu
+++ b/stdlib-candidate/set-env.nu
@@ -13,22 +13,25 @@
 #   Add a config hook
 #   > set-env -a config.hooks.pre_prompt 'ellie | print'
 export def --env main [
-  path: cell-path # The environment variable name or nested option path
+  field: cell-path # The environment variable name or nested option cell path
   value: any # The value to set or append
   --append (-a) # Append to the previous value or wrap in a new list
 ]: nothing -> nothing {
-  def 'get or' [default path] { get --ignore-errors $path | default $default }
+  def 'get or' [default field] {
+    get --ignore-errors $field | default $default
+  }
   let value = if $append {
-    $env | get or [] $path | append $value
+    $env | get or [] $field | append $value
   } else {
     $value
   }
-  let path = $path | to text | split row .
-  let value = match $path {
+  let field = $field | to text | split row .
+  let value = match $field {
     [_] => $value
-    [$root, ..$path] => {
-      $env | get or {} $root | upsert ($path | into cell-path) $value
+    [$root, ..$field] => {
+      let field = $field | into cell-path
+      $env | get or {} $root | upsert $field $value
     }
   }
-  load-env { ($path | first): $value }
+  load-env { ($field | first): $value }
 }

--- a/stdlib-candidate/set-env.nu
+++ b/stdlib-candidate/set-env.nu
@@ -1,0 +1,34 @@
+# Gracefully set an environment variable or merge a nested option.
+#
+# Examples:
+#   Set $env.NUPM_HOME
+#   > set-env NUPM_HOME $'($nu.home-path)/.local/share/nupm'
+#
+#   Add to $env.NU_LIB_DIRS
+#   > set-env --append NU_LIB_DIRS $'($env.NUPM_HOME)/modules'
+#
+#   Set a nested config option
+#   > set-env config.filesize.metric true
+#
+#   Add a config hook
+#   > set-env -a config.hooks.pre_prompt 'ellie | print'
+export def --env main [
+  path: cell-path # The environment variable name or nested option path
+  value: any # The value to set or append
+  --append (-a) # Append to the previous value or wrap in a new list
+]: nothing -> nothing {
+  def 'get or' [default path] { get --ignore-errors $path | default $default }
+  let value = if $append {
+    $env | get or [] $path | append $value
+  } else {
+    $value
+  }
+  let path = $path | to text | split row .
+  let value = match $path {
+    [_] => $value
+    [$root, ..$path] => {
+      $env | get or {} $root | upsert ($path | into cell-path) $value
+    }
+  }
+  load-env { ($path | first): $value }
+}


### PR DESCRIPTION
Rewrite of nushell/nushell#12156 for jdx/mise#1763.

### Why?

Nushell philosophically omits a `set` list mutation. But `$env` is inherently mutable leading to issues described in nushell/nushell#12148. `set-env` provides such an operation exclusively for `$env`.

### What changed?

1. Explicit flag instead of implicit list concatenation
2. Expands updates to any `$env` field not only `$env.config`

### How is it used?

```yaml
❯ set-env -h
Gracefully set an environment variable or merge a nested option.

Examples:
  Set $env.NUPM_HOME
  > set-env NUPM_HOME $'($nu.home-path)/.local/share/nupm'

  Add to $env.NU_LIB_DIRS
  > set-env --append NU_LIB_DIRS $'($env.NUPM_HOME)/modules'

  Set a nested config option
  > set-env config.filesize.metric true

  Add a config hook
  > set-env -a config.hooks.pre_prompt 'ellie | print'

Usage:
  > main {flags} <field> <value>

Flags:
  -a, --append - Append to the previous value or wrap in a new list
  -h, --help - Display the help message for this command

Parameters:
  field <cell-path>: The environment variable name or nested option cell path
  value <any>: The value to set or append

Input/output types:
  ╭───┬─────────┬─────────╮
  │ # │  input  │ output  │
  ├───┼─────────┼─────────┤
  │ 0 │ nothing │ nothing │
  ╰───┴─────────┴─────────╯
```

### How does it work?

```nushell
export def --env main [
  field: cell-path
  value: any
  --append (-a)
]: nothing -> nothing {

  # just an alias
  def 'get or' [default field] {
    get --ignore-errors $field | default $default
  }

  let value = if $append {
    # append to the previous value or empty list
    $env | get or [] $field | append $value
  } else {
    $value
  }

  # work around nushell/nushell#12168
  let field = $field | to text | split row .
  let value = match $field {

    [_] => $value
    # if cell path is nested
    [$root, ..$field] => {
      let field = $field | into cell-path

      # reassigning $env would be an error
      # merging reserved names like PWD would be an error
      # so merge from 1 level deep instead
      $env | get or {} $root | upsert $field $value
    }
  }

  # avoid issues noted above
  load-env { ($field | first): $value }
}
```

### Where are the tests?

Pending next PR for nupm integration.