### PR TITLE
fix: remove now unecessary `-b` flag

### DIFF
--- a/sourced/imaging/imgcat.nu
+++ b/sourced/imaging/imgcat.nu
@@ -21,7 +21,7 @@ def --env b64_encode [fn] {
 }
 
 def --env b64_decode [fn] {
-    $fn | decode base64 -b
+    $fn | decode base64
 }
 
 def print_image [


### PR DESCRIPTION
The `-b`, that outputs the value as binary, has been removed as it is now the default behaviour.
```sh
"U29tZSBEYXRh" | decode base64                                                                                                                                        2024-10-20 20:56:15 
Length: 9 (0x9) bytes | printable whitespace ascii_other non_ascii
00000000:   53 6f 6d 65  20 44 61 74  61                         Some Data
```
Docs: https://www.nushell.sh/commands/docs/decode_base64.html