### PR TITLE
add "nuenv" hook

### DIFF
--- a/nu-hooks/nu-hooks/nuenv/hook.nu
+++ b/nu-hooks/nu-hooks/nuenv/hook.nu
@@ -32,7 +32,7 @@ export def setup []: [ nothing -> record<condition: closure, code: string> ] {
                 }
             }
 
-            print $'[\(ansi yellow_bold\)nu-hooks nuenv\(ansi reset\)] loading env file'
+            print $'[\(ansi yellow_bold\)nu-hooks nuenv\(ansi reset\)] loading env file \(ansi purple\).env.nu\(ansi reset\)'
             source .env.nu
         "
     }

--- a/nu-hooks/nu-hooks/nuenv/hook.nu
+++ b/nu-hooks/nu-hooks/nuenv/hook.nu
@@ -19,7 +19,10 @@ export def setup []: [ nothing -> record<condition: closure, code: string> ] {
             }
 
             if \(open .env.nu | hash sha256\) not-in $allowed {
-                error make --unspanned { msg: 'not allowed' }
+                error make --unspanned {
+                    msg: $'\(ansi purple\)\('.env.nu' | path expand\)\(ansi reset\) is not allowed',
+                    help: $'please run \(ansi default_dimmed\)nuenv allow\(ansi reset\) first',
+                }
             }
 
             print $'[\(ansi yellow_bold\)hook\(ansi reset\)] loading env file'

--- a/nu-hooks/nu-hooks/nuenv/hook.nu
+++ b/nu-hooks/nu-hooks/nuenv/hook.nu
@@ -32,7 +32,7 @@ export def setup []: [ nothing -> record<condition: closure, code: string> ] {
                 }
             }
 
-            print $'[\(ansi yellow_bold\)hook\(ansi reset\)] loading env file'
+            print $'[\(ansi yellow_bold\)nu-hooks nuenv\(ansi reset\)] loading env file'
             source .env.nu
         "
     }

--- a/nu-hooks/nu-hooks/nuenv/hook.nu
+++ b/nu-hooks/nu-hooks/nuenv/hook.nu
@@ -8,6 +8,13 @@ def get-allowed []: [ nothing -> list<string> ] {
     }
 }
 
+# setup a hook that will try to load `.env.nu` if it is allowed
+#
+# # Example
+# ```nushell
+# use nu-hooks/nuenv/hook.nu [ "nuenv allow", "nuenv disallow" ]
+# $env.config.hooks.env_change.PWD = (use nu-hooks/nuenv/hook.nu; hook setup)
+# ```
 export def setup []: [ nothing -> record<condition: closure, code: string> ] {
     {
         condition: {|_, after| $after | path join '.env.nu' | path exists }
@@ -52,6 +59,7 @@ def check-env-file [] {
     }
 }
 
+# adds `./.env.nu` to the list of allowed "env" files
 export def "nuenv allow" [] {
     check-env-file
 
@@ -68,6 +76,7 @@ export def "nuenv allow" [] {
     info "has been allowed"
 }
 
+# removes `./.env.nu` from the list of allowed "env" files
 export def "nuenv disallow" [] {
     check-env-file
 

--- a/nu-hooks/nu-hooks/nuenv/hook.nu
+++ b/nu-hooks/nu-hooks/nuenv/hook.nu
@@ -1,0 +1,81 @@
+const NUENV_FILE = ($nu.cache-dir | path join 'nuenv' 'allowed.txt')
+
+def get-allowed []: [ nothing -> list<string> ] {
+    if ($NUENV_FILE | path exists) {
+        open $NUENV_FILE | lines
+    } else {
+        []
+    }
+}
+
+export def setup []: [ nothing -> record<condition: closure, code: string> ] {
+    {
+        condition: {|_, after| $after | path join '.env.nu' | path exists }
+        code: $"
+            let allowed = if \('($NUENV_FILE)' | path exists\) {
+                open ($NUENV_FILE) | lines
+            } else {
+                []
+            }
+
+            if \(open .env.nu | hash sha256\) not-in $allowed {
+                error make --unspanned { msg: 'not allowed' }
+            }
+
+            print $'[\(ansi yellow_bold\)hook\(ansi reset\)] loading env file'
+            source .env.nu
+        "
+    }
+}
+
+def _log [msg: string, color: string] {
+    print $'[(ansi $color)nuenv(ansi reset)] (ansi purple)(".env.nu" | path expand)(ansi reset) ($msg)'
+}
+
+def warning [msg: string] {
+    _log $msg "yellow_bold"
+}
+
+def info [msg: string] {
+    _log $msg "green_bold"
+}
+
+def check-env-file [] {
+    if not (".env.nu" | path exists) {
+        error make --unspanned {
+            msg: $"(ansi red_bold)env file not found(ansi reset)",
+            help: $"no (ansi yellow).env.nu(ansi reset) in (ansi purple)(pwd)(ansi reset)",
+        }
+    }
+}
+
+export def "nuenv allow" [] {
+    check-env-file
+
+    let allowed = get-allowed
+
+    let hash = open .env.nu | hash sha256
+    if $hash in $allowed {
+        warning "is already allowed"
+        return
+    }
+
+    mkdir ($nu.cache-dir | path join "nuenv")
+    $hash | $in + "\n" out>> $NUENV_FILE
+    info "has been allowed"
+}
+
+export def "nuenv disallow" [] {
+    check-env-file
+
+    let allowed = get-allowed
+
+    let hash = open .env.nu | hash sha256
+    if $hash not-in $allowed {
+        warning "is already disallowed"
+        return
+    }
+
+    $allowed | find --invert $hash | to text | save --force $NUENV_FILE
+    info "has been disallowed"
+}


### PR DESCRIPTION
> :bulb: **Note**
>
> greatly inspired by _Direnv_

this new "_nuenv_" hook will `source` any `.env.nu` file found in the current directory as part of a hook.

in order to be a bit more safe, i've added `nuenv allow` and `nuenv disallow` that will keep track of which "env" files are allowed to be sourced, i.e. if a file is not allowed, then you'll have to run `nuenv allow` first.

## example usage
```nushell
use nu-hooks/nuenv/hook.nu [ "nuenv allow", "nuenv disallow" ]
$env.config.hooks.env_change.PWD = (use nu-hooks/nuenv/hook.nu; hook setup)
```