### PR TITLE
Feature/add git grep completions

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -714,3 +714,58 @@ export extern "git restore" [
   --pathspec-file-nul                           # Separate pathspec elements with NUL character when reading from file
   ...pathspecs: string@"nu-complete git files"  # Target pathspecs to restore
 ]
+
+# Print lines matching a pattern
+export extern "git grep" [
+  --help(-h)                            # Display the help message for this command
+  --cached                              # Search blobs registered in the index file instead of worktree
+  --untracked                           # Include untracked files in search
+  --no-index                            # Similar to `grep -r`, but with additional benefits, such as using pathspec patterns to limit paths; Cannot be used together with --cached or --untracked
+  --no-exclude-standard                 # Include ignored files in search (only useful with --untracked)
+  --exclude-standard                    # No not include ignored files in search (only useful with --no-index)
+  --recurse-submodules                  # Recursively search in each submodule that is active and checked out
+  --text(-a)                            # Process binary files as if they were text
+  --textconv                            # Honor textconv filter settings
+  --no-textconv                         # Do not honor textconv filter settings (default)
+  --ignore-case(-i)                     # Ignore case differences between patterns and files
+  -I                                    # Don’t match the pattern in binary files
+  --max-depth: int                      # Max <depth> to descend down directories for each pathspec. A value of -1 means no limit.
+  --recursive(-r)                       # Same as --max-depth=-1
+  --no-recursive                        # Same as --max-depth=0
+  --word-regexp(-w)                     # Match the pattern only at word boundary
+  --invert-match(-v)                    # Select non-matching lines
+  #-H                                   # (Omitted; doesn't seem to work as documented) Suppress filename in output of matched lines
+  --full-name                           # Force relative path to filename from top directory
+  --extended-regexp(-E)                 # Use POSIX extended regexp for patterns
+  --basic-regexp(-G)                    # Use POSIX basic regexp for patterns (default)
+  --perl-regexp(-P)                     # Use Perl-compatible regular expressions for patterns
+  --line-number(-n)                     # Prefix the line number to matching lines
+  --column                              # Prefix the 1-indexed byte-offset of the first match from the start of the matching line
+  --files-with-matches(-l)              # Print filenames of files that contains matches
+  --name-only                           # Same as --files-with-matches
+  --files-without-match(-L)             # Print filenames of files that do not contain matches
+  #--open-files-in-pager(-O): string     # (Omitted; Syntax for using a different pager doesn't parse well from Git to Nu) Open the matching files in the pager. A different =<pager> can be specified.
+  --null(-z)                            # Use \0 as the delimiter for pathnames in the output, and print them verbatim
+  --only-matching(-o)                   # Print only the matched (non-empty) parts of a matching line, with each such part on a separate output line
+  --count(-c)                           # Instead of showing every matched line, show the number of lines that match
+  #--color: string@"nu-complete git grep color"  # (Omitted; Parsing is again weird) Show colored matches. The value must be always (the default), never, or auto.
+  --no-color                            # Same as --color=never
+  --break                               # Print an empty line between matches from different files.
+  --heading                             # Show the filename above the matches in that file instead of at the start of each shown line.
+  --show-function(-p)                   # Show the preceding line that contains the function name of the match, unless the matching line is a function name itself.
+  --context(-C): int                    # Show <num> leading and trailing lines, and place a line containing -- between contiguous groups of matches.
+  --after-context(-A): int              # Show <num> trailing lines, and place a line containing -- between contiguous groups of matches.
+  --before-context(-B): int             # Show <num> leading lines, and place a line containing -- between contiguous groups of matches.
+  --function-context(-W)                # Show the surrounding text from the previous line containing a function name up to the one before the next function name
+  --max-count(-m): int                  # Limit the amount of matches per file. When using the -v or --invert-match option, the search stops after the specified number of non-matches.
+  --threads: int                        # Number of grep worker threads to use. Use --help for more information on grep threads.
+  -f: string                            # Read patterns from <file>, one per line.
+  -e: string                            # Next parameter is the pattern. Multiple patterns are combined by --or.
+  --and                                 # Search for lines that match multiple patterns.
+  --or                                  # Search for lines that match at least one of multiple patterns. --or is implied between patterns without --and or --not.
+  --not                                 # Search for lines that does not match pattern.
+  --all-match                           # When giving multiple pattern expressions combined with --or, this flag is specified to limit the match to files that have lines to match all of them.
+  --quiet(-q)                           # Do not output matched lines; instead, exit with status 0 when there is a match and with non-zero status when there isn’t.
+  #trees?: string  # Instead of searching tracked files in the working tree, search blobs in the given trees.
+  ...pathspecs: string                  # Target pathspecs to limit the scope of the search.
+]

--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -734,7 +734,7 @@ export extern "git grep" [
   --no-recursive                        # Same as --max-depth=0
   --word-regexp(-w)                     # Match the pattern only at word boundary
   --invert-match(-v)                    # Select non-matching lines
-  #-H                                   # (Omitted; doesn't seem to work as documented) Suppress filename in output of matched lines
+  -H                                    # Suppress filename in output of matched lines
   --full-name                           # Force relative path to filename from top directory
   --extended-regexp(-E)                 # Use POSIX extended regexp for patterns
   --basic-regexp(-G)                    # Use POSIX basic regexp for patterns (default)
@@ -744,11 +744,9 @@ export extern "git grep" [
   --files-with-matches(-l)              # Print filenames of files that contains matches
   --name-only                           # Same as --files-with-matches
   --files-without-match(-L)             # Print filenames of files that do not contain matches
-  #--open-files-in-pager(-O): string     # (Omitted; Syntax for using a different pager doesn't parse well from Git to Nu) Open the matching files in the pager. A different =<pager> can be specified.
   --null(-z)                            # Use \0 as the delimiter for pathnames in the output, and print them verbatim
   --only-matching(-o)                   # Print only the matched (non-empty) parts of a matching line, with each such part on a separate output line
   --count(-c)                           # Instead of showing every matched line, show the number of lines that match
-  #--color: string@"nu-complete git grep color"  # (Omitted; Parsing is again weird) Show colored matches. The value must be always (the default), never, or auto.
   --no-color                            # Same as --color=never
   --break                               # Print an empty line between matches from different files.
   --heading                             # Show the filename above the matches in that file instead of at the start of each shown line.
@@ -766,6 +764,5 @@ export extern "git grep" [
   --not                                 # Search for lines that does not match pattern.
   --all-match                           # When giving multiple pattern expressions combined with --or, this flag is specified to limit the match to files that have lines to match all of them.
   --quiet(-q)                           # Do not output matched lines; instead, exit with status 0 when there is a match and with non-zero status when there isn’t.
-  #trees?: string  # Instead of searching tracked files in the working tree, search blobs in the given trees.
   ...pathspecs: string                  # Target pathspecs to limit the scope of the search.
 ]


### PR DESCRIPTION
Added completions for most of the flags for `git grep`. 

A few flags have been omitted for this PR due to Git expecting arguments for those be passed without whitespaces. The arguments are optional, but the flags would not work when passed arguments (see `--open-with-pager` and `--color` flags in [this commit](https://github.com/nushell/nu_scripts/commit/ffa9ceab737a575397f625044143c9f26f49ac97) for how I tried to do it). 

Ex. 

`--open-with-pager(-O)` expects the optional argument to be passed as either `--open-with-pager=<pager>` or `-O<pager>`. Including it in the completions list as I had implemented it breaks the flag when using the optional parameter.

Feedback appreciated for how to handle that. I'm still new to the Nu language, so I might have missed something obvious that could fix that.