### PR TITLE
Edit release notes template

### DIFF
--- a/make_release/Readme.md
+++ b/make_release/Readme.md
@@ -72,7 +72,7 @@
 
 - [ ] inspect the merged PRs to write changelogs with `./make_release/release-note/list-merged-prs nushell/nushell`
 - [ ] reorder sections by priority, what makes the most sense to the user?
-- [ ] paste the output of  `./make_release/release-note/list-merged-prs nushell/nushell --label breaking-change --pretty --no-author` to the "*Breaking changes*" section
+- [ ] paste the output of `./make_release/release-note/list-merged-prs nushell/nushell --label pr:breaking-change --pretty --no-author` to the "*Breaking changes*" section
 - [ ] make sure breaking changes titles are clear enough
 - [ ] paste the output of `./make_release/release-note/get-full-changelog` to the "*Full changelog*" section
 - [ ] mark as *ready for review* when uploading to *crates.io*

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -25,11 +25,13 @@ As part of this release, we also publish a set of optional plugins you can insta
 - [*Hall of fame*](#hall-of-fame-toc)
     - [*Bug fixes*](#bug-fixes-toc)
     - [*Enhancing the documentation*](#enhancing-the-documentation-toc)
-- [*Our set of commands is evolving*](#our-set-of-commands-is-evolving-toc)
-    - [*New commands*](#new-commands-toc)
-    - [*Changes to existing commands*](#changes-to-existing-commands-toc)
-    - [*Deprecated commands*](#deprecated-commands-toc)
-    - [*Removed commands*](#removed-commands-toc)
+- [*Changes to commands*](#changes-to-commands-toc)
+    - [*Additions*](#additions-toc)
+    - [*Breaking changes*](#breaking-changes-toc)
+    - [*Deprecations*](#deprecations-toc)
+    - [*Removals*](#removals-toc)
+    - [*Other changes*](#other-changes-toc)
+    - [*Bug fixes*](#bug-fixes-toc)
 <!-- TODO: please add links to the other sections here
 
     the following command should help pre-generate a great deal of the table of content.
@@ -45,7 +47,7 @@ As part of this release, we also publish a set of optional plugins you can insta
         | to text
     ```
 -->
-- [*Breaking changes*](#breaking-changes-toc)
+- [*All breaking changes*](#all-breaking-changes-toc)
 - [*Full changelog*](#full-changelog-toc)
 
 # Highlights and themes of this release [[toc](#table-of-content)]
@@ -76,13 +78,19 @@ Thanks to all the contributors below for helping us making the documentation of 
 | ------------------------------------ | ----------- | ------------------------------------------------------- |
 | [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
 
-# Our set of commands is evolving [[toc](#table-of-content)]
-As usual, new release rhyms with changes to commands!
+# Changes to commands [[toc](#table-of-content)]
 
-## New commands [[toc](#table-of-content)]
-## Changes to existing commands [[toc](#table-of-content)]
-## Deprecated commands [[toc](#table-of-content)]
-## Removed commands [[toc](#table-of-content)]
+## Additions [[toc](#table-of-content)]
+
+## Breaking changes [[toc](#table-of-content)]
+
+## Deprecations [[toc](#table-of-content)]
+
+## Removals [[toc](#table-of-content)]
+
+## Other changes [[toc](#table-of-content)]
+
+## Bug fixes [[toc](#table-of-content)]
 
 <!-- NOTE: to start investigating the contributions of last release, i like to list them all in a raw table.
     to achieve this, one can use the [`list-merged-prs` script from `nu_scripts`](https://github.com/nushell/nu_scripts/blob/main/make_release/release-note/list-merged-prs)
@@ -112,7 +120,7 @@ As usual, new release rhyms with changes to commands!
     ```
 -->
 
-# Breaking changes [[toc](#table-of-content)]
+# All breaking changes [[toc](#table-of-content)]
 <!-- TODO:
     paste the output of
     ```nu

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -22,9 +22,6 @@ As part of this release, we also publish a set of optional plugins you can insta
 
 # Table of content
 - [*Highlights and themes of this release*](#highlights-and-themes-of-this-release-toc)
-- [*Hall of fame*](#hall-of-fame-toc)
-    - [*Bug fixes*](#bug-fixes-toc)
-    - [*Enhancing the documentation*](#enhancing-the-documentation-toc)
 - [*Changes to commands*](#changes-to-commands-toc)
     - [*Additions*](#additions-toc)
     - [*Breaking changes*](#breaking-changes-toc)
@@ -33,6 +30,7 @@ As part of this release, we also publish a set of optional plugins you can insta
     - [*Other changes*](#other-changes-toc)
     - [*Bug fixes*](#bug-fixes-toc)
 - [*All breaking changes*](#all-breaking-changes-toc)
+- [*Hall of fame*](#hall-of-fame-toc)
 - [*Full changelog*](#full-changelog-toc)
 <!-- TODO: please add links to the other sections here
 
@@ -64,19 +62,6 @@ As part of this release, we also publish a set of optional plugins you can insta
 <!-- NOTE: see https://vuepress.github.io/reference/default-theme/markdown.html#custom-containers
     for the list of available *containers*
 -->
-
-# Hall of fame [[toc](#table-of-content)]
-## Bug fixes [[toc](#table-of-content)]
-Thanks to all the contributors below for helping us solve issues and bugs :pray:
-| author                               | description | url                                                     |
-| ------------------------------------ | ----------- | ------------------------------------------------------- |
-| [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
-
-## Enhancing the documentation [[toc](#table-of-content)]
-Thanks to all the contributors below for helping us making the documentation of Nushell commands better :pray:
-| author                               | description | url                                                     |
-| ------------------------------------ | ----------- | ------------------------------------------------------- |
-| [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
 
 # Changes to commands [[toc](#table-of-content)]
 
@@ -128,6 +113,14 @@ Thanks to all the contributors below for helping us making the documentation of 
     ```
     here
 -->
+
+# Hall of fame [[toc](#table-of-content)]
+
+Thanks to all the contributors below for helping us solve issues and improve documentation :pray:
+
+| author                               | title       | url                                                     |
+| ------------------------------------ | ----------- | ------------------------------------------------------- |
+| [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
 
 # Full changelog [[toc](#table-of-content)]
 <!-- TODO:

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -22,14 +22,14 @@ As part of this release, we also publish a set of optional plugins you can insta
 
 # Table of content
 - [*Highlights and themes of this release*](#highlights-and-themes-of-this-release-toc)
-    - [*Hall of fame*](#hall-of-fame-toc)
-        - [*Bug fixes*](#bug-fixes-toc)
-        - [*Enhancing the documentation*](#enhancing-the-documentation-toc)
-    - [*Our set of commands is evolving*](#our-set-of-commands-is-evolving-toc)
-        - [*New commands*](#new-commands-toc)
-        - [*Changes to existing commands*](#changes-to-existing-commands-toc)
-        - [*Deprecated commands*](#deprecated-commands-toc)
-        - [*Removed commands*](#removed-commands-toc)
+- [*Hall of fame*](#hall-of-fame-toc)
+    - [*Bug fixes*](#bug-fixes-toc)
+    - [*Enhancing the documentation*](#enhancing-the-documentation-toc)
+- [*Our set of commands is evolving*](#our-set-of-commands-is-evolving-toc)
+    - [*New commands*](#new-commands-toc)
+    - [*Changes to existing commands*](#changes-to-existing-commands-toc)
+    - [*Deprecated commands*](#deprecated-commands-toc)
+    - [*Removed commands*](#removed-commands-toc)
 <!-- TODO: please add links to the other sections here
 
     the following command should help pre-generate a great deal of the table of content.
@@ -63,26 +63,26 @@ As part of this release, we also publish a set of optional plugins you can insta
     for the list of available *containers*
 -->
 
-## Hall of fame [[toc](#table-of-content)]
-### Bug fixes [[toc](#table-of-content)]
+# Hall of fame [[toc](#table-of-content)]
+## Bug fixes [[toc](#table-of-content)]
 Thanks to all the contributors below for helping us solve issues and bugs :pray:
 | author                               | description | url                                                     |
 | ------------------------------------ | ----------- | ------------------------------------------------------- |
 | [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
 
-### Enhancing the documentation [[toc](#table-of-content)]
+## Enhancing the documentation [[toc](#table-of-content)]
 Thanks to all the contributors below for helping us making the documentation of Nushell commands better :pray:
 | author                               | description | url                                                     |
 | ------------------------------------ | ----------- | ------------------------------------------------------- |
 | [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
 
-## Our set of commands is evolving [[toc](#table-of-content)]
+# Our set of commands is evolving [[toc](#table-of-content)]
 As usual, new release rhyms with changes to commands!
 
-### New commands [[toc](#table-of-content)]
-### Changes to existing commands [[toc](#table-of-content)]
-### Deprecated commands [[toc](#table-of-content)]
-### Removed commands [[toc](#table-of-content)]
+## New commands [[toc](#table-of-content)]
+## Changes to existing commands [[toc](#table-of-content)]
+## Deprecated commands [[toc](#table-of-content)]
+## Removed commands [[toc](#table-of-content)]
 
 <!-- NOTE: to start investigating the contributions of last release, i like to list them all in a raw table.
     to achieve this, one can use the [`list-merged-prs` script from `nu_scripts`](https://github.com/nushell/nu_scripts/blob/main/make_release/release-note/list-merged-prs)

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -30,6 +30,7 @@ As part of this release, we also publish a set of optional plugins you can insta
   - [_Other changes_](#other-changes-toc)
   - [_Bug fixes_](#bug-fixes-toc)
 - [_All breaking changes_](#all-breaking-changes-toc)
+  - [_Notes for plugin developers_](#notes-for-plugin-developers)
 - [_Hall of fame_](#hall-of-fame-toc)
 - [_Full changelog_](#full-changelog-toc)
 <!-- TODO: please add links to the other sections here
@@ -112,6 +113,8 @@ As part of this release, we also publish a set of optional plugins you can insta
     ```
     here
 -->
+
+## Notes for plugin developers
 
 # Hall of fame [[toc](#table-of-content)]
 

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -109,7 +109,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 <!-- TODO:
     paste the output of
     ```nu
-    ./make_release/release-note/list-merged-prs nushell/nushell --label breaking-change --pretty --no-author
+    ./make_release/release-note/list-merged-prs nushell/nushell --label pr:breaking-change --pretty --no-author
     ```
     here
 -->

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -21,7 +21,7 @@ Nu {{VERSION}} is available as [pre-built binaries](https://github.com/nushell/n
 As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
 
 # Table of content
-- [*Themes of this release / New features*](#themes-of-this-release-new-features-toc)
+- [*Highlights and themes of this release*](#highlights-and-themes-of-this-release-toc)
     - [*Hall of fame*](#hall-of-fame-toc)
         - [*Bug fixes*](#bug-fixes-toc)
         - [*Enhancing the documentation*](#enhancing-the-documentation-toc)
@@ -48,7 +48,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 - [*Breaking changes*](#breaking-changes-toc)
 - [*Full changelog*](#full-changelog-toc)
 
-# Themes of this release / New features [[toc](#table-of-content)]
+# Highlights and themes of this release [[toc](#table-of-content)]
 <!-- NOTE: if you wanna write a section about a breaking change, when it's a very important one,
     please add the following snippet to have a "warning" banner :)
     > see [an example](https://www.nushell.sh/blog/2023-09-19-nushell_0_85_0.html#pythonesque-operators-removal)

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -18,10 +18,6 @@ Today, we're releasing version {{VERSION}} of Nu. This release adds...
 
 Nu {{VERSION}} is available as [pre-built binaries](https://github.com/nushell/nushell/releases/tag/{{VERSION}}) or from [crates.io](https://crates.io/crates/nu). If you have Rust installed you can install it using `cargo install nu`.
 
-::: tip Note
-The optional dataframe functionality is available by `cargo install nu --features=dataframe`.
-:::
-
 As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
 
 # Table of content

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -21,17 +21,17 @@ Nu {{VERSION}} is available as [pre-built binaries](https://github.com/nushell/n
 As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
 
 # Table of content
-- [*Highlights and themes of this release*](#highlights-and-themes-of-this-release-toc)
-- [*Changes to commands*](#changes-to-commands-toc)
-    - [*Additions*](#additions-toc)
-    - [*Breaking changes*](#breaking-changes-toc)
-    - [*Deprecations*](#deprecations-toc)
-    - [*Removals*](#removals-toc)
-    - [*Other changes*](#other-changes-toc)
-    - [*Bug fixes*](#bug-fixes-toc)
-- [*All breaking changes*](#all-breaking-changes-toc)
-- [*Hall of fame*](#hall-of-fame-toc)
-- [*Full changelog*](#full-changelog-toc)
+- [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
+- [_Changes to commands_](#changes-to-commands-toc)
+  - [_Additions_](#additions-toc)
+  - [_Breaking changes_](#breaking-changes-toc)
+  - [_Deprecations_](#deprecations-toc)
+  - [_Removals_](#removals-toc)
+  - [_Other changes_](#other-changes-toc)
+  - [_Bug fixes_](#bug-fixes-toc)
+- [_All breaking changes_](#all-breaking-changes-toc)
+- [_Hall of fame_](#hall-of-fame-toc)
+- [_Full changelog_](#full-changelog-toc)
 <!-- TODO: please add links to the other sections here
 
     the following command should help pre-generate a great deal of the table of content.
@@ -42,7 +42,7 @@ As part of this release, we also publish a set of optional plugins you can insta
         | each {
             str replace '# ' '- '
                 | str replace --all '#' '    '
-                | str replace --regex '- (.*)' '- [*$1*](#$1-toc)'
+                | str replace --regex '- (.*)' '- [_$1_](#$1-toc)'
         }
         | to text
     ```

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -93,7 +93,6 @@ As part of this release, we also publish a set of optional plugins you can insta
         | last
 
     let prs = list-merged-prs nushell/nushell $last_release_date
-        | where author != "app/dependabot"
         | sort-by mergedAt
         | update url {|it| $"[#($it.number)]\(($it.url)\)" }
         | update author { $"[@($in)]\(https://github.com/($in)\)" }

--- a/make_release/release-note/template.md
+++ b/make_release/release-note/template.md
@@ -32,6 +32,8 @@ As part of this release, we also publish a set of optional plugins you can insta
     - [*Removals*](#removals-toc)
     - [*Other changes*](#other-changes-toc)
     - [*Bug fixes*](#bug-fixes-toc)
+- [*All breaking changes*](#all-breaking-changes-toc)
+- [*Full changelog*](#full-changelog-toc)
 <!-- TODO: please add links to the other sections here
 
     the following command should help pre-generate a great deal of the table of content.
@@ -47,8 +49,6 @@ As part of this release, we also publish a set of optional plugins you can insta
         | to text
     ```
 -->
-- [*All breaking changes*](#all-breaking-changes-toc)
-- [*Full changelog*](#full-changelog-toc)
 
 # Highlights and themes of this release [[toc](#table-of-content)]
 <!-- NOTE: if you wanna write a section about a breaking change, when it's a very important one,


### PR DESCRIPTION
- Removes the note about installing the dataframes feature.
- Moves the command changes section to the top level, renames some sub sections, and adds some more sub sections.
- Moves and simplifies the hall of fame.