### PR TITLE
Fix TWiN script

### DIFF
--- a/make_release/this_week_in_nu_weekly.nu
+++ b/make_release/this_week_in_nu_weekly.nu
@@ -33,7 +33,7 @@ def query-week-span [] {
         if not ($site_json | all { |it| $it | is-empty }) {
             print $"(char nl)## ($repo.site)(char nl)"
 
-            for user in ($site_json | group-by user_login | transpose user prs) {
+            for user in ($site_json | group-by "user.login" | transpose user prs) {
                 let user_name = $user.user
                 let pr_count = ($user.prs | length)
 


### PR DESCRIPTION
At some point this broke, just committing a fix I've had on my personal computer for a while.

```
# This week in Nushell #261


## Nushell

Error: nu::shell::name_not_found

  × Name not found
    ╭─[/home/reilly/github/nu_scripts/make_release/this_week_in_nu_weekly.nu:36:48]
 35 │
 36 │             for user in ($site_json | group-by user_login | transpose user prs) {
    ·                                                ─────┬────
    ·                                                     ╰── did you mean 'user.login'?
 37 │                 let user_name = $user.user
    ╰────
```