### PR TITLE
fix `nu-themes` package

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -29,14 +29,11 @@ The theme should be activated!
    ```
 
 3. Activate the `nupm` module with `use nupm`
-4. Install the `nu-scripts` package
+4. Install the `nu-themes` package
 
    ```nushell
-   nupm install --path --force nu_scripts
+   nupm install --path --force themes
    ```
-
-   > **Note**
-   > installing the `nu-scripts` package will install `nu-themes` and other modules
 
 5. Add the following in your config, substituting the `theme_name` as desired:
 
@@ -58,7 +55,7 @@ If you would like to do *just* one or the other, you can load a theme's color de
 For example, to load and use the `tokyo-night` theme's colors:
 
 ```nushell
-> use nu-themes/tokyo-night.nu *
+> use nu-themes/tokyo-night.nu
   # Display the values
 > tokyo-night
   # Set the color_config to that scheme
@@ -72,7 +69,7 @@ For example, to load and use the `tokyo-night` theme's colors:
 Again, using the `tokyo-night` theme as an example:
 
 ```nushell
-> use nu-themes/tokyo-night.nu *
+> use nu-themes/tokyo-night.nu
 > tokyo-night update terminal
 ```
 

--- a/themes/nu-themes/catppuccin-latte.nu
+++ b/themes/nu-themes/catppuccin-latte.nu
@@ -1,0 +1,114 @@
+const color_palette = {
+    rosewater: "#dc8a78"
+    flamingo: "#dd7878"
+    pink: "#ea76cb"
+    mauve: "#8839ef"
+    red: "#d20f39"
+    maroon: "#e64553"
+    peach: "#fe640b"
+    yellow: "#df8e1d"
+    green: "#40a02b"
+    teal: "#179299"
+    sky: "#04a5e5"
+    sapphire: "#209fb5"
+    blue: "#1e66f5"
+    lavender: "#7287fd"
+    text: "#4c4f69"
+    subtext1: "#5c5f77"
+    subtext0: "#6c6f85"
+    overlay2: "#7c7f93"
+    overlay1: "#8c8fa1"
+    overlay0: "#9ca0b0"
+    surface2: "#acb0be"
+    surface1: "#bcc0cc"
+    surface0: "#ccd0da"
+    crust: "#dce0e8"
+    mantle: "#e6e9ef"
+    base: "#eff1f5"
+
+}
+
+export def main [] { return {
+    separator: $color_palette.overlay0
+    leading_trailing_space_bg: { attr: "n" }
+    header: { fg: $color_palette.blue attr: "b" }
+    empty: $color_palette.lavender
+    bool: $color_palette.lavender
+    int: $color_palette.peach
+    duration: $color_palette.text
+    filesize: {|e|
+          if $e < 1mb {
+            $color_palette.green
+        } else if $e < 100mb {
+            $color_palette.yellow
+        } else if $e < 500mb {
+            $color_palette.peach
+        } else if $e < 800mb {
+            $color_palette.maroon
+        } else if $e > 800mb {
+            $color_palette.red
+        }
+    }
+    date: {|| (date now) - $in |
+        if $in < 1hr {
+            $color_palette.green
+        } else if $in < 1day {
+            $color_palette.yellow
+        } else if $in < 3day {
+            $color_palette.peach
+        } else if $in < 1wk {
+            $color_palette.maroon
+        } else if $in > 1wk {
+            $color_palette.red
+        }
+    }
+    range: $color_palette.text
+    float: $color_palette.text
+    string: $color_palette.text
+    nothing: $color_palette.text
+    binary: $color_palette.text
+    cellpath: $color_palette.text
+    row_index: { fg: $color_palette.mauve attr: "b" }
+    record: $color_palette.text
+    list: $color_palette.text
+    block: $color_palette.text
+    hints: $color_palette.overlay1
+    search_result: { fg: $color_palette.red bg: $color_palette.text }
+
+    shape_and: { fg: $color_palette.pink attr: "b" }
+    shape_binary: { fg: $color_palette.pink attr: "b" }
+    shape_block: { fg: $color_palette.blue attr: "b" }
+    shape_bool: $color_palette.teal
+    shape_custom: $color_palette.green
+    shape_datetime: { fg: $color_palette.teal attr: "b" }
+    shape_directory: $color_palette.teal
+    shape_external: $color_palette.teal
+    shape_externalarg: { fg: $color_palette.green attr: "b" }
+    shape_filepath: $color_palette.teal
+    shape_flag: { fg: $color_palette.blue attr: "b" }
+    shape_float: { fg: $color_palette.pink attr: "b" }
+    shape_garbage: { fg: $color_palette.text bg: $color_palette.red attr: "b" }
+    shape_globpattern: { fg: $color_palette.teal attr: "b" }
+    shape_int: { fg: $color_palette.pink attr: "b" }
+    shape_internalcall: { fg: $color_palette.teal attr: "b" }
+    shape_list: { fg: $color_palette.teal attr: "b" }
+    shape_literal: $color_palette.blue
+    shape_match_pattern: $color_palette.green
+    shape_matching_brackets: { attr: "u" }
+    shape_nothing: $color_palette.teal
+    shape_operator: $color_palette.peach
+    shape_or: { fg: $color_palette.pink attr: "b" }
+    shape_pipe: { fg: $color_palette.pink attr: "b" }
+    shape_range: { fg: $color_palette.peach attr: "b" }
+    shape_record: { fg: $color_palette.teal attr: "b" }
+    shape_redirection: { fg: $color_palette.pink attr: "b" }
+    shape_signature: { fg: $color_palette.green attr: "b" }
+    shape_string: $color_palette.green
+    shape_string_interpolation: { fg: $color_palette.teal attr: "b" }
+    shape_table: { fg: $color_palette.blue attr: "b" }
+    shape_variable: $color_palette.pink
+
+    background: $color_palette.base
+    foreground: $color_palette.text
+    cursor: $color_palette.blue
+}}

--- a/themes/nu-themes/catppuccin-latte.nu
+++ b/themes/nu-themes/catppuccin-latte.nu
@@ -28,87 +28,126 @@ const color_palette = {
 
 }
 
-export def main [] { return {
-    separator: $color_palette.overlay0
-    leading_trailing_space_bg: { attr: "n" }
-    header: { fg: $color_palette.blue attr: "b" }
-    empty: $color_palette.lavender
-    bool: $color_palette.lavender
-    int: $color_palette.peach
-    duration: $color_palette.text
-    filesize: {|e|
-          if $e < 1mb {
-            $color_palette.green
-        } else if $e < 100mb {
-            $color_palette.yellow
-        } else if $e < 500mb {
-            $color_palette.peach
-        } else if $e < 800mb {
-            $color_palette.maroon
-        } else if $e > 800mb {
-            $color_palette.red
-        }
-    }
-    date: {|| (date now) - $in |
-        if $in < 1hr {
-            $color_palette.green
-        } else if $in < 1day {
-            $color_palette.yellow
-        } else if $in < 3day {
-            $color_palette.peach
-        } else if $in < 1wk {
-            $color_palette.maroon
-        } else if $in > 1wk {
-            $color_palette.red
-        }
-    }
-    range: $color_palette.text
-    float: $color_palette.text
-    string: $color_palette.text
-    nothing: $color_palette.text
-    binary: $color_palette.text
-    cellpath: $color_palette.text
-    row_index: { fg: $color_palette.mauve attr: "b" }
-    record: $color_palette.text
-    list: $color_palette.text
-    block: $color_palette.text
-    hints: $color_palette.overlay1
-    search_result: { fg: $color_palette.red bg: $color_palette.text }
+# Update terminal colors
+export def "update terminal" [] {
+    let theme = (main)
 
-    shape_and: { fg: $color_palette.pink attr: "b" }
-    shape_binary: { fg: $color_palette.pink attr: "b" }
-    shape_block: { fg: $color_palette.blue attr: "b" }
-    shape_bool: $color_palette.teal
-    shape_custom: $color_palette.green
-    shape_datetime: { fg: $color_palette.teal attr: "b" }
-    shape_directory: $color_palette.teal
-    shape_external: $color_palette.teal
-    shape_externalarg: { fg: $color_palette.green attr: "b" }
-    shape_filepath: $color_palette.teal
-    shape_flag: { fg: $color_palette.blue attr: "b" }
-    shape_float: { fg: $color_palette.pink attr: "b" }
-    shape_garbage: { fg: $color_palette.text bg: $color_palette.red attr: "b" }
-    shape_globpattern: { fg: $color_palette.teal attr: "b" }
-    shape_int: { fg: $color_palette.pink attr: "b" }
-    shape_internalcall: { fg: $color_palette.teal attr: "b" }
-    shape_list: { fg: $color_palette.teal attr: "b" }
-    shape_literal: $color_palette.blue
-    shape_match_pattern: $color_palette.green
-    shape_matching_brackets: { attr: "u" }
-    shape_nothing: $color_palette.teal
-    shape_operator: $color_palette.peach
-    shape_or: { fg: $color_palette.pink attr: "b" }
-    shape_pipe: { fg: $color_palette.pink attr: "b" }
-    shape_range: { fg: $color_palette.peach attr: "b" }
-    shape_record: { fg: $color_palette.teal attr: "b" }
-    shape_redirection: { fg: $color_palette.pink attr: "b" }
-    shape_signature: { fg: $color_palette.green attr: "b" }
-    shape_string: $color_palette.green
-    shape_string_interpolation: { fg: $color_palette.teal attr: "b" }
-    shape_table: { fg: $color_palette.blue attr: "b" }
-    shape_variable: $color_palette.pink
+    # Set terminal colors
+    let osc_screen_foreground_color = '10;'
+    let osc_screen_background_color = '11;'
+    let osc_cursor_color = '12;'
 
-    background: $color_palette.base
-    foreground: $color_palette.text
-    cursor: $color_palette.blue
-}}
+    $"
+    (ansi -o $osc_screen_foreground_color)($theme.foreground)(char bel)
+    (ansi -o $osc_screen_background_color)($theme.background)(char bel)
+    (ansi -o $osc_cursor_color)($theme.cursor)(char bel)
+    "
+    # Line breaks above are just for source readability
+    # but create extra whitespace when activating. Collapse
+    # to one line
+    | str replace --all "\n" ''
+    | print $in
+}
+
+# Update the Nushell configuration
+export def --env "set color_config" [] {
+    $env.config.color_config = (main)
+}
+
+# Retrieve the theme settings
+export def main [] {
+    return {
+        separator: $color_palette.overlay0
+        leading_trailing_space_bg: { attr: "n" }
+        header: { fg: $color_palette.blue attr: "b" }
+        empty: $color_palette.lavender
+        bool: $color_palette.lavender
+        int: $color_palette.peach
+        duration: $color_palette.text
+        filesize: {|e|
+              if $e < 1mb {
+                $color_palette.green
+            } else if $e < 100mb {
+                $color_palette.yellow
+            } else if $e < 500mb {
+                $color_palette.peach
+            } else if $e < 800mb {
+                $color_palette.maroon
+            } else if $e > 800mb {
+                $color_palette.red
+            }
+        }
+        date: {|| (date now) - $in |
+            if $in < 1hr {
+                $color_palette.green
+            } else if $in < 1day {
+                $color_palette.yellow
+            } else if $in < 3day {
+                $color_palette.peach
+            } else if $in < 1wk {
+                $color_palette.maroon
+            } else if $in > 1wk {
+                $color_palette.red
+            }
+        }
+        range: $color_palette.text
+        float: $color_palette.text
+        string: $color_palette.text
+        nothing: $color_palette.text
+        binary: $color_palette.text
+        cellpath: $color_palette.text
+        row_index: { fg: $color_palette.mauve attr: "b" }
+        record: $color_palette.text
+        list: $color_palette.text
+        block: $color_palette.text
+        hints: $color_palette.overlay1
+        search_result: { fg: $color_palette.red bg: $color_palette.text }
+
+        shape_and: { fg: $color_palette.pink attr: "b" }
+        shape_binary: { fg: $color_palette.pink attr: "b" }
+        shape_block: { fg: $color_palette.blue attr: "b" }
+        shape_bool: $color_palette.teal
+        shape_custom: $color_palette.green
+        shape_datetime: { fg: $color_palette.teal attr: "b" }
+        shape_directory: $color_palette.teal
+        shape_external: $color_palette.teal
+        shape_externalarg: { fg: $color_palette.green attr: "b" }
+        shape_filepath: $color_palette.teal
+        shape_flag: { fg: $color_palette.blue attr: "b" }
+        shape_float: { fg: $color_palette.pink attr: "b" }
+        shape_garbage: { fg: $color_palette.text bg: $color_palette.red attr: "b" }
+        shape_globpattern: { fg: $color_palette.teal attr: "b" }
+        shape_int: { fg: $color_palette.pink attr: "b" }
+        shape_internalcall: { fg: $color_palette.teal attr: "b" }
+        shape_list: { fg: $color_palette.teal attr: "b" }
+        shape_literal: $color_palette.blue
+        shape_match_pattern: $color_palette.green
+        shape_matching_brackets: { attr: "u" }
+        shape_nothing: $color_palette.teal
+        shape_operator: $color_palette.peach
+        shape_or: { fg: $color_palette.pink attr: "b" }
+        shape_pipe: { fg: $color_palette.pink attr: "b" }
+        shape_range: { fg: $color_palette.peach attr: "b" }
+        shape_record: { fg: $color_palette.teal attr: "b" }
+        shape_redirection: { fg: $color_palette.pink attr: "b" }
+        shape_signature: { fg: $color_palette.green attr: "b" }
+        shape_string: $color_palette.green
+        shape_string_interpolation: { fg: $color_palette.teal attr: "b" }
+        shape_table: { fg: $color_palette.blue attr: "b" }
+        shape_variable: $color_palette.pink
+
+        background: $color_palette.base
+        foreground: $color_palette.text
+        cursor: $color_palette.blue
+    }
+}
+
+export module activate {
+    export-env {
+        set color_config
+        update terminal
+    }
+}
+
+# Activate the theme when sourced
+use activate

--- a/themes/nu-themes/catppuccin-mocha.nu
+++ b/themes/nu-themes/catppuccin-mocha.nu
@@ -1,0 +1,113 @@
+const color_palette = {
+    rosewater: "#f5e0dc"
+    flamingo: "#f2cdcd"
+    pink: "#f5c2e7"
+    mauve: "#cba6f7"
+    red: "#f38ba8"
+    maroon: "#eba0ac"
+    peach: "#fab387"
+    yellow: "#f9e2af"
+    green: "#a6e3a1"
+    teal: "#94e2d5"
+    sky: "#89dceb"
+    sapphire: "#74c7ec"
+    blue: "#89b4fa"
+    lavender: "#b4befe"
+    text: "#cdd6f4"
+    subtext1: "#bac2de"
+    subtext0: "#a6adc8"
+    overlay2: "#9399b2"
+    overlay1: "#7f849c"
+    overlay0: "#6c7086"
+    surface2: "#585b70"
+    surface1: "#45475a"
+    surface0: "#313244"
+    base: "#1e1e2e"
+    mantle: "#181825"
+    crust: "#11111b"
+}
+
+export def main [] { return {
+    separator: $color_palette.overlay0
+    leading_trailing_space_bg: { attr: "n" }
+    header: { fg: $color_palette.blue attr: "b" }
+    empty: $color_palette.lavender
+    bool: $color_palette.lavender
+    int: $color_palette.peach
+    duration: $color_palette.text
+    filesize: {|e|
+          if $e < 1mb {
+            $color_palette.green
+        } else if $e < 100mb {
+            $color_palette.yellow
+        } else if $e < 500mb {
+            $color_palette.peach
+        } else if $e < 800mb {
+            $color_palette.maroon
+        } else if $e > 800mb {
+            $color_palette.red
+        }
+    }
+    date: {|| (date now) - $in |
+        if $in < 1hr {
+            $color_palette.green
+        } else if $in < 1day {
+            $color_palette.yellow
+        } else if $in < 3day {
+            $color_palette.peach
+        } else if $in < 1wk {
+            $color_palette.maroon
+        } else if $in > 1wk {
+            $color_palette.red
+        }
+    }
+    range: $color_palette.text
+    float: $color_palette.text
+    string: $color_palette.text
+    nothing: $color_palette.text
+    binary: $color_palette.text
+    cellpath: $color_palette.text
+    row_index: { fg: $color_palette.mauve attr: "b" }
+    record: $color_palette.text
+    list: $color_palette.text
+    block: $color_palette.text
+    hints: $color_palette.overlay1
+    search_result: { fg: $color_palette.red bg: $color_palette.text }
+
+    shape_and: { fg: $color_palette.pink attr: "b" }
+    shape_binary: { fg: $color_palette.pink attr: "b" }
+    shape_block: { fg: $color_palette.blue attr: "b" }
+    shape_bool: $color_palette.teal
+    shape_custom: $color_palette.green
+    shape_datetime: { fg: $color_palette.teal attr: "b" }
+    shape_directory: $color_palette.teal
+    shape_external: $color_palette.teal
+    shape_externalarg: { fg: $color_palette.green attr: "b" }
+    shape_filepath: $color_palette.teal
+    shape_flag: { fg: $color_palette.blue attr: "b" }
+    shape_float: { fg: $color_palette.pink attr: "b" }
+    shape_garbage: { fg: $color_palette.text bg: $color_palette.red attr: "b" }
+    shape_globpattern: { fg: $color_palette.teal attr: "b" }
+    shape_int: { fg: $color_palette.pink attr: "b" }
+    shape_internalcall: { fg: $color_palette.teal attr: "b" }
+    shape_list: { fg: $color_palette.teal attr: "b" }
+    shape_literal: $color_palette.blue
+    shape_match_pattern: $color_palette.green
+    shape_matching_brackets: { attr: "u" }
+    shape_nothing: $color_palette.teal
+    shape_operator: $color_palette.peach
+    shape_or: { fg: $color_palette.pink attr: "b" }
+    shape_pipe: { fg: $color_palette.pink attr: "b" }
+    shape_range: { fg: $color_palette.peach attr: "b" }
+    shape_record: { fg: $color_palette.teal attr: "b" }
+    shape_redirection: { fg: $color_palette.pink attr: "b" }
+    shape_signature: { fg: $color_palette.green attr: "b" }
+    shape_string: $color_palette.green
+    shape_string_interpolation: { fg: $color_palette.teal attr: "b" }
+    shape_table: { fg: $color_palette.blue attr: "b" }
+    shape_variable: $color_palette.pink
+
+    background: $color_palette.base
+    foreground: $color_palette.text
+    cursor: $color_palette.blue
+}}

--- a/themes/nu-themes/catppuccin-mocha.nu
+++ b/themes/nu-themes/catppuccin-mocha.nu
@@ -27,87 +27,126 @@ const color_palette = {
     crust: "#11111b"
 }
 
-export def main [] { return {
-    separator: $color_palette.overlay0
-    leading_trailing_space_bg: { attr: "n" }
-    header: { fg: $color_palette.blue attr: "b" }
-    empty: $color_palette.lavender
-    bool: $color_palette.lavender
-    int: $color_palette.peach
-    duration: $color_palette.text
-    filesize: {|e|
-          if $e < 1mb {
-            $color_palette.green
-        } else if $e < 100mb {
-            $color_palette.yellow
-        } else if $e < 500mb {
-            $color_palette.peach
-        } else if $e < 800mb {
-            $color_palette.maroon
-        } else if $e > 800mb {
-            $color_palette.red
-        }
-    }
-    date: {|| (date now) - $in |
-        if $in < 1hr {
-            $color_palette.green
-        } else if $in < 1day {
-            $color_palette.yellow
-        } else if $in < 3day {
-            $color_palette.peach
-        } else if $in < 1wk {
-            $color_palette.maroon
-        } else if $in > 1wk {
-            $color_palette.red
-        }
-    }
-    range: $color_palette.text
-    float: $color_palette.text
-    string: $color_palette.text
-    nothing: $color_palette.text
-    binary: $color_palette.text
-    cellpath: $color_palette.text
-    row_index: { fg: $color_palette.mauve attr: "b" }
-    record: $color_palette.text
-    list: $color_palette.text
-    block: $color_palette.text
-    hints: $color_palette.overlay1
-    search_result: { fg: $color_palette.red bg: $color_palette.text }
+# Update terminal colors
+export def "update terminal" [] {
+    let theme = (main)
 
-    shape_and: { fg: $color_palette.pink attr: "b" }
-    shape_binary: { fg: $color_palette.pink attr: "b" }
-    shape_block: { fg: $color_palette.blue attr: "b" }
-    shape_bool: $color_palette.teal
-    shape_custom: $color_palette.green
-    shape_datetime: { fg: $color_palette.teal attr: "b" }
-    shape_directory: $color_palette.teal
-    shape_external: $color_palette.teal
-    shape_externalarg: { fg: $color_palette.green attr: "b" }
-    shape_filepath: $color_palette.teal
-    shape_flag: { fg: $color_palette.blue attr: "b" }
-    shape_float: { fg: $color_palette.pink attr: "b" }
-    shape_garbage: { fg: $color_palette.text bg: $color_palette.red attr: "b" }
-    shape_globpattern: { fg: $color_palette.teal attr: "b" }
-    shape_int: { fg: $color_palette.pink attr: "b" }
-    shape_internalcall: { fg: $color_palette.teal attr: "b" }
-    shape_list: { fg: $color_palette.teal attr: "b" }
-    shape_literal: $color_palette.blue
-    shape_match_pattern: $color_palette.green
-    shape_matching_brackets: { attr: "u" }
-    shape_nothing: $color_palette.teal
-    shape_operator: $color_palette.peach
-    shape_or: { fg: $color_palette.pink attr: "b" }
-    shape_pipe: { fg: $color_palette.pink attr: "b" }
-    shape_range: { fg: $color_palette.peach attr: "b" }
-    shape_record: { fg: $color_palette.teal attr: "b" }
-    shape_redirection: { fg: $color_palette.pink attr: "b" }
-    shape_signature: { fg: $color_palette.green attr: "b" }
-    shape_string: $color_palette.green
-    shape_string_interpolation: { fg: $color_palette.teal attr: "b" }
-    shape_table: { fg: $color_palette.blue attr: "b" }
-    shape_variable: $color_palette.pink
+    # Set terminal colors
+    let osc_screen_foreground_color = '10;'
+    let osc_screen_background_color = '11;'
+    let osc_cursor_color = '12;'
 
-    background: $color_palette.base
-    foreground: $color_palette.text
-    cursor: $color_palette.blue
-}}
+    $"
+    (ansi -o $osc_screen_foreground_color)($theme.foreground)(char bel)
+    (ansi -o $osc_screen_background_color)($theme.background)(char bel)
+    (ansi -o $osc_cursor_color)($theme.cursor)(char bel)
+    "
+    # Line breaks above are just for source readability
+    # but create extra whitespace when activating. Collapse
+    # to one line
+    | str replace --all "\n" ''
+    | print $in
+}
+
+# Update the Nushell configuration
+export def --env "set color_config" [] {
+    $env.config.color_config = (main)
+}
+
+# Retrieve the theme settings
+export def main [] {
+    return {
+        separator: $color_palette.overlay0
+        leading_trailing_space_bg: { attr: "n" }
+        header: { fg: $color_palette.blue attr: "b" }
+        empty: $color_palette.lavender
+        bool: $color_palette.lavender
+        int: $color_palette.peach
+        duration: $color_palette.text
+        filesize: {|e|
+              if $e < 1mb {
+                $color_palette.green
+            } else if $e < 100mb {
+                $color_palette.yellow
+            } else if $e < 500mb {
+                $color_palette.peach
+            } else if $e < 800mb {
+                $color_palette.maroon
+            } else if $e > 800mb {
+                $color_palette.red
+            }
+        }
+        date: {|| (date now) - $in |
+            if $in < 1hr {
+                $color_palette.green
+            } else if $in < 1day {
+                $color_palette.yellow
+            } else if $in < 3day {
+                $color_palette.peach
+            } else if $in < 1wk {
+                $color_palette.maroon
+            } else if $in > 1wk {
+                $color_palette.red
+            }
+        }
+        range: $color_palette.text
+        float: $color_palette.text
+        string: $color_palette.text
+        nothing: $color_palette.text
+        binary: $color_palette.text
+        cellpath: $color_palette.text
+        row_index: { fg: $color_palette.mauve attr: "b" }
+        record: $color_palette.text
+        list: $color_palette.text
+        block: $color_palette.text
+        hints: $color_palette.overlay1
+        search_result: { fg: $color_palette.red bg: $color_palette.text }
+
+        shape_and: { fg: $color_palette.pink attr: "b" }
+        shape_binary: { fg: $color_palette.pink attr: "b" }
+        shape_block: { fg: $color_palette.blue attr: "b" }
+        shape_bool: $color_palette.teal
+        shape_custom: $color_palette.green
+        shape_datetime: { fg: $color_palette.teal attr: "b" }
+        shape_directory: $color_palette.teal
+        shape_external: $color_palette.teal
+        shape_externalarg: { fg: $color_palette.green attr: "b" }
+        shape_filepath: $color_palette.teal
+        shape_flag: { fg: $color_palette.blue attr: "b" }
+        shape_float: { fg: $color_palette.pink attr: "b" }
+        shape_garbage: { fg: $color_palette.text bg: $color_palette.red attr: "b" }
+        shape_globpattern: { fg: $color_palette.teal attr: "b" }
+        shape_int: { fg: $color_palette.pink attr: "b" }
+        shape_internalcall: { fg: $color_palette.teal attr: "b" }
+        shape_list: { fg: $color_palette.teal attr: "b" }
+        shape_literal: $color_palette.blue
+        shape_match_pattern: $color_palette.green
+        shape_matching_brackets: { attr: "u" }
+        shape_nothing: $color_palette.teal
+        shape_operator: $color_palette.peach
+        shape_or: { fg: $color_palette.pink attr: "b" }
+        shape_pipe: { fg: $color_palette.pink attr: "b" }
+        shape_range: { fg: $color_palette.peach attr: "b" }
+        shape_record: { fg: $color_palette.teal attr: "b" }
+        shape_redirection: { fg: $color_palette.pink attr: "b" }
+        shape_signature: { fg: $color_palette.green attr: "b" }
+        shape_string: $color_palette.green
+        shape_string_interpolation: { fg: $color_palette.teal attr: "b" }
+        shape_table: { fg: $color_palette.blue attr: "b" }
+        shape_variable: $color_palette.pink
+
+        background: $color_palette.base
+        foreground: $color_palette.text
+        cursor: $color_palette.blue
+    }
+}
+
+export module activate {
+    export-env {
+        set color_config
+        update terminal
+    }
+}
+
+# Activate the theme when sourced
+use activate

--- a/themes/nu-themes/nushell-dark.nu
+++ b/themes/nu-themes/nushell-dark.nu
@@ -1,0 +1,88 @@
+export def main [] { return {
+    # color for nushell primitives
+    separator: white
+    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+    header: green_bold
+    empty: blue
+    # Closures can be used to choose colors for specific values.
+    # The value (in this case, a bool) is piped into the closure.
+    bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
+    int: white
+    filesize: {|e|
+      if $e == 0b {
+        'white'
+      } else if $e < 1mb {
+        'cyan'
+      } else { 'blue' }
+    }
+    duration: white
+    date: {|| (date now) - $in |
+      if $in < 1hr {
+        'purple'
+      } else if $in < 6hr {
+        'red'
+      } else if $in < 1day {
+        'yellow'
+      } else if $in < 3day {
+        'green'
+      } else if $in < 1wk {
+        'light_green'
+      } else if $in < 6wk {
+        'cyan'
+      } else if $in < 52wk {
+        'blue'
+      } else { 'dark_gray' }
+    }
+    range: white
+    float: white
+    string: white
+    nothing: white
+    binary: white
+    cellpath: white
+    row_index: green_bold
+    record: white
+    list: white
+    block: white
+    hints: dark_gray
+    search_result: {bg: red fg: white}
+
+    shape_and: purple_bold
+    shape_binary: purple_bold
+    shape_block: blue_bold
+    shape_bool: light_cyan
+    shape_closure: green_bold
+    shape_custom: green
+    shape_datetime: cyan_bold
+    shape_directory: cyan
+    shape_external: cyan
+    shape_externalarg: green_bold
+    shape_filepath: cyan
+    shape_flag: blue_bold
+    shape_float: purple_bold
+    # shapes are used to change the cli syntax highlighting
+    shape_garbage: { fg: white bg: red attr: b}
+    shape_globpattern: cyan_bold
+    shape_int: purple_bold
+    shape_internalcall: cyan_bold
+    shape_list: cyan_bold
+    shape_literal: blue
+    shape_match_pattern: green
+    shape_matching_brackets: { attr: u }
+    shape_nothing: light_cyan
+    shape_operator: yellow
+    shape_or: purple_bold
+    shape_pipe: purple_bold
+    shape_range: yellow_bold
+    shape_record: cyan_bold
+    shape_redirection: purple_bold
+    shape_signature: green_bold
+    shape_string: green
+    shape_string_interpolation: cyan_bold
+    shape_table: blue_bold
+    shape_variable: purple
+    shape_vardecl: purple
+
+    background: dark_gray
+    foreground: default
+    cursor: red
+}}

--- a/themes/nu-themes/nushell-dark.nu
+++ b/themes/nu-themes/nushell-dark.nu
@@ -1,88 +1,127 @@
-export def main [] { return {
-    # color for nushell primitives
-    separator: white
-    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
-    header: green_bold
-    empty: blue
-    # Closures can be used to choose colors for specific values.
-    # The value (in this case, a bool) is piped into the closure.
-    bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
-    int: white
-    filesize: {|e|
-      if $e == 0b {
-        'white'
-      } else if $e < 1mb {
-        'cyan'
-      } else { 'blue' }
-    }
-    duration: white
-    date: {|| (date now) - $in |
-      if $in < 1hr {
-        'purple'
-      } else if $in < 6hr {
-        'red'
-      } else if $in < 1day {
-        'yellow'
-      } else if $in < 3day {
-        'green'
-      } else if $in < 1wk {
-        'light_green'
-      } else if $in < 6wk {
-        'cyan'
-      } else if $in < 52wk {
-        'blue'
-      } else { 'dark_gray' }
-    }
-    range: white
-    float: white
-    string: white
-    nothing: white
-    binary: white
-    cellpath: white
-    row_index: green_bold
-    record: white
-    list: white
-    block: white
-    hints: dark_gray
-    search_result: {bg: red fg: white}
+# Update terminal colors
+export def "update terminal" [] {
+    let theme = (main)
 
-    shape_and: purple_bold
-    shape_binary: purple_bold
-    shape_block: blue_bold
-    shape_bool: light_cyan
-    shape_closure: green_bold
-    shape_custom: green
-    shape_datetime: cyan_bold
-    shape_directory: cyan
-    shape_external: cyan
-    shape_externalarg: green_bold
-    shape_filepath: cyan
-    shape_flag: blue_bold
-    shape_float: purple_bold
-    # shapes are used to change the cli syntax highlighting
-    shape_garbage: { fg: white bg: red attr: b}
-    shape_globpattern: cyan_bold
-    shape_int: purple_bold
-    shape_internalcall: cyan_bold
-    shape_list: cyan_bold
-    shape_literal: blue
-    shape_match_pattern: green
-    shape_matching_brackets: { attr: u }
-    shape_nothing: light_cyan
-    shape_operator: yellow
-    shape_or: purple_bold
-    shape_pipe: purple_bold
-    shape_range: yellow_bold
-    shape_record: cyan_bold
-    shape_redirection: purple_bold
-    shape_signature: green_bold
-    shape_string: green
-    shape_string_interpolation: cyan_bold
-    shape_table: blue_bold
-    shape_variable: purple
-    shape_vardecl: purple
+    # Set terminal colors
+    let osc_screen_foreground_color = '10;'
+    let osc_screen_background_color = '11;'
+    let osc_cursor_color = '12;'
 
-    background: dark_gray
-    foreground: default
-    cursor: red
-}}
+    $"
+    (ansi -o $osc_screen_foreground_color)($theme.foreground)(char bel)
+    (ansi -o $osc_screen_background_color)($theme.background)(char bel)
+    (ansi -o $osc_cursor_color)($theme.cursor)(char bel)
+    "
+    # Line breaks above are just for source readability
+    # but create extra whitespace when activating. Collapse
+    # to one line
+    | str replace --all "\n" ''
+    | print $in
+}
+
+# Update the Nushell configuration
+export def --env "set color_config" [] {
+    $env.config.color_config = (main)
+}
+
+# Retrieve the theme settings
+export def main [] {
+    return {
+        # color for nushell primitives
+        separator: white
+        leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+        header: green_bold
+        empty: blue
+        # Closures can be used to choose colors for specific values.
+        # The value (in this case, a bool) is piped into the closure.
+        bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
+        int: white
+        filesize: {|e|
+          if $e == 0b {
+            'white'
+          } else if $e < 1mb {
+            'cyan'
+          } else { 'blue' }
+        }
+        duration: white
+        date: {|| (date now) - $in |
+          if $in < 1hr {
+            'purple'
+          } else if $in < 6hr {
+            'red'
+          } else if $in < 1day {
+            'yellow'
+          } else if $in < 3day {
+            'green'
+          } else if $in < 1wk {
+            'light_green'
+          } else if $in < 6wk {
+            'cyan'
+          } else if $in < 52wk {
+            'blue'
+          } else { 'dark_gray' }
+        }
+        range: white
+        float: white
+        string: white
+        nothing: white
+        binary: white
+        cellpath: white
+        row_index: green_bold
+        record: white
+        list: white
+        block: white
+        hints: dark_gray
+        search_result: {bg: red fg: white}
+
+        shape_and: purple_bold
+        shape_binary: purple_bold
+        shape_block: blue_bold
+        shape_bool: light_cyan
+        shape_closure: green_bold
+        shape_custom: green
+        shape_datetime: cyan_bold
+        shape_directory: cyan
+        shape_external: cyan
+        shape_externalarg: green_bold
+        shape_filepath: cyan
+        shape_flag: blue_bold
+        shape_float: purple_bold
+        # shapes are used to change the cli syntax highlighting
+        shape_garbage: { fg: white bg: red attr: b}
+        shape_globpattern: cyan_bold
+        shape_int: purple_bold
+        shape_internalcall: cyan_bold
+        shape_list: cyan_bold
+        shape_literal: blue
+        shape_match_pattern: green
+        shape_matching_brackets: { attr: u }
+        shape_nothing: light_cyan
+        shape_operator: yellow
+        shape_or: purple_bold
+        shape_pipe: purple_bold
+        shape_range: yellow_bold
+        shape_record: cyan_bold
+        shape_redirection: purple_bold
+        shape_signature: green_bold
+        shape_string: green
+        shape_string_interpolation: cyan_bold
+        shape_table: blue_bold
+        shape_variable: purple
+        shape_vardecl: purple
+
+        background: dark_gray
+        foreground: default
+        cursor: red
+    }
+}
+
+export module activate {
+    export-env {
+        set color_config
+        update terminal
+    }
+}
+
+# Activate the theme when sourced
+use activate

--- a/themes/nu-themes/nushell-light.nu
+++ b/themes/nu-themes/nushell-light.nu
@@ -1,0 +1,88 @@
+export def main [] { return {
+    # color for nushell primitives
+    separator: dark_gray
+    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+    header: green_bold
+    empty: blue
+    # Closures can be used to choose colors for specific values.
+    # The value (in this case, a bool) is piped into the closure.
+    bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
+    int: dark_gray
+    filesize: {|e|
+      if $e == 0b {
+        'dark_gray'
+      } else if $e < 1mb {
+        'cyan_bold'
+      } else { 'blue_bold' }
+    }
+    duration: dark_gray
+  date: {|| (date now) - $in |
+    if $in < 1hr {
+      'purple'
+    } else if $in < 6hr {
+      'red'
+    } else if $in < 1day {
+      'yellow'
+    } else if $in < 3day {
+      'green'
+    } else if $in < 1wk {
+      'light_green'
+    } else if $in < 6wk {
+      'cyan'
+    } else if $in < 52wk {
+      'blue'
+    } else { 'dark_gray' }
+  }
+    range: dark_gray
+    float: dark_gray
+    string: dark_gray
+    nothing: dark_gray
+    binary: dark_gray
+    cellpath: dark_gray
+    row_index: green_bold
+    record: white
+    list: white
+    block: white
+    hints: dark_gray
+    search_result: {fg: white bg: red}
+
+    shape_and: purple_bold
+    shape_binary: purple_bold
+    shape_block: blue_bold
+    shape_bool: light_cyan
+    shape_closure: green_bold
+    shape_custom: green
+    shape_datetime: cyan_bold
+    shape_directory: cyan
+    shape_external: cyan
+    shape_externalarg: green_bold
+    shape_filepath: cyan
+    shape_flag: blue_bold
+    shape_float: purple_bold
+    # shapes are used to change the cli syntax highlighting
+    shape_garbage: { fg: white bg: red attr: b}
+    shape_globpattern: cyan_bold
+    shape_int: purple_bold
+    shape_internalcall: cyan_bold
+    shape_list: cyan_bold
+    shape_literal: blue
+    shape_match_pattern: green
+    shape_matching_brackets: { attr: u }
+    shape_nothing: light_cyan
+    shape_operator: yellow
+    shape_or: purple_bold
+    shape_pipe: purple_bold
+    shape_range: yellow_bold
+    shape_record: cyan_bold
+    shape_redirection: purple_bold
+    shape_signature: green_bold
+    shape_string: green
+    shape_string_interpolation: cyan_bold
+    shape_table: blue_bold
+    shape_variable: purple
+    shape_vardecl: purple
+
+    background: light_gray
+    foreground: default
+    cursor: red
+}}

--- a/themes/nu-themes/nushell-light.nu
+++ b/themes/nu-themes/nushell-light.nu
@@ -1,88 +1,127 @@
-export def main [] { return {
-    # color for nushell primitives
-    separator: dark_gray
-    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
-    header: green_bold
-    empty: blue
-    # Closures can be used to choose colors for specific values.
-    # The value (in this case, a bool) is piped into the closure.
-    bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
-    int: dark_gray
-    filesize: {|e|
-      if $e == 0b {
-        'dark_gray'
-      } else if $e < 1mb {
-        'cyan_bold'
-      } else { 'blue_bold' }
+# Update terminal colors
+export def "update terminal" [] {
+    let theme = (main)
+
+    # Set terminal colors
+    let osc_screen_foreground_color = '10;'
+    let osc_screen_background_color = '11;'
+    let osc_cursor_color = '12;'
+
+    $"
+    (ansi -o $osc_screen_foreground_color)($theme.foreground)(char bel)
+    (ansi -o $osc_screen_background_color)($theme.background)(char bel)
+    (ansi -o $osc_cursor_color)($theme.cursor)(char bel)
+    "
+    # Line breaks above are just for source readability
+    # but create extra whitespace when activating. Collapse
+    # to one line
+    | str replace --all "\n" ''
+    | print $in
+}
+
+# Update the Nushell configuration
+export def --env "set color_config" [] {
+    $env.config.color_config = (main)
+}
+
+# Retrieve the theme settings
+export def main [] {
+    return {
+      # color for nushell primitives
+      separator: dark_gray
+      leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+      header: green_bold
+      empty: blue
+      # Closures can be used to choose colors for specific values.
+      # The value (in this case, a bool) is piped into the closure.
+      bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
+      int: dark_gray
+      filesize: {|e|
+        if $e == 0b {
+          'dark_gray'
+        } else if $e < 1mb {
+          'cyan_bold'
+        } else { 'blue_bold' }
+      }
+      duration: dark_gray
+    date: {|| (date now) - $in |
+      if $in < 1hr {
+        'purple'
+      } else if $in < 6hr {
+        'red'
+      } else if $in < 1day {
+        'yellow'
+      } else if $in < 3day {
+        'green'
+      } else if $in < 1wk {
+        'light_green'
+      } else if $in < 6wk {
+        'cyan'
+      } else if $in < 52wk {
+        'blue'
+      } else { 'dark_gray' }
     }
-    duration: dark_gray
-  date: {|| (date now) - $in |
-    if $in < 1hr {
-      'purple'
-    } else if $in < 6hr {
-      'red'
-    } else if $in < 1day {
-      'yellow'
-    } else if $in < 3day {
-      'green'
-    } else if $in < 1wk {
-      'light_green'
-    } else if $in < 6wk {
-      'cyan'
-    } else if $in < 52wk {
-      'blue'
-    } else { 'dark_gray' }
-  }
-    range: dark_gray
-    float: dark_gray
-    string: dark_gray
-    nothing: dark_gray
-    binary: dark_gray
-    cellpath: dark_gray
-    row_index: green_bold
-    record: white
-    list: white
-    block: white
-    hints: dark_gray
-    search_result: {fg: white bg: red}
+      range: dark_gray
+      float: dark_gray
+      string: dark_gray
+      nothing: dark_gray
+      binary: dark_gray
+      cellpath: dark_gray
+      row_index: green_bold
+      record: white
+      list: white
+      block: white
+      hints: dark_gray
+      search_result: {fg: white bg: red}
 
-    shape_and: purple_bold
-    shape_binary: purple_bold
-    shape_block: blue_bold
-    shape_bool: light_cyan
-    shape_closure: green_bold
-    shape_custom: green
-    shape_datetime: cyan_bold
-    shape_directory: cyan
-    shape_external: cyan
-    shape_externalarg: green_bold
-    shape_filepath: cyan
-    shape_flag: blue_bold
-    shape_float: purple_bold
-    # shapes are used to change the cli syntax highlighting
-    shape_garbage: { fg: white bg: red attr: b}
-    shape_globpattern: cyan_bold
-    shape_int: purple_bold
-    shape_internalcall: cyan_bold
-    shape_list: cyan_bold
-    shape_literal: blue
-    shape_match_pattern: green
-    shape_matching_brackets: { attr: u }
-    shape_nothing: light_cyan
-    shape_operator: yellow
-    shape_or: purple_bold
-    shape_pipe: purple_bold
-    shape_range: yellow_bold
-    shape_record: cyan_bold
-    shape_redirection: purple_bold
-    shape_signature: green_bold
-    shape_string: green
-    shape_string_interpolation: cyan_bold
-    shape_table: blue_bold
-    shape_variable: purple
-    shape_vardecl: purple
+      shape_and: purple_bold
+      shape_binary: purple_bold
+      shape_block: blue_bold
+      shape_bool: light_cyan
+      shape_closure: green_bold
+      shape_custom: green
+      shape_datetime: cyan_bold
+      shape_directory: cyan
+      shape_external: cyan
+      shape_externalarg: green_bold
+      shape_filepath: cyan
+      shape_flag: blue_bold
+      shape_float: purple_bold
+      # shapes are used to change the cli syntax highlighting
+      shape_garbage: { fg: white bg: red attr: b}
+      shape_globpattern: cyan_bold
+      shape_int: purple_bold
+      shape_internalcall: cyan_bold
+      shape_list: cyan_bold
+      shape_literal: blue
+      shape_match_pattern: green
+      shape_matching_brackets: { attr: u }
+      shape_nothing: light_cyan
+      shape_operator: yellow
+      shape_or: purple_bold
+      shape_pipe: purple_bold
+      shape_range: yellow_bold
+      shape_record: cyan_bold
+      shape_redirection: purple_bold
+      shape_signature: green_bold
+      shape_string: green
+      shape_string_interpolation: cyan_bold
+      shape_table: blue_bold
+      shape_variable: purple
+      shape_vardecl: purple
 
-    background: light_gray
-    foreground: default
-    cursor: red
-}}
+      background: light_gray
+      foreground: default
+      cursor: red
+    }
+}
+
+export module activate {
+    export-env {
+        set color_config
+        update terminal
+    }
+}
+
+# Activate the theme when sourced
+use activate

--- a/themes/nu-themes/tokyo-moon.nu
+++ b/themes/nu-themes/tokyo-moon.nu
@@ -1,0 +1,82 @@
+export def main [] { return {
+    separator: "#828bb8"
+    leading_trailing_space_bg: { attr: "n" }
+    header: { fg: "#c3e88d" attr: "b" }
+    empty: "#82aaff"
+    bool: {|| if $in { "#86e1fc" } else { "light_gray" } }
+    int: "#828bb8"
+    filesize: {|e|
+        if $e == 0b {
+            "#828bb8"
+        } else if $e < 1mb {
+            "#86e1fc"
+        } else {{ fg: "#82aaff" }}
+    }
+    duration: "#828bb8"
+    date: {|| (date now) - $in |
+        if $in < 1hr {
+            { fg: "#ff757f" attr: "b" }
+        } else if $in < 6hr {
+            "#ff757f"
+        } else if $in < 1day {
+            "#ffc777"
+        } else if $in < 3day {
+            "#c3e88d"
+        } else if $in < 1wk {
+            { fg: "#c3e88d" attr: "b" }
+        } else if $in < 6wk {
+            "#86e1fc"
+        } else if $in < 52wk {
+            "#82aaff"
+        } else { "dark_gray" }
+    }
+    range: "#828bb8"
+    float: "#828bb8"
+    string: "#828bb8"
+    nothing: "#828bb8"
+    binary: "#828bb8"
+    cellpath: "#828bb8"
+    row_index: { fg: "#c3e88d" attr: "b" }
+    record: "#828bb8"
+    list: "#828bb8"
+    block: "#828bb8"
+    hints: "dark_gray"
+    search_result: { fg: "#ff757f" bg: "#828bb8" }
+
+    shape_and: { fg: "#c099ff" attr: "b" }
+    shape_binary: { fg: "#c099ff" attr: "b" }
+    shape_block: { fg: "#82aaff" attr: "b" }
+    shape_bool: "#86e1fc"
+    shape_custom: "#c3e88d"
+    shape_datetime: { fg: "#86e1fc" attr: "b" }
+    shape_directory: "#86e1fc"
+    shape_external: "#86e1fc"
+    shape_externalarg: { fg: "#c3e88d" attr: "b" }
+    shape_filepath: "#86e1fc"
+    shape_flag: { fg: "#82aaff" attr: "b" }
+    shape_float: { fg: "#c099ff" attr: "b" }
+    shape_garbage: { fg: "#FFFFFF" bg: "#FF0000" attr: "b" }
+    shape_globpattern: { fg: "#86e1fc" attr: "b" }
+    shape_int: { fg: "#c099ff" attr: "b" }
+    shape_internalcall: { fg: "#86e1fc" attr: "b" }
+    shape_list: { fg: "#86e1fc" attr: "b" }
+    shape_literal: "#82aaff"
+    shape_match_pattern: "#c3e88d"
+    shape_matching_brackets: { attr: "u" }
+    shape_nothing: "#86e1fc"
+    shape_operator: "#ffc777"
+    shape_or: { fg: "#c099ff" attr: "b" }
+    shape_pipe: { fg: "#c099ff" attr: "b" }
+    shape_range: { fg: "#ffc777" attr: "b" }
+    shape_record: { fg: "#86e1fc" attr: "b" }
+    shape_redirection: { fg: "#c099ff" attr: "b" }
+    shape_signature: { fg: "#c3e88d" attr: "b" }
+    shape_string: "#c3e88d"
+    shape_string_interpolation: { fg: "#86e1fc" attr: "b" }
+    shape_table: { fg: "#82aaff" attr: "b" }
+    shape_variable: "#c099ff"
+
+    background: "#222436"
+    foreground: "#c8d3f5"
+    cursor: "#c8d3f5"
+}}

--- a/themes/nu-themes/tokyo-moon.nu
+++ b/themes/nu-themes/tokyo-moon.nu
@@ -1,82 +1,121 @@
-export def main [] { return {
-    separator: "#828bb8"
-    leading_trailing_space_bg: { attr: "n" }
-    header: { fg: "#c3e88d" attr: "b" }
-    empty: "#82aaff"
-    bool: {|| if $in { "#86e1fc" } else { "light_gray" } }
-    int: "#828bb8"
-    filesize: {|e|
-        if $e == 0b {
-            "#828bb8"
-        } else if $e < 1mb {
-            "#86e1fc"
-        } else {{ fg: "#82aaff" }}
-    }
-    duration: "#828bb8"
-    date: {|| (date now) - $in |
-        if $in < 1hr {
-            { fg: "#ff757f" attr: "b" }
-        } else if $in < 6hr {
-            "#ff757f"
-        } else if $in < 1day {
-            "#ffc777"
-        } else if $in < 3day {
-            "#c3e88d"
-        } else if $in < 1wk {
-            { fg: "#c3e88d" attr: "b" }
-        } else if $in < 6wk {
-            "#86e1fc"
-        } else if $in < 52wk {
-            "#82aaff"
-        } else { "dark_gray" }
-    }
-    range: "#828bb8"
-    float: "#828bb8"
-    string: "#828bb8"
-    nothing: "#828bb8"
-    binary: "#828bb8"
-    cellpath: "#828bb8"
-    row_index: { fg: "#c3e88d" attr: "b" }
-    record: "#828bb8"
-    list: "#828bb8"
-    block: "#828bb8"
-    hints: "dark_gray"
-    search_result: { fg: "#ff757f" bg: "#828bb8" }
+# Update terminal colors
+export def "update terminal" [] {
+    let theme = (main)
 
-    shape_and: { fg: "#c099ff" attr: "b" }
-    shape_binary: { fg: "#c099ff" attr: "b" }
-    shape_block: { fg: "#82aaff" attr: "b" }
-    shape_bool: "#86e1fc"
-    shape_custom: "#c3e88d"
-    shape_datetime: { fg: "#86e1fc" attr: "b" }
-    shape_directory: "#86e1fc"
-    shape_external: "#86e1fc"
-    shape_externalarg: { fg: "#c3e88d" attr: "b" }
-    shape_filepath: "#86e1fc"
-    shape_flag: { fg: "#82aaff" attr: "b" }
-    shape_float: { fg: "#c099ff" attr: "b" }
-    shape_garbage: { fg: "#FFFFFF" bg: "#FF0000" attr: "b" }
-    shape_globpattern: { fg: "#86e1fc" attr: "b" }
-    shape_int: { fg: "#c099ff" attr: "b" }
-    shape_internalcall: { fg: "#86e1fc" attr: "b" }
-    shape_list: { fg: "#86e1fc" attr: "b" }
-    shape_literal: "#82aaff"
-    shape_match_pattern: "#c3e88d"
-    shape_matching_brackets: { attr: "u" }
-    shape_nothing: "#86e1fc"
-    shape_operator: "#ffc777"
-    shape_or: { fg: "#c099ff" attr: "b" }
-    shape_pipe: { fg: "#c099ff" attr: "b" }
-    shape_range: { fg: "#ffc777" attr: "b" }
-    shape_record: { fg: "#86e1fc" attr: "b" }
-    shape_redirection: { fg: "#c099ff" attr: "b" }
-    shape_signature: { fg: "#c3e88d" attr: "b" }
-    shape_string: "#c3e88d"
-    shape_string_interpolation: { fg: "#86e1fc" attr: "b" }
-    shape_table: { fg: "#82aaff" attr: "b" }
-    shape_variable: "#c099ff"
+    # Set terminal colors
+    let osc_screen_foreground_color = '10;'
+    let osc_screen_background_color = '11;'
+    let osc_cursor_color = '12;'
 
-    background: "#222436"
-    foreground: "#c8d3f5"
-    cursor: "#c8d3f5"
-}}
+    $"
+    (ansi -o $osc_screen_foreground_color)($theme.foreground)(char bel)
+    (ansi -o $osc_screen_background_color)($theme.background)(char bel)
+    (ansi -o $osc_cursor_color)($theme.cursor)(char bel)
+    "
+    # Line breaks above are just for source readability
+    # but create extra whitespace when activating. Collapse
+    # to one line
+    | str replace --all "\n" ''
+    | print $in
+}
+
+# Update the Nushell configuration
+export def --env "set color_config" [] {
+    $env.config.color_config = (main)
+}
+
+# Retrieve the theme settings
+export def main [] {
+    return {
+        separator: "#828bb8"
+        leading_trailing_space_bg: { attr: "n" }
+        header: { fg: "#c3e88d" attr: "b" }
+        empty: "#82aaff"
+        bool: {|| if $in { "#86e1fc" } else { "light_gray" } }
+        int: "#828bb8"
+        filesize: {|e|
+            if $e == 0b {
+                "#828bb8"
+            } else if $e < 1mb {
+                "#86e1fc"
+            } else {{ fg: "#82aaff" }}
+        }
+        duration: "#828bb8"
+        date: {|| (date now) - $in |
+            if $in < 1hr {
+                { fg: "#ff757f" attr: "b" }
+            } else if $in < 6hr {
+                "#ff757f"
+            } else if $in < 1day {
+                "#ffc777"
+            } else if $in < 3day {
+                "#c3e88d"
+            } else if $in < 1wk {
+                { fg: "#c3e88d" attr: "b" }
+            } else if $in < 6wk {
+                "#86e1fc"
+            } else if $in < 52wk {
+                "#82aaff"
+            } else { "dark_gray" }
+        }
+        range: "#828bb8"
+        float: "#828bb8"
+        string: "#828bb8"
+        nothing: "#828bb8"
+        binary: "#828bb8"
+        cellpath: "#828bb8"
+        row_index: { fg: "#c3e88d" attr: "b" }
+        record: "#828bb8"
+        list: "#828bb8"
+        block: "#828bb8"
+        hints: "dark_gray"
+        search_result: { fg: "#ff757f" bg: "#828bb8" }
+
+        shape_and: { fg: "#c099ff" attr: "b" }
+        shape_binary: { fg: "#c099ff" attr: "b" }
+        shape_block: { fg: "#82aaff" attr: "b" }
+        shape_bool: "#86e1fc"
+        shape_custom: "#c3e88d"
+        shape_datetime: { fg: "#86e1fc" attr: "b" }
+        shape_directory: "#86e1fc"
+        shape_external: "#86e1fc"
+        shape_externalarg: { fg: "#c3e88d" attr: "b" }
+        shape_filepath: "#86e1fc"
+        shape_flag: { fg: "#82aaff" attr: "b" }
+        shape_float: { fg: "#c099ff" attr: "b" }
+        shape_garbage: { fg: "#FFFFFF" bg: "#FF0000" attr: "b" }
+        shape_globpattern: { fg: "#86e1fc" attr: "b" }
+        shape_int: { fg: "#c099ff" attr: "b" }
+        shape_internalcall: { fg: "#86e1fc" attr: "b" }
+        shape_list: { fg: "#86e1fc" attr: "b" }
+        shape_literal: "#82aaff"
+        shape_match_pattern: "#c3e88d"
+        shape_matching_brackets: { attr: "u" }
+        shape_nothing: "#86e1fc"
+        shape_operator: "#ffc777"
+        shape_or: { fg: "#c099ff" attr: "b" }
+        shape_pipe: { fg: "#c099ff" attr: "b" }
+        shape_range: { fg: "#ffc777" attr: "b" }
+        shape_record: { fg: "#86e1fc" attr: "b" }
+        shape_redirection: { fg: "#c099ff" attr: "b" }
+        shape_signature: { fg: "#c3e88d" attr: "b" }
+        shape_string: "#c3e88d"
+        shape_string_interpolation: { fg: "#86e1fc" attr: "b" }
+        shape_table: { fg: "#82aaff" attr: "b" }
+        shape_variable: "#c099ff"
+
+        background: "#222436"
+        foreground: "#c8d3f5"
+        cursor: "#c8d3f5"
+    }
+}
+
+export module activate {
+    export-env {
+        set color_config
+        update terminal
+    }
+}
+
+# Activate the theme when sourced
+use activate


### PR DESCRIPTION
- followup to https://github.com/nushell/nu_scripts/pull/896
- cc/ @NotTheDr01ds 

## description
this PR puts back a few themes that have been removed in the previous PR and fixes the commands in the README.

## a few questions
@NotTheDr01ds, i have a few questions too :)
- is it required to have a separate `activate` module? why not directly put the `export-env` in the module?
- i don't understand the `update terminal` command, what does it do?