### PR TITLE
Add `zellij action new-tab` completions

### DIFF
--- a/custom-completions/zellij/zellij-completions.nu
+++ b/custom-completions/zellij/zellij-completions.nu
@@ -81,6 +81,13 @@ def "nu-complete sessions" [] {
   ^zellij ls -n | lines | parse "{value} {description}"
 }
 
+def "nu-complete zellij layouts" [] {
+	ls ~/.config/zellij/layouts/ 
+		| where name =~ "\\.kdl" 
+		| get name 
+		| each { |$it| { value: ($it | path basename | str replace ".kdl" ""), description: $it } }
+}
+
 # Turned off since it messes with sub-commands
 #export extern "zellij" [
 #  command?: string@"nu-complete zellij"
@@ -104,6 +111,15 @@ export extern "zellij action" [
 # Renames the focused tab
 export extern "zellij action rename-tab" [
   name: string # Name for the tab
+]
+
+# Create a new tab, optionally with a specified tab layout and name
+export extern "zellij action new-tab" [
+  --cwd(-c): path # Change the working directory of the new tab
+  --help(-h) # Print help information
+  --layout(-l): string@"nu-complete zellij layouts" # Layout ot use for the new tab
+  --layout-dir: path # Default folder to look for layouts
+  --name(-n): string # Name for the tab
 ]
 
 # Attach to a session

--- a/custom-completions/zellij/zellij-completions.nu
+++ b/custom-completions/zellij/zellij-completions.nu
@@ -82,7 +82,17 @@ def "nu-complete sessions" [] {
 }
 
 def "nu-complete zellij layouts" [] {
-	ls ~/.config/zellij/layouts/ 
+	let layout_dir = if 'ZELLIJ_CONFIG_DIR' in $env {
+		[$env.ZELLIJ_CONFIG_DIR "layouts"] | path join
+	} else {
+		match $nu.os-info.name {
+			"linux" => "~/.config/zellij/layouts/"
+			"mac" => "~/Library/Application Support/org.Zellij-Contributors.Zellij/layouts"
+			_ => (error make { msg: "Unsupported OS for zellij" })
+		}
+	}
+
+	ls ( $layout_dir | path expand )
 		| where name =~ "\\.kdl" 
 		| get name 
 		| each { |$it| { value: ($it | path basename | str replace ".kdl" ""), description: $it } }


### PR DESCRIPTION
This PR add completions for this `zellij action new-tab` command, which is currently missing.