### PR TITLE
Updated select-aws-profile script to work with nushell version >= 0.94.2

### DIFF
--- a/modules/aws/select-aws-profile.nu
+++ b/modules/aws/select-aws-profile.nu
@@ -9,16 +9,13 @@
 #
 # Usage
 #     select-aws-profile
-export def select-aws-profile [] {
+export def --env main [] {
     hide AWS_REGION;
 
     (do {
         let creds = (open ($env.HOME + "/.aws/credentials") | from toml)
-            let selectedProfile = (for it in ($creds | transpose name creds) {
-                echo $it.name
-            })
-            
-            selectedProfile = selectedProfile  | str join "\n" | fzf | str trim
+        let profiles = $creds | transpose name creds | each {|x| printf $x.name }            
+        let selectedProfile = $profiles | str join "\n" | fzf | str trim
 
             if $selectedProfile != "" {
                 let out = {


### PR DESCRIPTION
I've noticed that the `select-aws-profile` script doesn't work anymore as of nushell version 0.94.2.
I've never used that script before, therefore I don't know from which version on it stopped working.

Exporting a function with the same filename is disallowed, hence the name change to `main`. As per the docs:
> Exporting a command called main from a module defines a command named as the module.

Also, there were scoping issues. The env vars weren't being set. Adding the `--env` flag fixes that.