### PR TITLE
add windows compatibility for command not found hook

### DIFF
--- a/nu-hooks/nu-hooks/command_not_found/did_you_mean.nu
+++ b/nu-hooks/nu-hooks/command_not_found/did_you_mean.nu
@@ -18,9 +18,18 @@
 # ```
 {|cmd|
     let commands_in_path = (
-        $env.PATH | each {|directory|
-            if ($directory | path exists) {
-                ls $directory | get name | path parse | update parent "" | path join
+        if ($nu.os-info.name == windows) {
+            $env.Path | each {|directory|
+                if ($directory | path exists) {
+                    let cmd_exts = $env.PATHEXT | str downcase | split row ';' | str trim --char .
+                    ls $directory | get name | path parse | where {|it| $cmd_exts | any {|ext| $ext == ($it.extension | str downcase)} } | get stem
+                }
+            }
+        } else {
+            $env.PATH | each {|directory|
+                if ($directory | path exists) {
+                    ls $directory | get name | path parse | update parent "" | path join
+                }
             }
         }
         | flatten


### PR DESCRIPTION
the hook (did_you_mean.nu) had stopped working for me recently, I added an if branch for Windows to use their `Path` env var (not `PATH`) and only list files that match in the `PATHEXT` env var to resolve my issue