### PR TITLE
Use `cargo hack` in release process

### DIFF
--- a/make_release/Readme.md
+++ b/make_release/Readme.md
@@ -25,7 +25,17 @@
 
 ## 1. Minor bump of the version ([example][nushell bump example])
 - [ ] in the repo of Nushell, run `/path/to/nu_scripts/make_release/bump-version.nu`
-- [ ] Also commit `Cargo.lock` AFTER running a Cargo command like `cargo check --workspace`
+- [ ] then, ensure there are no compilation errors with any combination of features by running:
+    ```nushell
+    cargo hack --all --feature-powerset --skip default-no-clipboard,stable,wasi,mimalloc check
+    ```
+    (this will take a while...)
+- [ ] check for build errors by running:
+    ```nushell
+    cargo hack --all build
+    ```
+    (this will build each crate with default features)
+- [ ] commit changes with bumped versions (this includes changes to `Cargo.lock`)
 
 ## 2. Tag the [`nushell`] repo
 > **Warning**
@@ -37,7 +47,6 @@
 > e.g. the `nushell` remote would be `https://github.com/nushell/nushell` or `git@github.com:nushell/nushell`
 
 - [ ] get the latest version bump commit with `git pull nushell main`
-- [ ] run `cargo build` to check if it's ok and check last features
 - [ ] tag the project with `git tag 0.xx.0`
 - [ ] :warning: push the release tag to *GitHub* `git push nushell main --tags` :warning:
 

--- a/make_release/Readme.md
+++ b/make_release/Readme.md
@@ -1,16 +1,16 @@
 # The release process of Nushell
 ## 0. Release direct dependencies
-> **Note**  
+> **Note**
 > the following procedure is the same for `nu-ansi-term` and `reedline` and needs to be repeated
 
-> **Warning**  
+> **Warning**
 > release `nu-ansi-term` **before** `reedline` and `reedline` **before** Nushell
 
-> **Note**  
+> **Note**
 > `nu-ansi-term` is typically released only when there are changes to publish.
 > `reedline` is typically released on the same schedule as Nushell.
 
-> **Note**  
+> **Note**
 > in the following, `dep` denotes either the `reedline` or the `nu-ansi-term` remote
 > e.g. `https://github.com/nushell/reedline` or `git@github.com:nushell/nu-ansi-term`,
 > depending on the dependency being installed
@@ -28,11 +28,11 @@
 - [ ] Also commit `Cargo.lock` AFTER running a Cargo command like `cargo check --workspace`
 
 ## 2. Tag the [`nushell`] repo
-> **Warning**  
+> **Warning**
 > this is maybe the most critical step of the whole release process!!
 > this step, once pushed to *GitHub* will trigger the release workflows.
 
-> **Note**  
+> **Note**
 > in the following, `nushell` will be used to pull and push to the [`nushell`] repo,
 > e.g. the `nushell` remote would be `https://github.com/nushell/nushell` or `git@github.com:nushell/nushell`
 
@@ -41,24 +41,24 @@
 - [ ] tag the project with `git tag 0.xx.0`
 - [ ] :warning: push the release tag to *GitHub* `git push nushell main --tags` :warning:
 
-:point_right: check the [CI jobs](https://github.com/nushell/nushell/actions)  
+:point_right: check the [CI jobs](https://github.com/nushell/nushell/actions)
 :point_right: check that there is the same number of targets compared to [last release](https://github.com/nushell/nushell/releases/latest)
 
 ## 3. Publish `nu` to *crates.io*
 - [ ] check the order of dependencies with `nushell/nu_scripts/make_release/nu_deps.nu` from the `nushell` repo
 - [ ] release the Nushell crates `nushell/nu_scripts/make_release/nu_release.nu` from the `nushell` repo
 
-> **Note**  
+> **Note**
 > if there is a new crate, you must add it to the `github:nushell:publishing` group (`cargo owner --list`)
 
-> **Note**  
+> **Note**
 > if a step fails
 > - ask the owner to `cargo owner --add github:nushell:publishing`
 > - edit the `nu_release.nu` script to start again where it failed
 > - re-run the script
 
 ## 4. Publish the release note on the website
-> **Note**  
+> **Note**
 > the scripts have been written in such a way they can be run from anywhere
 
 - [ ] inspect the merged PRs to write changelogs with `./make_release/release-note/list-merged-prs nushell/nushell`

--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -39,26 +39,6 @@ export def main [] {
         nu_plugin_formats,
     ]
 
-    log info "running publish dry run"
-
-    log info "dry-run publishing the first wave of crates"
-    for crate in $subcrates_wave_1 {
-        cargo publish -p $crate --dry-run
-    }
-
-    log info "dry-run publishing the second wave of crates"
-    for crate in $subcrates_wave_2 {
-        cargo publish -p $crate --no-verify --dry-run
-    }
-
-    log info "dry-run publishing the third wave of crates"
-    for crate in $subcrates_wave_3 {
-        cargo publish -p $crate --dry-run
-    }
-
-    cargo publish --dry-run
-
-
     log warning "starting publish"
 
     log warning "publishing the first wave of crates"

--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -1,76 +1,80 @@
 use std log
 
-let subcrates_wave_1 = [
-    nu-glob,
-    nu-json,
-    nu-path,
-    nu-pretty-hex,
-    nu-system,
-    nu-utils,
-    nu-term-grid,
-    nu-test-support,
-    nu-protocol,
-    nu-engine,
-    nu-plugin,
-    nu-color-config,
-    nu-parser,
-    nu-std,
-    nu-table,
-    nu-cmd-base,
-]
+export def main [] {
+    let subcrates_wave_1 = [
+        nu-glob,
+        nu-json,
+        nu-path,
+        nu-pretty-hex,
+        nu-system,
+        nu-utils,
+        nu-term-grid,
+        nu-test-support,
+        nu-protocol,
+        nu-engine,
+        nu-plugin,
+        nu-color-config,
+        nu-parser,
+        nu-std,
+        nu-table,
+        nu-cmd-base,
+    ]
 
-# This crate has a `build.rs` file and thus needs `--no-verify`
-let subcrates_wave_2 = [
-    nu-cmd-lang,
-]
+    # This crate has a `build.rs` file and thus needs `--no-verify`
+    let subcrates_wave_2 = [
+        nu-cmd-lang,
+    ]
 
-let subcrates_wave_3 = [
-    nu-command,
-    nu-explore,
-    nu-cli,
-    nu-cmd-dataframe,
-    nu-cmd-extra,
-    nu-lsp,
+    let subcrates_wave_3 = [
+        nu-command,
+        nu-explore,
+        nu-cli,
+        nu-cmd-dataframe,
+        nu-cmd-extra,
+        nu-lsp,
 
-    nu_plugin_query,
-    nu_plugin_inc,
-    nu_plugin_gstat,
-    nu_plugin_formats,
-]
+        nu_plugin_query,
+        nu_plugin_inc,
+        nu_plugin_gstat,
+        nu_plugin_formats,
+    ]
 
-log info "running publish dry run"
+    log info "running publish dry run"
 
-log info "dry-run publishing the first wave of crates"
-for crate in $subcrates_wave_1 {
-    cargo publish -p $crate --dry-run
+    log info "dry-run publishing the first wave of crates"
+    for crate in $subcrates_wave_1 {
+        cargo publish -p $crate --dry-run
+    }
+
+    log info "dry-run publishing the second wave of crates"
+    for crate in $subcrates_wave_2 {
+        cargo publish -p $crate --no-verify --dry-run
+    }
+
+    log info "dry-run publishing the third wave of crates"
+    for crate in $subcrates_wave_3 {
+        cargo publish -p $crate --dry-run
+    }
+
+    cargo publish --dry-run
+
+
+    log warning "starting publish"
+
+    log warning "publishing the first wave of crates"
+    for crate in $subcrates_wave_1 {
+        cargo publish -p $crate
+    }
+
+    log warning "publishing the second wave of crates"
+    for crate in $subcrates_wave_2 {
+        cargo publish -p $crate --no-verify
+    }
+
+    log warning "publishing the third wave of crates"
+    for crate in $subcrates_wave_3 {
+        cargo publish -p $crate
+    }
+
+    cargo publish
 }
-
-log info "dry-run publishing the second wave of crates"
-for crate in $subcrates_wave_2 {
-    cargo publish -p $crate --no-verify --dry-run
-}
-
-log info "dry-run publishing the third wave of crates"
-for crate in $subcrates_wave_3 {
-    cargo publish -p $crate --dry-run
-}
-
-cargo publish --dry-run
-
-
-log warning "publishing the first wave of crates"
-for crate in $subcrates_wave_1 {
-    cargo publish -p $crate
-}
-
-log warning "publishing the second wave of crates"
-for crate in $subcrates_wave_2 {
-    cargo publish -p $crate --no-verify
-}
-
-log warning "publishing the third wave of crates"
-for crate in $subcrates_wave_3 {
-    cargo publish -p $crate
-}
-
-cargo publish

--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -1,18 +1,5 @@
 use std log
 
-def publish [
-    crate: path # the path to the crate to publish.
-    --no-verify # don’t verify the contents by building them. Can be useful for crates with a `build.rs`.
-] {
-    cd $crate
-
-    if $no_verify {
-        cargo publish --no-verify
-    } else {
-        cargo publish
-    }
-}
-
 let subcrates_wave_1 = [
     nu-glob,
     nu-json,
@@ -51,19 +38,39 @@ let subcrates_wave_3 = [
     nu_plugin_formats,
 ]
 
+log info "running publish dry run"
+
+log info "dry-run publishing the first wave of crates"
+for crate in $subcrates_wave_1 {
+    cargo publish -p $crate --dry-run
+}
+
+log info "dry-run publishing the second wave of crates"
+for crate in $subcrates_wave_2 {
+    cargo publish -p $crate --no-verify --dry-run
+}
+
+log info "dry-run publishing the third wave of crates"
+for crate in $subcrates_wave_3 {
+    cargo publish -p $crate --dry-run
+}
+
+cargo publish --dry-run
+
+
 log warning "publishing the first wave of crates"
-for subcrate in $subcrates_wave_1 {
-    publish ("crates" | path join $subcrate)
+for crate in $subcrates_wave_1 {
+    cargo publish -p $crate
 }
 
 log warning "publishing the second wave of crates"
-for subcrate in $subcrates_wave_2 {
-    publish ("crates" | path join $subcrate) --no-verify
+for crate in $subcrates_wave_2 {
+    cargo publish -p $crate --no-verify
 }
 
 log warning "publishing the third wave of crates"
-for subcrate in $subcrates_wave_3 {
-    publish ("crates" | path join $subcrate)
+for crate in $subcrates_wave_3 {
+    cargo publish -p $crate
 }
 
 cargo publish


### PR DESCRIPTION
This PR adds two [`cargo hack`](https://github.com/taiki-e/cargo-hack) commands to the release process to check for errors due to combination of features. The first one will run `cargo check` on each crate multiple times over, toggling different combinations of features each time. This is to check for compilation errors regarding missing imports, etc. The second command will run `cargo build` for each crate separately (with default features) to check for build errors (from `build.rs` or whatever).

Using the [error](https://github.com/nushell/nushell/pull/11786) from the 0.90.0 publishing as a test, the first command does indeed find the compilation error.

In the future, we should probably put these commands into a manually triggered CI job so that they will be run on multiple platforms.

Also, this PR cleans up `nu_release.nu` a little bit.