### PR TITLE
Add `nu_plugin_polars` as a crate to release

### DIFF
--- a/make_release/nu_release.nu
+++ b/make_release/nu_release.nu
@@ -38,6 +38,7 @@ export def main [] {
         nu_plugin_inc,
         nu_plugin_gstat,
         nu_plugin_formats,
+        nu_plugin_polars,
     ]
 
     log warning "starting publish"


### PR DESCRIPTION
For the upcoming `0.93.0` release we want to ship this plugin.

Merge ahead of the release process (not when we have a patch release inbetween)
