### PR TITLE
fix(aws): Fix select-aws-profile script functionality and style

### DIFF
--- a/modules/aws/select-aws-profile.nu
+++ b/modules/aws/select-aws-profile.nu
@@ -1,40 +1,40 @@
 # This alias lets you choose your aws environment variables with ease.
 #
-# Dependencies
-#    * fzf
+# Dependencies:
+#   * fzf
 #
-# Installation
-#     1. store in ~/.config/nushell/select-aws-profile.nu
-#     2. add to your config.nu: `use ~/.config/nushell/select-aws-profile.nu *`
+# Installation:
+#   1. store in ~/.config/nushell/select-aws-profile.nu
+#   2. add to your config.nu: `use ~/.config/nushell/select-aws-profile.nu *`
 #
-# Usage
-#     select-aws-profile
-export def select-aws-profile [] {
-    hide AWS_REGION;
+# Usage:
+#   select-aws-profile
+export def --env main [] {
+    hide AWS_REGION
 
-    (do {
-        let creds = (open ($env.HOME + "/.aws/credentials") | from toml)
-            let selectedProfile = (for it in ($creds | transpose name creds) {
-                echo $it.name
-            })
-            
-            selectedProfile = selectedProfile  | str join "\n" | fzf | str trim
+    do {
+        let creds = open ($env.HOME + "/.aws/credentials") | from toml
+        let selected_profile = $creds
+            | transpose name creds
+            | get name
+            | str join "\n"
+            | fzf
 
-            if $selectedProfile != "" {
-                let out = {
-                    AWS_PROFILE: $selectedProfile,
-                    AWS_ACCESS_KEY_ID: ($creds | get $selectedProfile | get "aws_access_key_id"),
-                    AWS_SECRET_ACCESS_KEY: ($creds | get $selectedProfile | get "aws_secret_access_key"),
-                }
-                
-                let region = ($creds | get $selectedProfile | get -i "region")
-                if $region != "" {
-                    $out | insert "AWS_REGION" $region
-                } else {
-                    $out
-                }
+        if $selected_profile != "" {
+            let out = {
+                AWS_PROFILE: $selected_profile,
+                AWS_ACCESS_KEY_ID: ($creds | get $selected_profile | get "aws_access_key_id"),
+                AWS_SECRET_ACCESS_KEY: ($creds | get $selected_profile | get "aws_secret_access_key"),
             }
-    } | load-env);
+
+            let region = ($creds | get $selected_profile | get -i "region")
+            if $region != null {
+                $out | insert AWS_REGION $region
+            } else {
+                $out
+            }
+        }
+    } | load-env
 
     {
         AWS_PROFILE: $env.AWS_PROFILE,


### PR DESCRIPTION
### What
- Rename main function to 'main' and add --env flag for environment modification
- Fix region handling to properly check for null values

### Why

The aws/select-aws-profile script syntax is outdated

```shell
➜ nu
Error: nu::parser::named_as_module

  × Can't export command named same as the module.
    ╭─[~/.config/nushell/nu_scripts/modules/aws/select-aws-profile.nu:12:12]
 11 │ #     select-aws-profile
 12 │ export def select-aws-profile [] {
    ·            ─────────┬────────
    ·                     ╰── can't export from module select-aws-profile
 13 │     hide AWS_REGION;
    ╰────
  help: Module select-aws-profile can't export command named the same as the module. Either change the module name, or export `main` command.
```