### PR TITLE
Prevent branch from merging against main

### DIFF
--- a/make_release/release-note/create-pr
+++ b/make_release/release-note/create-pr
@@ -100,7 +100,7 @@ by opening PRs against the `release-notes-($version)` branch.
     git -C $repo remote set-url nushell --push git@github.com:nushell/nushell.github.io.git
 
     log info "creating release branch"
-    git -C $repo checkout -b $branch nushell/main
+    git -C $repo checkout -b $branch
 
     log info "writing release note"
     $release_note | save --force $blog_path


### PR DESCRIPTION
Having the the main branch listed in the checkout command:
```nushell
git -C $repo checkout -b $branch nushell/main
```

Made my git to track against the main branch, causing it to push to main instead of a branch. Removing the branch fixed the problem:
```nushell
 git -C $repo checkout -b $branch
```