### PR TITLE
`create-pr`: add `git@` to the ssh url

### DIFF
--- a/make_release/release-note/create-pr
+++ b/make_release/release-note/create-pr
@@ -97,7 +97,7 @@ by opening PRs against the `release-notes-($version)` branch.
 
     log info "setting up nushell.github.io repo"
     git clone https://github.com/nushell/nushell.github.io $repo --origin nushell --branch main --single-branch
-    git -C $repo remote set-url nushell --push ssh://github.com/nushell/nushell.github.io
+    git -C $repo remote set-url nushell --push ssh://git@github.com/nushell/nushell.github.io
 
     log info "creating release branch"
     git -C $repo checkout -b $branch nushell/main


### PR DESCRIPTION
Ran into a bit of an issue where the script wouldn't work for me because it was trying to push to `devyn@github.com`. The username must be `git`
