### PR TITLE
Update scoop completions

### DIFF
--- a/custom-completions/scoop/scoop-completions.nu
+++ b/custom-completions/scoop/scoop-completions.nu
@@ -92,11 +92,25 @@ def scoopShimBuilds [] {
 }
 
 def scoopCommands [] {
-  scoop help | lines --skip-empty | skip 5 | parse '{value} {description}' | str trim
+  ^powershell -nop -nol -c "(scoop help | ConvertTo-Json -Compress)"
+  | decode
+  | lines
+  | last
+  | to text
+  | from json
+  | rename value description
 }
 
 def scoopAliases [] {
-  scoop alias list | lines --skip-empty | skip 2 | parse '{name} {path}' | get name
+  ^powershell -nop -nol -c "(scoop alias list|ConvertTo-Json -Compress)"
+  | decode
+  | str trim
+  | lines
+  | last
+  | to text
+  | '[' + $in + ']'
+  | from json
+  | get Name
 }
 
 def batStyles [] {


### PR DESCRIPTION
made scoop completions a bit more reliable by converting the PsObject from powershell to json instead of parsing lines from the `scoop help` output

doesn't take any longer since scoop run in powershell either way