### PR TITLE
fix: adjust for nushell `commandline` syntax deprecation

### DIFF
--- a/custom-menus/fuzzy/directory.nu
+++ b/custom-menus/fuzzy/directory.nu
@@ -5,7 +5,7 @@
     mode: [emacs, vi_normal, vi_insert]
     event: {
         send: executehostcommand
-        cmd: "commandline -a (
+        cmd: "commandline edit --append (
             ls **/*
             | where type == dir
             | get name

--- a/custom-menus/fuzzy/modules.nu
+++ b/custom-menus/fuzzy/modules.nu
@@ -6,8 +6,8 @@
     event: {
         send: executehostcommand
         cmd: '
-            commandline --replace "use "
-            commandline --insert (
+            commandline edit --replace "use "
+            commandline edit --insert (
                 $env.NU_LIB_DIRS
                 | each {|dir|
                     ls ($dir | path join "**" "*.nu")

--- a/themes/nu-themes/preview-theme.nu
+++ b/themes/nu-themes/preview-theme.nu
@@ -55,12 +55,12 @@ def "nu-complete list themes" [] {
 
 # preview completion. For this to work, it should be ran from the nu_scripts folder
 def preview [theme: string@"nu-complete list themes"] {
-    commandline --insert $"use themes/themes/($theme).nu; $env.config.color_config = (char lparen)($theme)(char rparen); preview_theme | table -e"
+    commandline edit --insert $"use themes/themes/($theme).nu; $env.config.color_config = (char lparen)($theme)(char rparen); preview_theme | table -e"
 }
 
 # preview completion. For this to work, it should be ran from the nu_scripts folder
 def preview_small [theme: string@"nu-complete list themes"] {
-    commandline --insert $"use themes/themes/($theme).nu; $env.config.color_config = (char lparen)($theme)(char rparen); preview_theme_small | table -e"
+    commandline edit --insert $"use themes/themes/($theme).nu; $env.config.color_config = (char lparen)($theme)(char rparen); preview_theme_small | table -e"
 }
 
 # Preview the current nushell theme, small mode


### PR DESCRIPTION
Fixes for changes introduced by https://github.com/nushell/nushell/pull/12658