### PR TITLE
Fix incorrect docker commands

### DIFF
--- a/custom-completions/docker/docker-completions.nu
+++ b/custom-completions/docker/docker-completions.nu
@@ -657,7 +657,7 @@ export extern "docker container run" [
     --memory-swappiness: int                            #Tune container memory swappiness (0 to 100) (default -1)
     --mount: string                                     #Attach a filesystem mount to the container
     --name: string                                      #Assign a name to the container
-    --network network                                   #Connect a container to a network
+    --network: string                                   #Connect a container to a network
     --network-alias: string                             #Add network-scoped alias for the container
     --no-healthcheck                                    #Disable any container-specified HEALTHCHECK
     --oom-kill-disable                                  #Disable OOM Killer
@@ -819,7 +819,7 @@ export extern "docker run" [
     --memory-swappiness: int                            #Tune container memory swappiness (0 to 100) (default -1)
     --mount: string                                     #Attach a filesystem mount to the container
     --name: string                                      #Assign a name to the container
-    --network network                                   #Connect a container to a network
+    --network: string                                   #Connect a container to a network
     --network-alias: string                             #Add network-scoped alias for the container
     --no-healthcheck                                    #Disable any container-specified HEALTHCHECK
     --oom-kill-disable                                  #Disable OOM Killer


### PR DESCRIPTION
Fix "docker run" and "docker container run" custom commands incorrectly expecting a "network" positional argument.