### PR TITLE
Add fibonacci benchmark, for fairly low-level eval performance

### DIFF
--- a/benchmarks/fibonacci.nu
+++ b/benchmarks/fibonacci.nu
@@ -1,0 +1,20 @@
+#!/usr/bin/env nu
+# This benchmark covers the evaluation performance of some very simple, iterative Nushell code that
+# doesn't require a bunch of calls into nested closures and doesn't rely on commands to do any
+# heavy lifting.
+#
+# Originally added by @devyn to show what absolute best case performance for IR evaluation can look
+# like. Not super representative of normal Nushell code.
+
+def fib [n: int] {
+  mut a = 0
+  mut b = 1
+  for _ in 2..=$n {
+    let c = $a + $b
+    $a = $b
+    $b = $c
+  }
+  $b
+}
+use std bench
+bench -n 1000 { 0..50 | each { |n| fib $n } } | reject times

--- a/benchmarks/fibonacci.nu
+++ b/benchmarks/fibonacci.nu
@@ -6,6 +6,8 @@
 # Originally added by @devyn to show what absolute best case performance for IR evaluation can look
 # like. Not super representative of normal Nushell code.
 
+use std bench
+
 def fib [n: int] {
   mut a = 0
   mut b = 1
@@ -16,5 +18,7 @@ def fib [n: int] {
   }
   $b
 }
-use std bench
-bench -n 1000 { 0..50 | each { |n| fib $n } } | reject times
+
+def main [] {
+  print (bench -n 1000 { 0..50 | each { |n| fib $n } } | reject times)
+}


### PR DESCRIPTION
This is a benchmark that I created while testing IR. It's meant to basically do only very simple operations but be running 100% Nushell code most of the time, without any heavy lifting being done by commands, and without any closure calls or anything like that. It seemed useful to keep around so I'm adding it to `nu_scripts`.
