### PR TITLE
fix: nu-complete for git ref and git files-and-ref uses nu-complete git switch now

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -126,20 +126,15 @@ def "nu-complete git built-in-refs" [] {
 }
 
 def "nu-complete git refs" [] {
-  nu-complete git switchable branches
-  | parse "{value}"
-  | insert description Branch
-  | append (nu-complete git tags | parse "{value}" | insert description Tag)
-  | append (nu-complete git built-in-refs)
+  nu-complete git switch
+  | update description Branch
+  | append (nu-complete git tags | update description Tag)
+  | append (nu-complete git built-in-refs | wrap value | insert description Ref)
 }
 
 def "nu-complete git files-or-refs" [] {
-  nu-complete git switchable branches
-  | parse "{value}"
-  | insert description Branch
-  | append (nu-complete git files | where description == "Modified" | select value)
-  | append (nu-complete git tags | parse "{value}" | insert description Tag)
-  | append (nu-complete git built-in-refs)
+  nu-complete git refs
+  | prepend (nu-complete git files | where description == "Modified")
 }
 
 def "nu-complete git subcommands" [] {


### PR DESCRIPTION
Git `nu-complete` defs where outdated, using a removed function `nu-complete git switachable branches`, now using `nu-complete git switch`

Already tested (except for tags)