### PR TITLE
add "toolkit" and "startup times" hooks

### DIFF
--- a/nu-hooks/nu-hooks/startup-times.nu
+++ b/nu-hooks/nu-hooks/startup-times.nu
@@ -1,0 +1,39 @@
+# setup a hook that will log startup times
+#
+# # Example
+# ```nushell
+# $env.config.hooks.env_change.PWD = (
+#     $env.config.hooks.env_change.PWD | append (
+#         use nu-hooks/startup-times.nu;
+#         startup-times setup
+#     )
+# )
+# ```
+export def setup [
+    dir: path = $nu.data-dir, # the path where to store the "startup times" file
+]: [ nothing -> closure ] {
+    {|before, _|
+        if $before == null {
+            let file = $dir | path join "startup-times.nuon"
+            if not ($file | path exists) {
+                mkdir ($file | path dirname)
+                touch $file
+            }
+
+            let version = (version)
+
+            # NOTE: this binding is required as per
+            # https://github.com/nushell/nushell/pull/12601#issuecomment-2069167555
+            let startup_times = open $file | append {
+                date: (date now)
+                time: $nu.startup-time
+                build: $version.build_rust_channel
+                allocator: $version.allocator
+                version: $version.version
+                commit: $version.commit_hash
+                build_time: $version.build_time
+            }
+            $startup_times | save --force $file
+        }
+    }
+}

--- a/nu-hooks/nu-hooks/toolkit.nu
+++ b/nu-hooks/nu-hooks/toolkit.nu
@@ -16,11 +16,11 @@ export def setup [
     {
         condition: {|_, after| $after | path join 'toolkit.nu' | path exists }
         code: $"
-            print $'[\(ansi ($color)\)hook\(ansi reset\)] loading toolkit'
+            print $'[\(ansi ($color)\)nu-hooks toolkit\(ansi reset\)] loading toolkit'
             overlay use --prefix toolkit.nu as ($name)
             overlay list
                 | str join ', '
-                | print $'[\(ansi ($color)\)hook\(ansi reset\)] overlays: \($in\)'
+                | print $'[\(ansi ($color)\)nu-hooks toolkit\(ansi reset\)] overlays: \($in\)'
         "
     }
 }

--- a/nu-hooks/nu-hooks/toolkit.nu
+++ b/nu-hooks/nu-hooks/toolkit.nu
@@ -16,11 +16,8 @@ export def setup [
     {
         condition: {|_, after| $after | path join 'toolkit.nu' | path exists }
         code: $"
-            print $'[\(ansi ($color)\)nu-hooks toolkit\(ansi reset\)] loading toolkit'
+            print $'[\(ansi ($color)\)nu-hooks toolkit\(ansi reset\)] loading \(ansi purple\)toolkit.nu\(ansi reset\) as an overlay'
             overlay use --prefix toolkit.nu as ($name)
-            overlay list
-                | str join ', '
-                | print $'[\(ansi ($color)\)nu-hooks toolkit\(ansi reset\)] overlays: \($in\)'
         "
     }
 }

--- a/nu-hooks/nu-hooks/toolkit.nu
+++ b/nu-hooks/nu-hooks/toolkit.nu
@@ -1,0 +1,26 @@
+# setup a hook that will activate `toolkit.nu` when found in a directory
+#
+# # Example
+# ```nushell
+# $env.config.hooks.env_change.PWD = (
+#     $env.config.hooks.env_change.PWD | append (
+#         use nu-hooks/toolkit.nu;
+#         toolkit setup --name "tk" --color "yellow_bold"
+#     )
+# )
+# ```
+export def setup [
+    --name: string = "toolkit", # the name of the overlay, i.e. the command that will be usable
+    --color: string = "yellow_bold", # the color of the "hook" indicator
+]: [ nothing -> record<condition: closure, code: string> ] {
+    {
+        condition: {|_, after| $after | path join 'toolkit.nu' | path exists }
+        code: $"
+            print $'[\(ansi ($color)\)hook\(ansi reset\)] loading toolkit'
+            overlay use --prefix toolkit.nu as ($name)
+            overlay list
+                | str join ', '
+                | print $'[\(ansi ($color)\)hook\(ansi reset\)] overlays: \($in\)'
+        "
+    }
+}


### PR DESCRIPTION
i wanted to share some of my hooks, as i don't see equivalent things in the `nu-hooks` package :relieved: 

## new hooks
- `toolkit.nu`: creates a hook that will activate any `toolkit.nu`
- `startup-times.nu`: creates a hook that will log the startup times in a log file

## review
i think the easiest is to read the docstring and arguments of the two `setup` commands i've added in the two modules defined above :wink: 


cc @fdncred, i might have missed the latest and hotest features of the "startup times" hook, please tell me if something should be added :innocent: 