### PR TITLE
bump the version of `nu-themes`

### DIFF
--- a/themes/nupm.nuon
+++ b/themes/nupm.nuon
@@ -3,6 +3,6 @@
     description: "Officially-supported themes for Nushell"
     documentation: "https://github.com/nushell/nu_scripts/blob/main/README.md"
     license: "https://github.com/nushell/nu_scripts/blob/main/LICENSE"
-    version: 0.1.0
+    version: 0.2.0
     type: "module"
 }


### PR DESCRIPTION
- followup to https://github.com/nushell/nu_scripts/pull/896

this bumps the version of `nu-themes` to 0.2.0 to include the changes on the theme files and how to use them.