### PR TITLE
Support whitespace before target name for make completions

### DIFF
--- a/custom-completions/make/make-completions.nu
+++ b/custom-completions/make/make-completions.nu
@@ -5,10 +5,9 @@ def "nu-complete make" [] {
 	| lines 
 	| find ':' 
 	| where ($it | str starts-with '.') == false 
-	| split column ' ' 
-	| get column1 
-	| find ':' 
-	| str replace ':' ''
+	| split column ':' target
+	| get target
+	| str trim
 }
 
 def "nu-complete make jobs" [] {

--- a/custom-completions/make/make-completions.nu
+++ b/custom-completions/make/make-completions.nu
@@ -3,7 +3,7 @@ def "nu-complete make" [] {
 	| find --ignore-case makefile
 	| open $in.0.name
 	| lines 
-	| find ':' 
+	| find --regex '^[\w\.-]+\s*:' 
 	| where ($it | str starts-with '.') == false 
 	| split column ':' target
 	| get target


### PR DESCRIPTION
TL;DR: The "simple" example from https://www.gnu.org/software/make/manual/html_node/Simple-Makefile.html is currently not compatible with the custom completion script found in `custom-completions/make/make-completions.nu`. This PR tries to fix that.

As I was working on `nur` (https://github.com/ddanier/nur) and the `nurify` script to convert to `nur` from different task runners (https://github.com/ddanier/nur/blob/main/scripts/nurify.nu) I wanted to create a good way to convert from using `make`. So I thought the `make` completion would for sure implement a good way to get a list of all possible `make` targets. Hence I started looking at `custom-completions/make/make-completions.nu`.

Then I searched for a good documentation for how `Makefile`s work, as the last time I was using this myself is about 5 to 10 years ago. If you for example look at the documentation on gnu.org you may find examples of `Makefile`s not working with the current autocompletion. See https://www.gnu.org/software/make/manual/html_node/Simple-Makefile.html for example, the "simple" example they provide.

The reason for this not working is that the targets use some whitespace after the target name. This is somehow allowed and thus valid. See https://www.gnu.org/software/make/manual/html_node/Rule-Introduction.html for a quick overview about how the `Makefile`s syntax works. I quickly checked this to ensure `make` actually parses this correctly, it really does.

This means that the current `make` completion does miss support for the "simple" example provided my `make` itself. So I went on to fix this.

My suggested solution is:
* Filter all lines by regex `'^[\w\.-]+\s*:'` to ensure possible targets
  - start with some word (also allowing `.` and `-`)
  - may have some whitespaces after the word
  - has ":" after this
* Split by the ":"
* Use first column
* Trim the remaining target name to remove those nasty whitespaces
* Use result for completion

For me this did fix the issue with the "simple" `Makefile`, allowing me to put this into my `nurify` script.

Would be nice to get this "backported" to nu scripts as well. Might help others 😉