### PR TITLE
update vswhere location for nu_msvs

### DIFF
--- a/modules/virtual_environments/nu_msvs/nu_msvs.nu
+++ b/modules/virtual_environments/nu_msvs/nu_msvs.nu
@@ -3,10 +3,16 @@ def --env find_msvs [] {
     $env.MSVS_BASE_PATH = $env.Path
     $env.PATH_VAR = (if "Path" in $env { "Path" } else { "PATH" })
 
+    # This is a total hack because nushell doesn't like parentheses in an environment variable like `$env.ProgramFiles(x86)`
+    let programfiles = $env | transpose name value | where name starts-with Program and name ends-with '(x86)' | get value.0
+    # According to https://github.com/microsoft/vswhere/wiki/Installing, vswhere should always be in this location.
+    let vswhere_cmd = $'($programfiles)\Microsoft Visual Studio\Installer\vswhere.exe'
+
     let info = (
-        if not (which vswhere | is-empty) {
-          (vswhere -format json | from json)
+      if ($vswhere_cmd | path exists) {
+          (^$vswhere_cmd -format json | from json)
         } else {
+          # this should really error out here
           ('{"installationPath": [""]}' | from json)
         }
     )


### PR DESCRIPTION
This PR makes the location of vswhere more programmatic by looking where it's supposed to be located on the file system instead of relying on it being in your path.