### PR TITLE
Add `from env`

### DIFF
--- a/modules/formats/from-env.nu
+++ b/modules/formats/from-env.nu
@@ -1,0 +1,12 @@
+# Converts a .env file into a record
+# may be used like this: open .env | load-env
+# works with quoted and unquoted .env files
+def "from env" []: string -> record {
+  lines 
+    | split column '#' # remove comments
+    | get column1 
+    | filter {($in | str length) > 0} 
+    | parse "{key}={value}"
+    | update value {str trim -c '"'} # unquote values
+    | transpose -r -d
+}

--- a/modules/formats/from-env.nu
+++ b/modules/formats/from-env.nu
@@ -5,8 +5,7 @@ def "from env" []: string -> record {
   lines 
     | split column '#' # remove comments
     | get column1 
-    | filter {($in | str length) > 0} 
     | parse "{key}={value}"
-    | update value {str trim -c '"'} # unquote values
+    | str trim value -c '"' # unquote values
     | transpose -r -d
 }


### PR DESCRIPTION
This adds a little command that allows opening .env files as records.
My implementation removes comments and works with both quoted and unquoted .env files.