### PR TITLE
work on the `nu-themes` make script

### DIFF
--- a/themes/src/make.nu
+++ b/themes/src/make.nu
@@ -234,11 +234,13 @@ def main [] {
         }
     }
 
-    let themes = ls $LEMNOS_SOURCE.dir
-        | insert source "lemnos"
-        | append (ls $CUSTOM_SOURCE.dir | insert source "custom")
-        | update name { path parse | get stem }
-        | select name source
+    let themes: table<name: string, source: string> = (
+        ls $LEMNOS_SOURCE.dir
+            | insert source "lemnos"
+            | append (ls $CUSTOM_SOURCE.dir | insert source "custom")
+            | update name { path parse | get stem }
+            | select name source
+    )
 
     let failed = $themes | each { |t|
         info -n $"Converting ($t.name)                                       \r"

--- a/themes/src/make.nu
+++ b/themes/src/make.nu
@@ -217,7 +217,22 @@ def make_theme [ name: string, origin: string = "lemnos" ] {
 def main [] {
     mkdir $themes_dir
 
-    try { git clone $LEMNOS_SOURCE.remote_repo $LEMNOS_SOURCE.local_repo }
+    if ($LEMNOS_SOURCE.local_repo | path exists) {
+        warn "local copy of Lemnos' themes already exists"
+        info "updating local copy"
+        try {
+            git -C $LEMNOS_SOURCE.local_repo pull origin master
+        } catch {
+            err "failed updating local copy"
+        }
+    } else {
+        info "cloning Lemnos' themes"
+        try {
+            git clone $LEMNOS_SOURCE.remote_repo $LEMNOS_SOURCE.local_repo
+        } catch {
+            error make --unspanned { msg: "failed cloning local copy" }
+        }
+    }
 
     let themes = ls $LEMNOS_SOURCE.dir
         | insert source "lemnos"

--- a/themes/src/make.nu
+++ b/themes/src/make.nu
@@ -15,6 +15,18 @@ let CUSTOM_SOURCE = {
 
 let themes_dir = ($current_dir | path join "../nu-themes")
 
+def info [msg: string, --no-newline (-n)] {
+    print --no-newline=$no_newline $"(ansi green)[INFO](ansi reset) ($msg)"
+}
+
+def err [msg: string, --no-newline (-n)] {
+    print --no-newline=$no_newline $"(ansi red_bold)[ERR](ansi reset) ($msg)"
+}
+
+def warn [msg: string, --no-newline (-n)] {
+    print --no-newline=$no_newline $"(ansi yellow)[WARNING](ansi reset) ($msg)"
+}
+
 # For lemnos themes, create the color_config from the lemnos theme
 # definition.
 # Custom Nushell themes should be defined in themes/src/custom-nu-themes
@@ -212,12 +224,11 @@ def main [] {
     | path parse
     | get stem
     | each {|theme|
-        print $"Converting ($theme)"
+        info -n $"Converting ($theme)                                       \r"
         try {
             make_theme $theme
         } catch {|e|
-            print -e $"Error converting ($theme)"
-            print -e $e.debug 
+            err $"Converting ($theme) failed: ($e.msg)"
         }
     }
     | ignore
@@ -227,12 +238,11 @@ def main [] {
     | path parse
     | get stem
     | each {|theme|
-        print $"Converting ($theme)"
+        info -n $"Converting ($theme)                                       \r"
         try {
             make_theme $theme "custom"
         } catch {|e|
-            print -e $"Error converting ($theme)"
-            print -e $e.debug 
+            err $"Converting ($theme) failed: ($e.msg)"
         }
     }
 

--- a/themes/src/make.nu
+++ b/themes/src/make.nu
@@ -219,7 +219,7 @@ def main [] {
 
     try { git clone $LEMNOS_SOURCE.remote_repo $LEMNOS_SOURCE.local_repo }
 
-    ls $LEMNOS_SOURCE.dir
+    let lemnos_failed = ls $LEMNOS_SOURCE.dir
     | get name
     | path parse
     | get stem
@@ -229,11 +229,11 @@ def main [] {
             make_theme $theme
         } catch {|e|
             err $"Converting ($theme) failed: ($e.msg)"
+            $theme
         }
     }
-    | ignore
 
-    ls $CUSTOM_SOURCE.dir
+    let custom_failed = ls $CUSTOM_SOURCE.dir
     | get name
     | path parse
     | get stem
@@ -243,8 +243,19 @@ def main [] {
             make_theme $theme "custom"
         } catch {|e|
             err $"Converting ($theme) failed: ($e.msg)"
+            $theme
         }
     }
 
-    print "all done"
+    let failed = $custom_failed | wrap name | insert source "custom" | append (
+        $lemnos_failed | wrap name | insert source "lemnos"
+    )
+
+    print ''
+    if not ($failed | is-empty) {
+        warn "The following themes have failed:"
+        print $failed
+    } else {
+        print "all done"
+    }
 }


### PR DESCRIPTION
i was mostly having fun there :yum:

cc/ @NotTheDr01ds 

## changes
- using some colors for the logging
- slight refactor of the main, i.e. i build a `table<name: string, source: string>` of themes and then iterate over it and call `make-theme $t.name $t.source`, thus getting rid of the twin pipelines
- i also build a `table<name: string, source: string>` of failing themes, to show them at the end

## reviewing
i think the best to review this is
- go to `themes/`
- remove any copy of the `lemnos/` directory
- run `./src/make.nu` twice and see the output :wink: 