### PR TITLE
improve `std bench` and add `significant-digits`

### DIFF
--- a/stdlib-candidate/std-rfc/bench.nu
+++ b/stdlib-candidate/std-rfc/bench.nu
@@ -7,7 +7,7 @@ use ./math
 def "from ns" [
     --units: string # units to convert duration to (min, sec, ms, µs, ns)
 ] {
-    math reset-insignificant-digits
+    math significant-digits
     | $"($in)ns"
     | into duration
     | if $units != null {

--- a/stdlib-candidate/std-rfc/bench.nu
+++ b/stdlib-candidate/std-rfc/bench.nu
@@ -1,11 +1,13 @@
 # A proposal for improving the original `std bench` command by @amtoine
 # https://github.com/nushell/nushell/blob/31f3d2f6642b585f0d88192724723bf0ce330ecf/crates/nu-std/std/mod.nu#L134
 
+use ./math
+
 # convert an integer amount of nanoseconds to a real duration
 def "from ns" [
     --units: string # units to convert duration to (min, sec, ms, µs, ns)
 ] {
-    round-significant-digits
+    math reset-insignificant-digits
     | $"($in)ns"
     | into duration
     | if $units != null {
@@ -66,13 +68,13 @@ def "from ns" [
 #     get a pretty benchmark report
 #     > std bench {1 + 2} --pretty
 #     922ns +/- 2µs 40ns
-export def bench [
+export def main [
     code: closure  # the piece of `nushell` code to measure the performance of
     --rounds (-n): int = 50  # the number of benchmark rounds (hopefully the more rounds the less variance)
     --verbose (-v) # be more verbose (namely prints the progress)
     --pretty # shows the results in human-readable format: "<mean> +/- <stddev>"
     --units: string # units to convert duration to (min, sec, ms, µs, ns)
-    --list_timings # list all rounds' timings in a `times` cell
+    --list_timings # list all rounds' timings in a `times` field
 ] {
     let times = seq 1 $rounds
         | each {|i|

--- a/stdlib-candidate/std-rfc/bench.nu
+++ b/stdlib-candidate/std-rfc/bench.nu
@@ -1,0 +1,99 @@
+# A proposal for improving the original `std bench` command by @amtoine
+# https://github.com/nushell/nushell/blob/31f3d2f6642b585f0d88192724723bf0ce330ecf/crates/nu-std/std/mod.nu#L134
+
+# convert an integer amount of nanoseconds to a real duration
+def "from ns" [
+    --units: string # units to convert duration to (min, sec, ms, µs, ns)
+] {
+    round-significant-digits
+    | $"($in)ns"
+    | into duration
+    | if $units != null {
+        format duration $units
+    } else {}
+}
+
+# run a piece of `nushell` code multiple times and measure the time of execution.
+#
+# this command returns a benchmark report of the following form:
+# ```
+# record<
+#   mean: duration
+#   min: duration
+#   max: duration
+#   std: duration
+#   times: list<duration>
+# >
+# ```
+#
+# > **Note**
+# > `std bench --pretty` will return a `string`.
+# > the `--units` option will convert all durations to strings
+#
+# # Examples
+#     measure the performance of simple addition
+#     > std bench {1 + 2}
+#     ╭──────┬────────────╮
+#     │ mean │ 3µs 30ns   │
+#     │ min  │ 542ns      │
+#     │ max  │ 12µs 900ns │
+#     │ std  │ 3µs 550ns  │
+#     ╰──────┴────────────╯
+#
+#     measure the performance of simple addition and output each timing
+#     > std bench {1 + 2} --list_timings -n 3 | table -e
+#     ╭───────┬───────────────╮
+#     │ mean  │ 2µs 970ns     │
+#     │ min   │ 833ns         │
+#     │ max   │ 7µs 210ns     │
+#     │ std   │ 3µs           │
+#     │       │ ╭───────────╮ │
+#     │ times │ │ 7µs 210ns │ │
+#     │       │ │     875ns │ │
+#     │       │ │     833ns │ │
+#     │       │ ╰───────────╯ │
+#     ╰───────┴───────────────╯
+#
+#     Output results of a benchmark in `ms`
+#     > std bench {sleep 1sec} --units ms
+#     ╭──────┬─────────╮
+#     │ mean │ 1000 ms │
+#     │ min  │ 1000 ms │
+#     │ max  │ 1010 ms │
+#     │ std  │ 1.87 ms │
+#     ╰──────┴─────────╯
+#
+#     get a pretty benchmark report
+#     > std bench {1 + 2} --pretty
+#     922ns +/- 2µs 40ns
+export def bench [
+    code: closure  # the piece of `nushell` code to measure the performance of
+    --rounds (-n): int = 50  # the number of benchmark rounds (hopefully the more rounds the less variance)
+    --verbose (-v) # be more verbose (namely prints the progress)
+    --pretty # shows the results in human-readable format: "<mean> +/- <stddev>"
+    --units: string # units to convert duration to (min, sec, ms, µs, ns)
+    --list_timings # list all rounds' timings in a `times` cell
+] {
+    let times = seq 1 $rounds
+        | each {|i|
+            if $verbose { print -n $"($i) / ($rounds)\r" }
+            timeit { do $code } | into int | into float
+        }
+
+    if $verbose { print $"($rounds) / ($rounds)" }
+
+    {
+        mean: ($times | math avg | from ns --units $units)
+        min: ($times | math min | from ns --units $units)
+        max: ($times | math max | from ns --units $units)
+        std: ($times | math stddev | from ns --units $units)
+    }
+    | if $pretty {
+        $"($in.mean) +/- ($in.std)"
+    } else {
+        if $list_timings {
+            # we don't use --units as to enable a user to do final trasnformations
+            merge { times: ($times | each { from ns }) }
+        } else {}
+    }
+}

--- a/stdlib-candidate/std-rfc/bench.nu
+++ b/stdlib-candidate/std-rfc/bench.nu
@@ -37,40 +37,39 @@ def "from ns" [
 #
 # # Examples
 #     measure the performance of simple addition
-#     > std bench {1 + 2}
-#     ╭──────┬────────────╮
-#     │ mean │ 3µs 30ns   │
-#     │ min  │ 542ns      │
-#     │ max  │ 12µs 900ns │
-#     │ std  │ 3µs 550ns  │
-#     ╰──────┴────────────╯
-#
-#     measure the performance of simple addition and output each timing
-#     > std bench {1 + 2} --list_timings -n 3 | table -e
-#     ╭───────┬───────────────╮
-#     │ mean  │ 2µs 970ns     │
-#     │ min   │ 833ns         │
-#     │ max   │ 7µs 210ns     │
-#     │ std   │ 3µs           │
-#     │       │ ╭───────────╮ │
-#     │ times │ │ 7µs 210ns │ │
-#     │       │ │     875ns │ │
-#     │       │ │     833ns │ │
-#     │       │ ╰───────────╯ │
-#     ╰───────┴───────────────╯
-#
-#     Output results of a benchmark in `ms`
-#     > std bench {sleep 1sec} --units ms
-#     ╭──────┬─────────╮
-#     │ mean │ 1000 ms │
-#     │ min  │ 1000 ms │
-#     │ max  │ 1010 ms │
-#     │ std  │ 1.87 ms │
-#     ╰──────┴─────────╯
+#     > bench {1 + 2}
+#     ╭──────┬───────────╮
+#     │ mean │ 716ns     │
+#     │ min  │ 583ns     │
+#     │ max  │ 4µs 541ns │
+#     │ std  │ 549ns     │
+#     ╰──────┴───────────╯
 #
 #     get a pretty benchmark report
 #     > std bench {1 + 2} --pretty
 #     922ns +/- 2µs 40ns
+#
+#     format results as `ms`
+#     > bench {sleep 0.1sec; 1 + 2} --units ms --rounds 5
+#     ╭──────┬───────────╮
+#     │ mean │ 104.90 ms │
+#     │ min  │ 103.60 ms │
+#     │ max  │ 105.90 ms │
+#     │ std  │ 0.75 ms   │
+#     ╰──────┴───────────╯
+#
+#     measure the performance of simple addition with 1ms delay and output each timing
+#     > bench {sleep 1ms; 1 + 2} --rounds 2 --list-timings | table -e
+#     ╭───────┬─────────────────────╮
+#     │ mean  │ 1ms 272µs           │
+#     │ min   │ 1ms 259µs           │
+#     │ max   │ 1ms 285µs           │
+#     │ std   │ 13µs 370ns          │
+#     │       │ ╭─────────────────╮ │
+#     │ times │ │ 1ms 285µs 791ns │ │
+#     │       │ │  1ms 259µs 42ns │ │
+#     │       │ ╰─────────────────╯ │
+#     ╰───────┴─────────────────────╯
 export def main [
     code: closure  # the piece of `nushell` code to measure the performance of
     --rounds (-n): int = 50  # the number of benchmark rounds (hopefully the more rounds the less variance)

--- a/stdlib-candidate/std-rfc/bench.nu
+++ b/stdlib-candidate/std-rfc/bench.nu
@@ -77,7 +77,7 @@ export def main [
     --verbose (-v) # be more verbose (namely prints the progress)
     --pretty # shows the results in human-readable format: "<mean> +/- <stddev>"
     --units: string # units to convert duration to (min, sec, ms, µs, ns)
-    --list_timings # list all rounds' timings in a `times` field
+    --list-timings # list all rounds' timings in a `times` field
     --sign-digits: int = 4 # a number of first non-zero digits to keep (default 4; set 0 to disable rounding)
 ] {
     let times = seq 1 $rounds

--- a/stdlib-candidate/std-rfc/bench.nu
+++ b/stdlib-candidate/std-rfc/bench.nu
@@ -6,8 +6,11 @@ use ./math
 # convert an integer amount of nanoseconds to a real duration
 def "from ns" [
     --units: string # units to convert duration to (min, sec, ms, µs, ns)
+    --sign-digits: int # a number of first non-zero digits to keep (default 4; set 0 to disable rounding)
 ] {
-    math significant-digits
+    if $sign_digits == 0 {} else {
+        math significant-digits $sign_digits
+    }
     | $"($in)ns"
     | into duration
     | if $units != null {
@@ -75,6 +78,7 @@ export def main [
     --pretty # shows the results in human-readable format: "<mean> +/- <stddev>"
     --units: string # units to convert duration to (min, sec, ms, µs, ns)
     --list_timings # list all rounds' timings in a `times` field
+    --sign-digits: int = 4 # a number of first non-zero digits to keep (default 4; set 0 to disable rounding)
 ] {
     let times = seq 1 $rounds
         | each {|i|
@@ -85,16 +89,16 @@ export def main [
     if $verbose { print $"($rounds) / ($rounds)" }
 
     {
-        mean: ($times | math avg | from ns --units $units)
-        min: ($times | math min | from ns --units $units)
-        max: ($times | math max | from ns --units $units)
-        std: ($times | math stddev | from ns --units $units)
+        mean: ($times | math avg | from ns --units $units --sign-digits=$sign_digits)
+        min: ($times | math min | from ns --units $units --sign-digits=$sign_digits)
+        max: ($times | math max | from ns --units $units --sign-digits=$sign_digits)
+        std: ($times | math stddev | from ns --units $units --sign-digits=$sign_digits)
     }
     | if $pretty {
         $"($in.mean) +/- ($in.std)"
     } else {
         if $list_timings {
-            # we don't use --units as to enable a user to do final trasnformations
+            # we don't use --units or --sign-digits as to allow a user to make final transformations
             merge { times: ($times | each { from ns }) }
         } else {}
     }

--- a/stdlib-candidate/std-rfc/bench.nu
+++ b/stdlib-candidate/std-rfc/bench.nu
@@ -98,8 +98,7 @@ export def main [
         $"($in.mean) +/- ($in.std)"
     } else {
         if $list_timings {
-            # we don't use --units or --sign-digits as to allow a user to make final transformations
-            merge { times: ($times | each { from ns }) }
+            merge { times: ($times | each { from ns  --units $units --sign-digits 0 }) }
         } else {}
     }
 }

--- a/stdlib-candidate/std-rfc/math/mod.nu
+++ b/stdlib-candidate/std-rfc/math/mod.nu
@@ -21,7 +21,7 @@ use std iter scan
 # > 1sec / 3 | math reset-insignificant-digits
 # 333ms
 export def 'reset-insignificant-digits' [
-    n: int = 4 # a number of significant digits
+    significant_digits: int = 4 # a number of first non-zero digits to keep
 ]: [int -> int, float -> float, duration -> duration] {
     let $input = $in
     let $chars = $input | into string | split chars
@@ -35,7 +35,7 @@ export def 'reset-insignificant-digits' [
             } else {$ind}
         }
         | zip $chars
-        | each {|i| if $i.1 =~ '\d' and $i.0 > $n {'0'} else {$i.1}}
+        | each {|i| if $i.1 =~ '\d' and $i.0 > $significant_digits {'0'} else {$i.1}}
         | str join
 
     match ($input | describe) {

--- a/stdlib-candidate/std-rfc/math/mod.nu
+++ b/stdlib-candidate/std-rfc/math/mod.nu
@@ -18,14 +18,10 @@ use std iter scan
 # > 1.2346789 | reset-insignificant-digits 3
 # 1.23
 #
-# > 123456789.89 | reset-insignificant-digits 5 --floor
-# 123450000
-#
 # > 1sec / 3 | math reset-insignificant-digits
 # 333ms
 export def 'reset-insignificant-digits' [
     n: int = 3 # a number of significant digits
-    --floor # use `math floor` for rounding
 ]: [int -> int, float -> float, duration -> duration] {
     let $input = $in
     let $num = $input | into string | split chars

--- a/stdlib-candidate/std-rfc/math/mod.nu
+++ b/stdlib-candidate/std-rfc/math/mod.nu
@@ -1,0 +1,45 @@
+# replace all insignificant digits with 0
+#
+# | Significant Digits | Maximum Relative Error |
+# |--------------------|------------------------|
+# | 1                  | 50%                    |
+# | 2                  | 5%                     |
+# | 3                  | 0.5%                   |
+# | 4                  | 0.05%                  |
+# | 5                  | 0.005%                 |
+# | 6                  | 0.0005%                |
+#
+# > 0.0000012346789 | round-significant-digits 2
+# 0.0000012
+#
+# > 1.2346789 | round-significant-digits 3
+# 1.23
+#
+# > 123456789.89 | round-significant-digits 5 --floor
+# 123450000
+#
+# > 1sec / 3 | math round-significant-digits
+# 333ms
+export def 'round-significant-digits' [
+    n: int = 3 # a number of significant digits
+    --floor # use `math floor` for rounding
+]: [int -> float, float -> float, duration -> duration] {
+    let $input = $in
+    let $type = $input | describe
+
+    let $num = match $type {
+        'int' => {$input | into float}
+        'duration' => {$input | into int | into float}
+        _ => {$input}
+    }
+
+    let first_digit_pos = 1 + ($num | math abs | math log 10 | math floor)
+    let scaling_factor = 10.0 ** ($n - $first_digit_pos)
+
+    $num * $scaling_factor
+    | if $floor {math floor} else {math round}
+    | $in / $scaling_factor
+    | if $type == 'duration' {
+        $'($in)ns' | into duration
+    } else {}
+}

--- a/stdlib-candidate/std-rfc/math/mod.nu
+++ b/stdlib-candidate/std-rfc/math/mod.nu
@@ -12,15 +12,15 @@ use std iter scan
 # | 5                  | 0.005%                 |
 # | 6                  | 0.0005%                |
 #
-# > 0.0000012346789 | reset-insignificant-digits 2
+# > 0.0000012346789 | significant-digits 2
 # 0.0000012
 #
-# > 1.2346789 | reset-insignificant-digits 3
+# > 1.2346789 | significant-digits 3
 # 1.23
 #
-# > 1sec / 3 | math reset-insignificant-digits
+# > 1sec / 3 | math significant-digits
 # 333ms
-export def 'reset-insignificant-digits' [
+export def 'significant-digits' [
     significant_digits: int = 4 # a number of first non-zero digits to keep
 ]: [int -> int, float -> float, duration -> duration] {
     let $input = $in

--- a/stdlib-candidate/std-rfc/math/mod.nu
+++ b/stdlib-candidate/std-rfc/math/mod.nu
@@ -21,12 +21,12 @@ use std iter scan
 # > 1sec / 3 | math reset-insignificant-digits
 # 333ms
 export def 'reset-insignificant-digits' [
-    n: int = 3 # a number of significant digits
+    n: int = 4 # a number of significant digits
 ]: [int -> int, float -> float, duration -> duration] {
     let $input = $in
-    let $num = $input | into string | split chars
+    let $chars = $input | into string | split chars
 
-    let $rounded_str = $num
+    let $rounded_str = $chars
         | scan --noinit 0 {|ind i|
             if $i =~ '\d' {
                 if $ind == 0 and $i == '0' {
@@ -34,9 +34,8 @@ export def 'reset-insignificant-digits' [
                 } else { $ind + 1 }
             } else {$ind}
         }
-        | wrap digit_ind
-        | merge ($num | wrap d)
-        | each {|i| if $i.d =~ '\d' and $i.digit_ind > $n {'0'} else {$i.d}}
+        | zip $chars
+        | each {|i| if $i.1 =~ '\d' and $i.0 > $n {'0'} else {$i.1}}
         | str join
 
     match ($input | describe) {

--- a/stdlib-candidate/std-rfc/math/mod.nu
+++ b/stdlib-candidate/std-rfc/math/mod.nu
@@ -21,7 +21,7 @@ use std iter scan
 # > 1sec / 3 | math significant-digits
 # 333ms
 export def 'significant-digits' [
-    significant_digits: int = 4 # a number of first non-zero digits to keep
+    n: int = 4 # a number of first non-zero digits to keep
 ]: [int -> int, float -> float, duration -> duration] {
     let $input = $in
     let $chars = $input | into string | split chars
@@ -35,7 +35,7 @@ export def 'significant-digits' [
             } else {$ind}
         }
         | zip $chars
-        | each {|i| if $i.1 =~ '\d' and $i.0 > $significant_digits {'0'} else {$i.1}}
+        | each {|i| if $i.1 =~ '\d' and $i.0 > $n {'0'} else {$i.1}}
         | str join
 
     match ($input | describe) {

--- a/stdlib-candidate/std-rfc/mod.nu
+++ b/stdlib-candidate/std-rfc/mod.nu
@@ -1,6 +1,7 @@
 # modules
 export module record/
 export module str/
+export module math/
 # commands
 export use bulk-rename.nu *
 export use set-env.nu *

--- a/stdlib-candidate/std-rfc/mod.nu
+++ b/stdlib-candidate/std-rfc/mod.nu
@@ -5,3 +5,4 @@ export module math/
 # commands
 export use bulk-rename.nu *
 export use set-env.nu *
+export use bench.nu

--- a/stdlib-candidate/tests/bench.nu
+++ b/stdlib-candidate/tests/bench.nu
@@ -1,0 +1,22 @@
+use std assert
+use ../std-rfc bench
+
+export def "test bench-units" [] {
+    let $test = bench {sleep 0.001sec; 1 + 2} --units ns --rounds 2 | get mean
+    assert str contains $test " ns"
+}
+
+export def "test bench-timings" [] {
+    let $test = bench {1 + 2} --rounds 3 --list-timings | get times | length
+    assert equal $test 3
+}
+
+export def "test bench-pretty" [] {
+    let $test = (bench {1 + 2} --rounds 3 --pretty) =~ '\d.* \+/- \d'
+    assert equal $test true
+}
+
+export def "test bench-sign-digits" [] {
+    let $test = bench {sleep 1ms} --sign-digits 1 --rounds 5 | get min
+    assert equal $test 1ms
+}

--- a/stdlib-candidate/tests/math.nu
+++ b/stdlib-candidate/tests/math.nu
@@ -1,0 +1,8 @@
+use std assert
+use ../std-rfc/math
+
+#[test]
+export def "test round-significant-digits" [] {
+    assert equal (0.0000012346789 | math round-significant-digits 2) 0.0000012
+    assert not equal (0.0000012346789 | math round-significant-digits 2) 0.00000123
+}

--- a/stdlib-candidate/tests/math.nu
+++ b/stdlib-candidate/tests/math.nu
@@ -2,7 +2,20 @@ use std assert
 use ../std-rfc/math
 
 #[test]
-export def "test round-significant-digits" [] {
-    assert equal (0.0000012346789 | math round-significant-digits 2) 0.0000012
-    assert not equal (0.0000012346789 | math round-significant-digits 2) 0.00000123
+export def "test reset-insignificant-digits-decimals" [] {
+    assert equal (0.0000012346789 | math reset-insignificant-digits 2) 0.0000012
+    assert equal (11 / 3 | math reset-insignificant-digits 6) 3.66666
+    assert not equal (0.0000012346789 | math reset-insignificant-digits 2) 0.00000123
+    assert equal (1.999999 | math reset-insignificant-digits 1) 1.0
+}
+
+#[test]
+export def "test reset-insignificant-digits-duration" [] {
+    assert equal (2min / 7 | math reset-insignificant-digits 3) 17100000000ns
+    assert equal (1sec | math reset-insignificant-digits 3) 1000000000ns
+}
+
+#[test]
+export def "test reset-insignificant-digits-ints" [] {
+    assert equal (123456 | math reset-insignificant-digits 2) 120000
 }

--- a/stdlib-candidate/tests/math.nu
+++ b/stdlib-candidate/tests/math.nu
@@ -2,20 +2,20 @@ use std assert
 use ../std-rfc/math
 
 #[test]
-export def "test reset-insignificant-digits-decimals" [] {
-    assert equal (0.0000012346789 | math reset-insignificant-digits 2) 0.0000012
-    assert equal (11 / 3 | math reset-insignificant-digits 6) 3.66666
-    assert not equal (0.0000012346789 | math reset-insignificant-digits 2) 0.00000123
-    assert equal (1.999999 | math reset-insignificant-digits 1) 1.0
+export def "test significant-digits-decimals" [] {
+    assert equal (0.0000012346789 | math significant-digits 2) 0.0000012
+    assert equal (11 / 3 | math significant-digits 6) 3.66666
+    assert not equal (0.0000012346789 | math significant-digits 2) 0.00000123
+    assert equal (1.999999 | math significant-digits 1) 1.0
 }
 
 #[test]
-export def "test reset-insignificant-digits-duration" [] {
-    assert equal (2min / 7 | math reset-insignificant-digits 3) 17100000000ns
-    assert equal (1sec | math reset-insignificant-digits 3) 1000000000ns
+export def "test significant-digits-duration" [] {
+    assert equal (2min / 7 | math significant-digits 3) 17100000000ns
+    assert equal (1sec | math significant-digits 3) 1000000000ns
 }
 
 #[test]
-export def "test reset-insignificant-digits-ints" [] {
-    assert equal (123456 | math reset-insignificant-digits 2) 120000
+export def "test significant-digits-ints" [] {
+    assert equal (123456 | math significant-digits 2) 120000
 }

--- a/stdlib-candidate/tests/mod.nu
+++ b/stdlib-candidate/tests/mod.nu
@@ -1,3 +1,4 @@
 export module bulk-rename.nu
 export module record.nu
 export module str_xpend.nu
+export module math.nu

--- a/stdlib-candidate/tests/mod.nu
+++ b/stdlib-candidate/tests/mod.nu
@@ -2,3 +2,4 @@ export module bulk-rename.nu
 export module record.nu
 export module str_xpend.nu
 export module math.nu
+export module bench.nu


### PR DESCRIPTION
Hi! I propose several changes to `std bench`:
- Remove insignificant precision by default (can be reverted with `--sign-digits=0`).
- Remove the 'times' field by default (can be returned with `--list-timings`).
- Add an option to set time units (inactive by default).

For removing insignificant precision, I needed a new command `significant-digits` which is also included in this PR. This command has tests.

<img width="747" alt="image" src="https://github.com/nushell/nu_scripts/assets/4896754/ce98aebe-7c1b-4d8f-b2d0-3282d1ff3883">
<img width="747" alt="image" src="https://github.com/nushell/nu_scripts/assets/4896754/508fef3e-ba70-40fd-8f9e-82b6ac608485">
<img width="747" alt="image" src="https://github.com/nushell/nu_scripts/assets/4896754/af755f28-8506-4f4c-8bc2-91b35798855d">
