### PR TITLE
Rmove usage of deprecated `str contains --not`

### DIFF
--- a/modules/prompt/panache-git.nu
+++ b/modules/prompt/panache-git.nu
@@ -55,7 +55,8 @@ export def repo-structured [] {
     $status
     | where ($it | str starts-with '# branch.head')
     | first
-    | str contains --not '(detached)'
+    | str contains '(detached)'
+    | not $in
   } else {
     false
   })


### PR DESCRIPTION
Related: https://github.com/nushell/nushell/issues/13163