### PR TITLE
Fixed sys usage

### DIFF
--- a/custom-completions/make/make-completions.nu
+++ b/custom-completions/make/make-completions.nu
@@ -11,7 +11,7 @@ def "nu-complete make" [] {
 }
 
 def "nu-complete make jobs" [] {
-	seq 1 (sys | get cpu | length)
+	seq 1 (sys cpu | length)
 }
 
 def "nu-complete make files" [] {

--- a/custom-completions/poetry/poetry-completions.nu
+++ b/custom-completions/poetry/poetry-completions.nu
@@ -115,12 +115,9 @@ def "nu-complete poetry setting-values" [context: string] nothing -> list<any> {
         return (
             ls | get name | where (($it | path type) == "dir") | each {|it| $it | path expand}
         ) | append (
-            if (
-                ((sys).host.name | str downcase | str ends-with "macos")
-                or ((sys).host.name | str downcase | str ends-with "osx")
-            ) {
+            if ($nu.os-info.name == "macos") {
                 $env.HOME | path join "Library/Caches/pypoetry"
-            } else if ((sys).host.name | str downcase | str ends-with "windows") {
+            } else if ($nu.os-info.name == "windows") {
                 $env.HOME | path join "AppData/Local/pypoetry/Cache"
             } else if ("XDG_CACHE_HOME" in $env) {
                 $env.XDG_CACHE_HOME | path join "pypoetry"

--- a/modules/prompt/left_and_right_prompt.nu
+++ b/modules/prompt/left_and_right_prompt.nu
@@ -4,7 +4,7 @@ export def construct_prompt [] {
     let decorator = (create_second_line)
 
     # not using machine name
-    # let machine_name = (sys | get host.hostname)
+    # let machine_name = (sys host | get hostname)
 
     # the current working directory
     # let current_dir = (pwd)

--- a/modules/prompt/oh-my-minimal.nu
+++ b/modules/prompt/oh-my-minimal.nu
@@ -19,7 +19,7 @@
 def home_abbrev [os] {
     let is_home_in_path = ($env.PWD | str starts-with $nu.home-path)
     if ($is_home_in_path == true) {
-        if ($os == "Windows") {
+        if ($os == "windows") {
             let home = ($nu.home-path | str replace -ar '\\' '/')
             let pwd = ($env.PWD | str replace -ar '\\' '/')
             $pwd | str replace $home '~'
@@ -82,21 +82,21 @@ export def path_abbrev_if_needed [apath term_width] {
 def get_os_icon [os use_nerd_fonts] {
     # f17c = tux, f179 = apple, f17a = windows
     if $use_nerd_fonts {
-        if ($os =~ Darwin) {
+        if ($os =~ macos) {
             (char -u f179)
-        } else if ($os =~ Linux) {
+        } else if ($os =~ linux) {
             (char -u f17c)
-        } else if ($os =~ Windows) {
+        } else if ($os =~ windows) {
             (char -u f17a)
         } else {
             ''
         }
     } else {
-        if ($os =~ Darwin) {
+        if ($os =~ macos) {
             "M"
-        } else if ($os =~ Linux) {
+        } else if ($os =~ linux) {
             "L"
-        } else if ($os =~ Windows) {
+        } else if ($os =~ windows) {
             "W"
         } else {
             ''
@@ -261,7 +261,7 @@ export def get_right_prompt [os use_nerd_fonts] {
 
 export def get_prompt [nerd?] {
     let use_nerd_fonts = ($nerd != null)
-    let os = ((sys).host.name)
+    let os = $nu.os-info.name
     let left_prompt = (get_left_prompt $os $use_nerd_fonts)
     let right_prompt = (get_right_prompt $os $use_nerd_fonts)
 

--- a/modules/virtual_environments/auto-venv/venv_helpers.nu
+++ b/modules/virtual_environments/auto-venv/venv_helpers.nu
@@ -28,8 +28,7 @@ export def 'venv-create' [] {
 	let venv_path = $env.PWD
 	let venv_name = ($env.PWD | path basename) 
 
-	let sys_posix = ['darwin', 'linux', 'unix', 'posix', 'gnu']
-	let is_posix = (((sys).host.name | str downcase) in $sys_posix)
+	let is_posix = ($nu.os-info.family == 'unix')
 	let python_name = if $is_posix {'python3'} else {'py.exe'}
 	run-external $python_name "-m" "venv" ".venv" "--clear" "--prompt" $venv_name
 	run-external $".venv/bin/($python_name)" "-m" "pip" "install" "-U" "pip" "wheel" "setuptools"

--- a/modules/virtual_environments/auto-venv/venvs/python-venv.nu
+++ b/modules/virtual_environments/auto-venv/venvs/python-venv.nu
@@ -21,7 +21,7 @@ export def --env auto-venv-on-enter [
     let bin            = ([$virtual_env, "bin"] | path join)
     let virtual_prompt = ""
 
-    let is_windows = ((sys).host.name | str downcase) == 'windows'
+    let is_windows = $nu.os-info.name == 'windows'
     let path_name = if $is_windows {
         if (has-env 'Path') {
             'Path'

--- a/modules/virtual_environments/nu_conda/nu_conda.nu
+++ b/modules/virtual_environments/nu_conda/nu_conda.nu
@@ -1,6 +1,6 @@
 export-env {
   if not ("CONDA_CURR" in $env) {
-    $env.CONDA_BASE_PATH = (if ((sys host).name == "Windows") {$env.Path} else {$env.PATH})
+    $env.CONDA_BASE_PATH = (if $nu.os-info.name == 'windows' {$env.Path} else {$env.PATH})
 
     let info = (
         if not (which mamba | is-empty) {
@@ -37,7 +37,7 @@ export def --env activate [name: string] {
   }
 
   let new_path = (
-    if ((sys host).name == "Windows") {
+    if $nu.os-info.name == 'windows' {
       update-path-windows ($env.CONDA_ENVS | get $name)
     } else {
       update-path-linux ($env.CONDA_ENVS | get $name)

--- a/modules/virtual_environments/nu_conda_2/conda.nu
+++ b/modules/virtual_environments/nu_conda_2/conda.nu
@@ -170,7 +170,7 @@ def conda-create-path-unix [env_dir: path] {
 }
 
 def windows? [] {
-    ((sys).host.name | str downcase) == "windows"
+    $nu.os-info.name == 'windows'
 }
 
 def system-path [] {

--- a/modules/weather/timed_weather_run.nu
+++ b/modules/weather/timed_weather_run.nu
@@ -18,10 +18,7 @@ def timed_weather_run [
     --interval(-i): duration # The interval duration
     ] {
 
-    # get the type of system we're on
-    let system_name = ((sys).host | get name)
-
-    if $system_name == "Windows" {
+    if $nu.os-info.name == "windows" {
         # $"The system is Windows(char nl)"
         # generate temp file name
         let weather_runtime_file = (($env.TMP) | path join weather_runtime_file.json)


### PR DESCRIPTION
Just as a heads up, I haven't really tested this since a lot of it is stuff I don't use or know how to set up without some reading up. I have tested the nu_conda_2 change since I have a python project that I use that for, and I could look into testing more of it if needed.

I've tried finding (naively using `/sys\W/`) all the usage of the old plain `sys` calls and replacing them with alternates as appropriate, which mostly has been to swap a `(sys).host.name` call into a `$nu.os-info.name` one, since it'll be tad faster and more consistent across platforms with naming (especially as the value comes from the [rust stdlib](https://doc.rust-lang.org/std/env/consts/constant.OS.html) and is very predictable).

Fixes #897 