### PR TITLE
Fix cell-path in themes

### DIFF
--- a/themes/nupm.nuon
+++ b/themes/nupm.nuon
@@ -3,6 +3,6 @@
     description: "Officially-supported themes for Nushell"
     documentation: "https://github.com/nushell/nu_scripts/blob/main/README.md"
     license: "https://github.com/nushell/nu_scripts/blob/main/LICENSE"
-    version: 0.3.0
+    version: 0.4.0
     type: "module"
 }

--- a/themes/src/custom-nu-themes/catppuccin-latte.nu
+++ b/themes/src/custom-nu-themes/catppuccin-latte.nu
@@ -111,4 +111,5 @@ export def main [] {
         background: $color_palette.base
         foreground: $color_palette.text
         cursor: $color_palette.blue
-}}
+    }
+}

--- a/themes/src/make.nu
+++ b/themes/src/make.nu
@@ -84,7 +84,7 @@ def make_color_config [ name: string, source: string = "lemnos" ] {
                     string: '($colors.color7)'
                     nothing: '($colors.color7)'
                     binary: '($colors.color7)'
-                    cellpath: '($colors.color7)'
+                    cell-path: '($colors.color7)'
                     row_index: { fg: '($colors.color2)' attr: 'b' }
                     record: '($colors.color7)'
                     list: '($colors.color7)'
@@ -251,10 +251,11 @@ def main [] {
             $t
         }
     }
+    info -n $"Completed converting (($themes | length) - ($failed | length)) themes         \r"
 
     print ''
     if not ($failed | is-empty) {
-        warn "The following themes have failed:"
+        warn $"The following ($failed | length) themes have failed:"
         print $failed
     } else {
         print "all done"


### PR DESCRIPTION
Four minor changes:

* As previously mentioned, updates `make.nu` to use `cell-path` rather than `cellpath`
* Slight improvements on #905 (cc @amtoine) - The last theme converted was the only one printed via `info`, but it didn't get removed from the screen.  Things moved so fast on my system that it looked like only one theme was being converted, since that's the only message that was left on the screen ;-).  Now prints a "Done" message showing how many themes were converted and how many failed.
* There was a previous update to `catppuccin-latte.nu` that was apparently made directly to the theme, rather than the custom src.  Synced these up.
* Bumped `nupm.nuon`