### PR TITLE
nix/activation-script: update for nushell 0.95

### DIFF
--- a/modules/nix/README.md
+++ b/modules/nix/README.md
@@ -29,26 +29,23 @@ Shorthand search (`nix search nixpkgs ...`) with much nicer output.
 Shows changed packages after running `nixos-rebuild switch/boot` and change in total size of installed packages. Changes that don't affect the installed size are filtered out. Intended to be added to `configuration.nix` of `NixOS`.
 
 ```
-╭─────────────────┬─────────────┬─────────────┬───────────╮
-│     Package     │ Old_Version │ New_Version │   Diff    │
-├─────────────────┼─────────────┼─────────────┼───────────┤
-│ xwayland        │ ∅           │ 24.1.0      │    5.3 MB │
-│ lsp-plugins     │ 1.2.15      │ 1.2.16      │    1.1 MB │
-│ libei           │ ∅           │ 1.2.1       │  547.6 KB │
-│ libXfont2       │ ∅           │ 2.0.6       │  270.0 KB │
-│ xkbcomp         │ ∅           │ 1.4.7       │  235.7 KB │
-│ font-util       │ ∅           │ 1.4.1       │  234.1 KB │
-│ libxkbfile      │ ∅           │ 1.1.3       │  174.6 KB │
-│ xfsprogs        │ 6.6.0       │ 6.8.0       │   61.0 KB │
-│ xcb-util-errors │ ∅           │ 1.0.1       │   48.5 KB │
-│ libieee1284     │ 0.2.11      │ ∅           │ -123.1 KB │
-│ libgnomekbd     │ 3.28.1      │ ∅           │ -702.0 KB │
-│ xwayland        │ 24.1.0      │ ∅           │   -5.3 MB │
-│ libgweather     │ 4.4.0       │ ∅           │  -23.8 MB │
-╰─────────────────┴─────────────┴─────────────┴───────────╯
-
-╭──────┬──────────╮
-│ Diff │ -22.0 MB │
-╰──────┴──────────╯
+╭────┬──────────────────┬───────────────────────┬────────┬────────────╮
+│  # │     Package      │          Old          │  New   │    Diff    │
+├────┼──────────────────┼───────────────────────┼────────┼────────────┤
+│  0 │ nushell          │ 0.94.1                │ 0.95.0 │  192.1 KiB │
+│  1 │ hyprland         │ 0.41.1                │ 0.41.2 │   52.9 KiB │
+│  2 │ qtdeclarative    │ 6.7.1                 │ 6.7.2  │   36.2 KiB │
+│  3 │ linux            │ 6.9.6                 │ 6.9.7  │   17.7 KiB │
+│  4 │ qtbase           │ 6.7.1                 │ 6.7.2  │   16.1 KiB │
+│  5 │ networkmanager   │ 1.48.0                │ 1.48.2 │    8.3 KiB │
+│  6 │ wireplumber      │ 0.5.3                 │ 0.5.4  │  -21.4 KiB │
+│  7 │ libbacktrace     │ 0-unstable-2024-03-02 │ ∅      │ -110.4 KiB │
+│  8 │ woff2            │ 1.0.2                 │ ∅      │ -155.5 KiB │
+│  9 │ libmanette       │ 0.2.7                 │ ∅      │ -226.0 KiB │
+│ 10 │ webkitgtk        │ 2.44.2+abi=6.0        │ ∅      │ -147.6 MiB │
+│ 11 │ telegram-desktop │ 5.1.8                 │ ∅      │ -219.4 MiB │
+│ 12 │                  │                       │        │            │
+│ 13 │                  │                       │ Total: │ -367.2 MiB │
+╰────┴──────────────────┴───────────────────────┴────────┴────────────╯
 ```
 

--- a/modules/nix/activation-script
+++ b/modules/nix/activation-script
@@ -4,8 +4,7 @@ nix.settings.experimental-features = ["nix-command"];
 
 system.activationScripts.diff = ''
   if [[ -e /run/current-system ]]; then
-    echo
-    ${pkgs.nushell}/bin/nu -c "let diff_closure = ${pkgs.nix}/bin/nix store diff-closures /run/current-system '$systemConfig'; if \$diff_closure != \"\" { let table = \$diff_closure | lines | where \$it =~ KiB | where \$it =~ → | parse -r '^(?<Package>\S+): (?<Old_Version>[^,]+)(?:.*) → (?<New_Version>[^,]+)(?:.*, )(?<DiffBin>.*)$' | insert Diff { get DiffBin | ansi strip | str trim -l -c '+' | into filesize } | reject DiffBin | sort-by -r Diff; print \$table; \$table | math sum }"
+    ${pkgs.nushell}/bin/nu -c "let diff_closure = ${pkgs.nix}/bin/nix store diff-closures /run/current-system '$systemConfig'; if (\$diff_closure | is-not-empty) { let table = \$diff_closure | lines | where \$it =~ KiB | where \$it =~ → | parse -r '^(?<Package>\S+): (?<Old>[^,]+)(?:.*) → (?<New>[^,]+)(?:.*), (?<DiffBin>.*)$' | insert Diff { get DiffBin | ansi strip | into filesize } | sort-by -r Diff | reject DiffBin; print \"\"; \$table | append [[Package Old New Diff]; [\"\" \"\" \"\" \"\"]] | append [[Package Old New Diff]; [\"\" \"\" \"Total:\" (\$table | get Diff | math sum)]] | print; print \"\" }"
   fi
 '';
 


### PR DESCRIPTION
- remove `str trim -l -c '+' |` as it's no longer needed with nushell 0.95
- Change display of total size difference