### PR TITLE
fix: prefix conda commands with `conda`

### DIFF
--- a/modules/virtual_environments/conda.nu
+++ b/modules/virtual_environments/conda.nu
@@ -1,5 +1,5 @@
 # Activate conda environment
-export def --env activate [
+export def --env "conda activate" [
     env_name?: string@'nu-complete conda envs' # name of the environment
 ] {
     let conda_info = (conda info --envs --json | from json)
@@ -73,7 +73,7 @@ export def --env activate [
 }
 
 # Deactivate currently active conda environment
-export def --env deactivate [] {
+export def --env "conda deactivate" [] {
     let path_name = if "PATH" in $env { "PATH" } else { "Path" }
     $env.$path_name = $env.CONDA_OLD_PATH
 

--- a/modules/virtual_environments/nu_conda/nu_conda.nu
+++ b/modules/virtual_environments/nu_conda/nu_conda.nu
@@ -22,7 +22,7 @@ export-env {
   $env.CONDA_CURR = null
 }
 
-export def --env activate [name: string] {
+export def --env "conda activate" [name: string] {
   if ($env.CONDA_ROOT | is-empty) {
     print "Neither Conda nor Mamba is valid."
     return
@@ -44,7 +44,7 @@ export def --env activate [name: string] {
   load-env ({CONDA_CURR: $name} | merge $new_path)
 }
 
-export def --env deactivate [] {
+export def --env "conda deactivate" [] {
   if ($env.CONDA_ROOT | is-empty) {
     print "Neither Conda nor Mamba is valid."
     return
@@ -55,7 +55,7 @@ export def --env deactivate [] {
   load-env {Path: $env.CONDA_BASE_PATH, PATH: $env.CONDA_BASE_PATH}
 }
 
-export def --env list [] {
+export def --env "conda list" [] {
   $env.CONDA_ENVS | 
     flatten | 
     transpose | 

--- a/modules/virtual_environments/nu_conda_2/conda.nu
+++ b/modules/virtual_environments/nu_conda_2/conda.nu
@@ -21,7 +21,7 @@ def --env load-conda-info-env [] {
 }
 
 # Activate conda environment
-export def --env activate [
+export def --env "conda activate" [
     env_name: string@'nu-complete conda envs' = "base" # name of the environment
 ] {
     load-conda-info-env
@@ -94,7 +94,7 @@ export def --env activate [
 }
 
 # Deactivate currently active conda environment
-export def --env deactivate [] {
+export def --env "conda deactivate" [] {
     let path_name = if "PATH" in $env { "PATH" } else { "Path" }
     $env.$path_name = $env.CONDA_OLD_PATH
 


### PR DESCRIPTION
I wasn't sure if this was on purpose or not but the conda environments were simply "activate" and "deactivate" instead of "conda activate" and "conda deactivate" as they would be normally in bash/zsh.

Due to the potential name conflicts I think it's better to leave these as the more specific `conda activate` and let the user define an alias in their file with `alias activate = conda activate`