### PR TITLE
Add nu-complete cache helper

### DIFF
--- a/custom-completions/cache/nu-complete-cache.nu
+++ b/custom-completions/cache/nu-complete-cache.nu
@@ -1,0 +1,60 @@
+def db [] {
+  [$env.XDG_CACHE_HOME "nu-complete.sqlite"] | path join
+}
+
+def init [] {
+  if (db | path exists) {
+    stor import --file-name (db)
+  } else {
+    (stor create
+      --table-name "nu_complete" 
+      --columns {
+        name: str
+        value: str
+        timestamp: datetime
+      }
+    )
+  }
+}
+
+export def "nu-complete cache" [
+  --expire: duration
+  cmd: any
+] {
+  init
+
+  let name = view source $cmd
+
+  let saved = stor open
+    | (query db
+        "SELECT value, timestamp FROM nu_complete WHERE name = :name"
+        -p { name: $name })
+    | get -i 0
+
+  if $saved == null or (($saved.timestamp | into datetime) + $expire < (date now)) {
+    let output = do $cmd
+
+    if $saved == null {
+      { name: $name, value: ($output | to nuon -r), timestamp: (date now) }
+      | stor insert -t "nu_complete"
+    } else {
+      stor open
+      | query db "UPDATE nu_complete SET value = :value, timestamp = :timestamp WHERE name = :name" -p {
+        value: ($output | to nuon -r),
+        timestamp: (date now),
+        name: $name
+      }
+    }
+
+    rm -f (db)
+    stor export --file-name (db)
+
+    $output
+  } else {
+    rm -f (db)
+    stor export --file-name (db)
+
+    $saved.value | from nuon
+  }
+}
+


### PR DESCRIPTION
I wanted to propose a solution to issues with very slow command completions (as mentioned in https://github.com/nushell/nushell/issues/11733 and https://github.com/nushell/nu_scripts/issues/588) with a command that caches closure outputs in a SQLite db with an explicit expiration.

## Usage

This can be used in custom completion functions to temporarily cache the output.

```nushell
def "nu-complete kubectl services" [] {
  nu-complete cache --expire 1min {
     ^kubectl get services -o name | parse "service/{value}"
  }
}
```

## Open points

- Does it make sense to use the in-memory store for this? Since this is supposed to speed up slow commands, maybe the performance hit of just querying a disk DB would be negligible in comparison, and I would expect the DB to grow a lot in size after a while.
- How and when do we clean up this DB?
- Does it make sense to use `view source` on the closure as a key into this cache?
- Can we check if the closure takes any arguments and throw an error?
- Should the location of this DB be configurable? For now I just dropped it into XDG_CACHE_HOME, but not every system has that env variable available.

This is very much a WIP, if you have any suggestions please mention it!