### PR TITLE
key-value module for std-rfc

### DIFF
--- a/stdlib-candidate/std-rfc/kv/mod.nu
+++ b/stdlib-candidate/std-rfc/kv/mod.nu
@@ -1,0 +1,152 @@
+# kv module
+#
+# use std-rfc/kv *
+#
+# Easily store and retrieve key-value pairs
+# in a pipeline.
+#
+# A common request is to be able to assign a
+# pipeline result to a variable. While it's
+# not currently possible to use a "let" statement
+# within a pipeline, this module provides an
+# alternative. Think of each key as a variable
+# that can be set and retrieved.
+
+# Stores the pipeline value for later use
+#
+# If the key already exists, it is updated
+# to the new value provided.
+#
+# Usage:
+# <input> | kv set <key> <value?>
+#
+# Example:
+# ls ~ | kv set "home snapshot"
+# kv set foo 5
+export def "kv set" [key: string, value?: any] {
+  # Pipeline input is preferred, but prioritize
+  # parameter if present. This allows $in to be
+  # used in the parameter if needed.
+  let input = $in
+  let value = $value | default $input
+
+  # Store values as nuons for type-integrity
+  let kv_pair = {
+    key: $key
+    value: ($value | to nuon)
+  }
+
+  # Create the table if it doesn't exist
+  try {
+    stor create -t kv_mod_store -c {key: str, value: str} | ignore
+  }
+
+  # Does the key exist yet?
+  let key_exists = ( $key in (stor open | $in.kv_mod_store?.key?))
+  
+  # If so, we need an update rather than an insert
+  let stor_action = match $key_exists {
+    true => {{stor update -t kv_mod_store --where-clause $"key = '($key)'"}}
+    false  => {{stor insert -t kv_mod_store}}
+  }
+
+  # Execute the update-or-insert action
+  $kv_pair | do $stor_action
+
+  # Returns the kv table itself in case it's
+  # useful in the pipeline
+  kv list
+}
+
+def kv_key_completions [] {
+  try {
+    stor open
+    # Hack to turn a SQLiteDatabase into a table
+  | $in.kv_mod_store | wrap temp | get temp
+  | get key? 
+  } catch {
+    # Return no completions
+    []
+  }
+
+}
+
+# Retrieves a stored value by key
+#
+# Counterpart of "kv set". Returns null
+# if the key is not found.
+# 
+# Usage:
+# kv get <key> | <pipeline>
+export def "kv get" [
+  key: string@kv_key_completions    # Key of the kv-pair to retrieve
+] {
+  try {
+    stor create -t kv_mod_store -c {key: str, value: str} | ignore
+  }
+
+  stor open
+    # Hack to turn a SQLiteDatabase into a table
+  | $in.kv_mod_store | wrap temp | get temp
+  | where key == $key
+    # Should only be one occurence of each key in the stor
+  | get -i value | first
+  | match $in {
+      # Key not found
+      null => null
+      # Key found
+      _ => { from nuon }
+  }
+}
+
+# List the currently stored key-value pairs
+#
+# Returns results as the Nushell value rather
+# than the stored nuon.
+export def "kv list" [] {
+  # Create the table if it doesn't exist
+  try {
+    stor create -t kv_mod_store -c {key: str, value: str} | ignore
+  }
+
+  stor open | $in.kv_mod_store | each {|kv_pair|
+    {
+      key: $kv_pair.key
+      value: ($kv_pair.value | from nuon )
+    }
+  }
+}
+
+# Returns and removes a key-value pair
+export def "kv drop" [
+  key: string@kv_key_completions    # Key of the kv-pair to drop
+] {
+  # Create the table if it doesn't exist
+  try {
+    stor create -t kv_mod_store -c {key: str, value: str} | ignore
+  }
+
+  try {
+    stor open
+      # Hack to turn a SQLiteDatabase into a table
+    | $in.kv_mod_store | wrap temp | get temp
+    | where key == $key
+      # Should only be one occurence of each key in the stor
+    | get -i value | first
+    | match $in {
+        # Key not found
+        null => null
+
+        # Key found
+        _ => {
+          let value = $in
+          stor delete --table-name kv_mod_store --where-clause $"key = '($key)'"
+          $value | from nuon
+        }
+    }
+
+  } catch {
+    # If value not found or other error, don't return anything
+    null
+  }
+}

--- a/stdlib-candidate/std-rfc/kv/mod.nu
+++ b/stdlib-candidate/std-rfc/kv/mod.nu
@@ -151,7 +151,7 @@ export def --env "kv drop" [
     | query db $"DELETE FROM std_kv_store WHERE key = '($key)'"
   }
 
-  if $universal and $env.NU_KV_UNIVERSALS? {
+  if $universal and ($env.NU_KV_UNIVERSALS? | default false) {
     hide-env $key
   }
 

--- a/stdlib-candidate/tests/kv.nu
+++ b/stdlib-candidate/tests/kv.nu
@@ -1,0 +1,240 @@
+use std/assert
+use ../std-rfc/kv *
+
+# Important to use random keys and clean-up
+# since the user running these tests may have
+# either an existing local stor or universal db.
+
+#[test]
+def simple-local-set [] {
+    let key = (random uuid)
+
+    kv set $key 42
+    let actual = (kv get $key)
+    let expected = 42
+    assert equal $actual $expected
+
+    kv drop $key | ignore
+}
+
+#[test]
+def local-pipeline_set_returns_value [] {
+    let key = (random uuid)
+    let actual = (42 | kv set $key)
+    let expected = 42
+    assert equal $actual $expected
+
+    let actual = (kv get $key)
+    let expected = 42
+    assert equal $actual $expected
+
+    kv drop $key | ignore
+}
+
+#[test]
+def local-multiple_assignment [] {
+    let key1 = (random uuid)
+    let key2 = (random uuid)
+    let key3 = (random uuid)
+
+    "test value" | kv set $key1 | kv set $key2 | kv set $key3
+    let expected = "test value"
+    assert equal (kv get $key1) $expected
+    assert equal (kv get $key2) $expected
+    assert equal (kv get $key3) $expected
+    assert equal (kv get $key3) (kv get $key1)
+
+    kv drop $key1
+    kv drop $key2
+    kv drop $key3
+}
+
+#[test]
+def local-transpose_to_record [] {
+    let key1 = (random uuid)
+    let key2 = (random uuid)
+    let key3 = (random uuid)
+
+    "test value" | kv set $key1 | kv set $key2 | kv set $key3
+
+    let record = (kv list | transpose -dr)
+    let actual = ($record | select $key1)
+    let expected = { $key1: "test value" }
+
+    assert equal $actual $expected
+
+    kv drop $key1
+    kv drop $key2
+    kv drop $key3
+}
+
+#[test]
+def local-using_closure [] {
+    let name_key = (random uuid)
+    let size_key = (random uuid)
+
+    ls
+    | kv set $name_key { get name }
+    | kv set $size_key { get size }
+
+    let expected = "list<string>"
+    let actual = (kv get $name_key | describe)
+    assert equal $actual $expected
+
+    let expected = "list<filesize>"
+    let actual = (kv get $size_key | describe)
+    assert equal $actual $expected
+
+    kv drop $name_key
+    kv drop $size_key
+}
+
+#[test]
+def local-return-entire-list [] {
+    let key1 = (random uuid)
+    let key2 = (random uuid)
+
+    let expected = 'value1'
+    $expected | kv set $key1
+
+    let actual = (
+        'value2'
+        | kv set --return all $key2   # Set $key2, but return the entire kv store
+        | transpose -dr  # Convert to record for easier retrieval
+        | get $key1      # Attempt to retrieve key1 (set previously)
+    )
+
+    assert equal $actual $expected
+    kv drop $key1
+    kv drop $key2
+}
+
+#[test]
+def local-return_value_only [] {
+    let key = (random uuid)
+
+    let expected = 'VALUE'
+    let actual = ('value' | kv set -r v $key {str upcase})
+
+    assert equal $actual $expected
+
+    kv drop $key
+
+}
+
+#[test]
+def universal-simple_set [] {
+    let key = (random uuid)
+
+    kv set -u $key 42
+    let actual = (kv get -u $key)
+    let expected = 42
+    assert equal $actual $expected
+
+    kv drop -u $key | ignore
+}
+
+#[test]
+def universal-pipeline_set_returns_value [] {
+    let key = (random uuid)
+    let actual = (42 | kv set -u $key)
+    let expected = 42
+    assert equal $actual $expected
+
+    let actual = (kv get -u $key)
+    let expected = 42
+    assert equal $actual $expected
+
+    kv drop -u $key | ignore
+}
+
+#[test]
+def universal-multiple_assignment [] {
+    let key1 = (random uuid)
+    let key2 = (random uuid)
+    let key3 = (random uuid)
+
+    "test value" | kv set -u $key1 | kv set -u $key2 | kv set -u $key3
+    let expected = "test value"
+    assert equal (kv get -u $key1) $expected
+    assert equal (kv get -u $key2) $expected
+    assert equal (kv get -u $key3) $expected
+    assert equal (kv get $key3) (kv get $key1)
+
+    kv drop -u $key1
+    kv drop -u $key2
+    kv drop -u $key3
+}
+
+#[test]
+def universal-transpose_to_record [] {
+    let key1 = (random uuid)
+    let key2 = (random uuid)
+    let key3 = (random uuid)
+
+    "test value" | kv set -u $key1 | kv set -u $key2 | kv set -u $key3
+
+    let record = (kv list -u | transpose -dr)
+    let actual = ($record | select $key1)
+    let expected = { $key1: "test value" }
+
+    assert equal $actual $expected
+
+    kv drop -u $key1
+    kv drop -u $key2
+    kv drop -u $key3
+}
+
+#[test]
+def universal-using_closure [] {
+    let name_key = (random uuid)
+    let size_key = (random uuid)
+
+    ls
+    | kv set -u $name_key { get name }
+    | kv set -u $size_key { get size }
+
+    let expected = "list<string>"
+    let actual = (kv get -u $name_key | describe)
+    assert equal $actual $expected
+
+    let expected = "list<filesize>"
+    let actual = (kv get -u $size_key | describe)
+    assert equal $actual $expected
+
+    kv drop -u $name_key
+    kv drop -u $size_key
+}
+
+#[test]
+def universal-return-entire-list [] {
+    let key1 = (random uuid)
+    let key2 = (random uuid)
+
+    let expected = 'value1'
+    $expected | kv set -u $key1
+
+    let actual = (
+        'value2'
+        | kv set -u --return all $key2   # Set $key2, but return the entire kv store
+        | transpose -dr  # Convert to record for easier retrieval
+        | get $key1      # Attempt to retrieve key1 (set previously)
+    )
+
+    assert equal $actual $expected
+    kv drop --universal $key1
+    kv drop --universal $key2
+}
+
+#[test]
+def universal-return_value_only [] {
+    let key = (random uuid)
+
+    let expected = 'VALUE'
+    let actual = ('value' | kv set --universal -r v $key {str upcase})
+
+    assert equal $actual $expected
+
+    kv drop --universal $key
+}
+


### PR DESCRIPTION
## Overview

`std-rfc/kv` is a straightforward but flexible interface for setting and getting key-value pairs.

## Use-cases

* Ergonomically assign the result of a pipeline to a "variable".  Just "Up Arrow" and append `| kv set foo`.
* Use mid-pipeline to assign a "variable" and yet still continue the pipeline
* Use mid-pipeline to inspect the state (like the `inspect` command) and examine the results via `kv list` or `kv get` after the command completes.
* Chaining assignments/setters
* Set universal variables once and access them even after the shell exits (or in other simultaneously running shells).

## Features

* Values can be any Nushell type other than a closure.  Values are converted to and from nuons that are stored in a SQLite database.
* The module's commands can operate on either an in-memory database (using `stor`) or on-disk (`into sqlite`).
* Includes a hook that enables "universal variables" similar to that of the Fish shell. Universal variables are environment variables that are immediately updated and available in *all* Nushell sessions that are running the hook. Since they are stored in an on-disk SQLite database, they also persist when the shell exits.
* Because kv pairs are stored as rows in a database, they can be removed, unlike normal variables.
* kv pairs are easily converted to a record using `| transpose -dr`. The resulting record is, of course, easily converted to environment variables using `load-env`.
* Assignment can come from either pipeline input or a positional parameter. When both are provided, the positional parameter is preferred so that `$in` can be used.
* A closure can be used to modify the pipeline input before storing.
* Can optionally return either the pipeline input (default), the value that was set, or the entire store back to continue the pipeline.

## Examples

### Simple get/set (positional)

```nushell
use std-rfc/kv *
kv set foo 42
kv get foo
# => 42

kv list
# => ╭───┬─────┬───────╮
# => │ # │ key │ value │
# => ├───┼─────┼───────┤
# => │ 0 │ foo │    42 │
# => ╰───┴─────┴───────╯

kv drop foo
# => 42   # Returns the value that was dropped

kv list
# => ╭────────────╮
# => │ empty list │
# => ╰────────────╯
```

### Multiple assignments, conversion to record, and conversion to environment variables

```nushell
use std-rfc/kv *
42 | kv set a | kv set b | kv set c
# => 42

kv list
# => ╭───┬─────┬───────╮
# => │ # │ key │ value │
# => ├───┼─────┼───────┤
# => │ 0 │ a   │    42 │
# => │ 1 │ b   │    42 │
# => │ 2 │ c   │    42 │
# => ╰───┴─────┴───────╯

kv list | transpose -dr
# => ╭───┬────╮
# => │ a │ 42 │
# => │ b │ 42 │
# => │ c │ 42 │
# => ╰───┴────╯

kv list | transpose -dr | load-env
$env.a
# => 42
#env.b
# => 42
```

### Using list of timestamps, pipeline examples

```nushell
use std-rfc/kv *
kv set timestamps [
  2024-01-25T00:00:00
  2024-04-17T04:24:32
  2023-09-12T19:01:33
]
kv list
# => ╭───┬────────────┬──────────────────────╮
# => │ # │    key     │        value         │
# => ├───┼────────────┼──────────────────────┤
# => │ 0 │ timestamps │ ╭───┬──────────────╮ │
# => │   │            │ │ 0 │ a year ago   │ │
# => │   │            │ │ 1 │ 9 months ago │ │
# => │   │            │ │ 2 │ a year ago   │ │
# => │   │            │ ╰───┴──────────────╯ │
# => ╰───┴────────────┴──────────────────────╯

kv get timestamps
# => ╭───┬──────────────╮
# => │ 0 │ a year ago   │
# => │ 1 │ 9 months ago │
# => │ 2 │ a year ago   │
# => ╰───┴──────────────╯

# update each timestamp to 4 weeks in the future
kv get timestamps | each { $in + 4wk } | kv set timestamps
# => ╭───┬───────────────╮
# => │ 0 │ 11 months ago │
# => │ 1 │ 8 months ago  │
# => │ 2 │ a year ago    │
# => ╰───┴───────────────╯

# Create a new kv-pair named updated_timestamps
# But return the entire kv store to the pipeline
kv get timestamps
| each { $in + 4wk }
| kv set --return all updated_timestamps
# => ╭───┬────────────────────┬───────────────────────╮
# => │ # │        key         │         value         │
# => ├───┼────────────────────┼───────────────────────┤
# => │ 0 │ timestamps         │ ╭───┬──────────────╮  │
# => │   │                    │ │ 0 │ a year ago   │  │
# => │   │                    │ │ 1 │ 9 months ago │  │
# => │   │                    │ │ 2 │ a year ago   │  │
# => │   │                    │ ╰───┴──────────────╯  │
# => │ 1 │ updated_timestamps │ ╭───┬───────────────╮ │
# => │   │                    │ │ 0 │ 11 months ago │ │
# => │   │                    │ │ 1 │ 8 months ago  │ │
# => │   │                    │ │ 2 │ a year ago    │ │
# => │   │                    │ ╰───┴───────────────╯ │
# => ╰───┴────────────────────┴───────────────────────╯

# Same as above, but then update the original timestamps to use Unix epoch
kv get timestamps
| each { $in + 4wk }
| kv set --return all updated_timestamps
| transpose -dr | get timestamps
| each {format date '%s'}
| kv set timestamps
# => ╭───┬────────────╮
# => │ 0 │ 1706140800 │
# => │ 1 │ 1713327872 │
# => │ 2 │ 1694545293 │
# => ╰───┴────────────╯

kv list
# => ╭───┬────────────────────┬───────────────────────╮
# => │ # │        key         │         value         │
# => ├───┼────────────────────┼───────────────────────┤
# => │ 0 │ updated_timestamps │ ╭───┬───────────────╮ │
# => │   │                    │ │ 0 │ 11 months ago │ │
# => │   │                    │ │ 1 │ 8 months ago  │ │
# => │   │                    │ │ 2 │ a year ago    │ │
# => │   │                    │ ╰───┴───────────────╯ │
# => │ 1 │ timestamps         │ ╭───┬────────────╮    │
# => │   │                    │ │ 0 │ 1706140800 │    │
# => │   │                    │ │ 1 │ 1713327872 │    │
# => │   │                    │ │ 2 │ 1694545293 │    │
# => │   │                    │ ╰───┴────────────╯    │
# => ╰───┴────────────────────┴───────────────────────╯
 ```

Note that, in the example above, the following would be roughly equivalent:

```nushell
use std-rfc/kv *
kv set timestamps1 [
  2024-01-25T00:00:00
  2024-04-17T04:24:32
  2023-09-12T19:01:33
]

[
  2024-01-25T00:00:00
  2024-04-17T04:24:32
  2023-09-12T19:01:33
] | kv set timestamps2
# => ╭───┬──────────────╮
# => │ 0 │ a year ago   │
# => │ 1 │ 9 months ago │
# => │ 2 │ a year ago   │
# => ╰───┴──────────────╯

(kv get timestamps1) == (kv get timestamps2)
# => true
```

The difference is that the second form (pipeline input) results in pipeline *output* by default.  Since the first form does not have any pipeline input, the value returned to the pipeline output is `null`.

### Using a closure to manipulate the value

```nushell
ls | kv set -u foo {|| select name }
# The pipeline *input* is returned by default
# => ╭───┬────────┬──────┬────────┬─────────────╮
# => │ # │  name  │ type │  size  │  modified   │
# => ├───┼────────┼──────┼────────┼─────────────┤
# => │ 0 │ mod.nu │ file │ 5.5 kB │ 2 hours ago │
# => ╰───┴────────┴──────┴────────┴─────────────╯

# But the value that was *stored* is the result of the closure
kv get -u foo
# => ╭───┬────────╮
# => │ # │  name  │
# => ├───┼────────┤
# => │ 0 │ mod.nu │
# => ╰───┴────────╯
```

Note that in the example above, the universal store is used (`-u`).  The behavior of the commands is the same, with the only difference being that the universal kv pairs are stored on-disk and persist across Nushell sessions.  Remember to "clean up" test values from the universal store:

```nushell
kv drop -u foo
```

### Universal variables hook

The module includes a hook that can be added to `pre_execution` to create and update environment variables from the universal store.  If this hook is set during your startup, all Nushell sessions will share the same universal variables.

```nushell
# Add this line to config.nu
$env.config.hooks.pre_execution ++= [(kv universal-variable-hook)]
```

Start two different Nushell sessions. In the first:

```nushell
[
  ('~/.ssh/id_ecdsa' | path expand)
  ('~/.ssh/id_for_raspberrypi' | path expand)
] | kv set -u SSH_KEYS_TO_AUTOLOAD
# => ╭───┬────────────────────────────────────╮
# => │ 0 │ /home/user/.ssh/id_ecdsa           │
# => │ 1 │ /home/user/.ssh/id_for_raspberrypi │
# => ╰───┴────────────────────────────────────╯
```

In the other shell, an environment variable of the same name is created and updated. There is no need to restart the shell.

```nushell
$env.SSH_KEYS_TO_AUTOLOAD
# => ╭───┬────────────────────────────────────╮
# => │ 0 │ /home/user/.ssh/id_ecdsa           │
# => │ 1 │ /home/user/.ssh/id_for_raspberrypi │
# => ╰───┴────────────────────────────────────╯
```