### PR TITLE
Add nu_plugin_nu_example to bump-version.nu

### DIFF
--- a/make_release/bump-version.nu
+++ b/make_release/bump-version.nu
@@ -36,7 +36,10 @@ def main [
             | save --force $file
     }
 
-    ["crates/nu_plugin_python/nu_plugin_python_example.py"] | each {|file|
+    [
+        "crates/nu_plugin_python/nu_plugin_python_example.py"
+        "crates/nu_plugin_nu_example/nu_plugin_nu_example.nu"
+    ] | each {|file|
         log debug $"bumping ($file) from ($version) to ($new_version)"
         open --raw $file
             | str replace --all $'NUSHELL_VERSION = "($version)"' $'NUSHELL_VERSION = "($new_version)"'


### PR DESCRIPTION
What it says on the tin. This just updates the `bump-version.nu` script to also edit the version in
the new nu_plugin_nu_example plugin, the same way it does for python
