### PR TITLE
Remove multi-line flag from regexes

### DIFF
--- a/stdlib-candidate/std-rfc/str/dedent/mod.nu
+++ b/stdlib-candidate/std-rfc/str/dedent/mod.nu
@@ -35,13 +35,13 @@ export def main []: string -> string {
         }
     }
 
-    if ($string !~ '(?ms)^\s*\n') {
+    if ($string !~ '^\s*\n') {
         return (error make {
             msg: 'First line must be empty'
         })
     }
 
-    if ($string !~ '(?ms)\n\s*$') {
+    if ($string !~ '\n\s*$') {
         return (error make {
             msg: 'Last line must contain only whitespace indicating the dedent'
         })
@@ -49,13 +49,13 @@ export def main []: string -> string {
 
     # Get number of spaces on the last line
     let indent = $string
-        | str replace -r '(?ms).*\n( *)$' '$1'
+        | str replace -r '(?s).*\n( *)$' '$1'
         | str length
 
     # Skip the first and last lines
     let lines = (
         $string
-        | str replace -r '(?ms)^[^\n]*\n(.*)\n[^\n]*$' '$1'
+        | str replace -r '(?s)^[^\n]*\n(.*)\n[^\n]*$' '$1'
           # Use `split` instead of `lines`, since `lines` will
           # drop legitimate trailing empty lines
         | split row "\n"
@@ -89,5 +89,5 @@ export def main []: string -> string {
     | to text
       # Remove the trailing newline which indicated
       # indent level
-    | str replace -r '(?ms)(.*)\n$' '$1'
+    | str replace -r '(?s)(.*)\n$' '$1'
 }

--- a/stdlib-candidate/tests/str_dedent.nu
+++ b/stdlib-candidate/tests/str_dedent.nu
@@ -80,10 +80,26 @@ export def "test str dedent" [] {
         $s | str dedent
     }
 
+    # Test 6.1:
+    # Error - Does not contain an empty first line
+    assert error {||
+        let s = "Error\n \nTesting\n"
+        $s | str dedent
+    }
+
     # Test 7:
     # Error - Does not contain an empty last line
     assert error {||
         let s = "
+            Error"
+        $s | str dedent
+    }
+
+    # Test 7.1:
+    # Error - Does not contain an empty last line
+    assert error {||
+        let s = "
+
             Error"
         $s | str dedent
     }


### PR DESCRIPTION
Minor fix on `str dedent` - I erroneously used the regex multi-line flag `(?m)` in several patterns where it shouldn't have been.  For the most part, this was harmless, but it did surface an error when I was working on updating the themes.

Fixed these and added two new tests that would have caught the issue.