### PR TITLE
hotfix for `significant-digits` to not error if the input was 0

### DIFF
--- a/stdlib-candidate/std-rfc/math/mod.nu
+++ b/stdlib-candidate/std-rfc/math/mod.nu
@@ -31,7 +31,16 @@ export def 'significant-digits' [
         _ => {$input}
     }
 
-    let insignif_position = $n - 1 - ($num | math abs | math log 10 | math floor)
+    let insignif_position = $num
+        | if $in == 0 {
+            0 # it's impoosbile to calculate `math log` from 0, thus 0 errors here
+        } else {
+            math abs
+            | math log 10
+            | math floor
+            | $n - 1 - $in
+        }
+
 
     # See the note below the code for an explanation of the construct used.
     let scaling_factor = 10 ** ($insignif_position | math abs)

--- a/stdlib-candidate/tests/math.nu
+++ b/stdlib-candidate/tests/math.nu
@@ -19,3 +19,7 @@ export def "test significant-digits-duration" [] {
 export def "test significant-digits-ints" [] {
     assert equal (123456 | math significant-digits 2) 120000
 }
+
+export def "test significant-digits-0" [] {
+    assert equal (0 | math significant-digits 2) 0
+}

--- a/stdlib-candidate/tests/math.nu
+++ b/stdlib-candidate/tests/math.nu
@@ -23,3 +23,7 @@ export def "test significant-digits-ints" [] {
 export def "test significant-digits-0" [] {
     assert equal (0 | math significant-digits 2) 0
 }
+
+export def "test significant-digits-negative" [] {
+    assert equal (-1.23456789 | math significant-digits 5) (-1.2346)
+}


### PR DESCRIPTION
In the last `pr` there was an error, that I just discovered and fixed. Also I added test for this case in future, and some test for negative numbers

```
0 | signfificant digits 2
 33 │
 34 │     let insignif_position = $n - 1 - ($num | math abs | math log 10 | math floor)
    ·                                       ──┬─              ────┬───
    ·                                         │                   ╰── 'math log' undefined for values outside the open interval (0, Inf).
    ·                                         ╰── value originates from here
 35 │
    ╰────
```

I'm sorry for hassle here 😞 