### PR TITLE
Remove outdated logging module

### DIFF
--- a/stdlib-candidate/std-rfc/logging.nu
+++ b/stdlib-candidate/std-rfc/logging.nu
@@ -1,6 +1,0 @@
-# This is a first attempt and some type of logging
-def log [message:any] {
-    let now = (date now | format date '%Y%m%d_%H%M%S.%f')
-    let mess = $"($now)|DBG|($message)(char nl)"
-    $mess
-}


### PR DESCRIPTION
I haven't been through all of them yet, and some of those that I have reviewed still have useful info that should be preserved.  However, this `logging.nu` version seems to long predate the one we now have in the standard-library.