### PR TITLE
Bump stdlib-candidate nupm version

### DIFF
--- a/stdlib-candidate/nupm.nuon
+++ b/stdlib-candidate/nupm.nuon
@@ -3,6 +3,6 @@
     description: "Official candidates for Nushell standard library"
     documentation: "https://github.com/nushell/nu_scripts/blob/main/stdlib-candidate/std-rfc/README.md"
     license: "https://github.com/nushell/nu_scripts/blob/main/LICENSE"
-    version: 0.1.0
+    version: 0.3.0
     type: "module"
 }


### PR DESCRIPTION
Forgot to bump the Nupm version, but then again everyone else did as well ;-)

Updated it to 0.3.0 (skipped 0.2.0) since it looks like there have been two commands that have been either added or drastically changed since 0.1.0.