### PR TITLE
fix regressions noted in 0.93.1 from 0.83:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .mailmap
 
 check-files.nu
+
+.vscode/


### PR DESCRIPTION
1. double pathsep when displaying PWD
2. error 'not a git repo' when PWD outside a repo (`do --ignore-error {}` no longer eats the stderr text?)
3. improve display when terminal quite narrow (not a regression, just an improvement)
4. reduce overhead for padding