### PR TITLE
:adhesive_bandage: fix `git init --initial-branch` string instead of bool

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -533,7 +533,7 @@ export extern "git stash drop" [
 
 # Create a new git repository
 export extern "git init" [
-  --initial-branch(-b)                                # initial branch name
+  --initial-branch(-b): string                         # initial branch name
 ]
 
 # List or manipulate tags


### PR DESCRIPTION
Just using the completions I realized that:

```nu
# Create a new git repository
export extern "git init" [
  --initial-branch(-b)                                # initial branch name
  #should be
  --initial-branch(-b): string                        # initial branch name
]
```

because initial branch takes a string, it not a boolean