### PR TITLE
in commands table rename usage to description

### DIFF
--- a/custom-menus/extra/commands.nu
+++ b/custom-menus/extra/commands.nu
@@ -25,6 +25,6 @@
     source: { |buffer, position|
         scope commands
         | where name =~ $buffer
-        | each { |it| {value: $it.name description: $it.usage} }
+        | each { |it| {value: $it.name description: $it.description } }
     }
 }

--- a/custom-menus/extra/commands_with_description.nu
+++ b/custom-menus/extra/commands_with_description.nu
@@ -27,6 +27,6 @@
     source: { |buffer, position|
         scope commands
         | where name =~ $buffer
-        | each { |it| {value: $it.name description: $it.usage} }
+        | each { |it| {value: $it.name description: $it.description} }
     }
 }

--- a/make_release/gen-ts-ext.nu
+++ b/make_release/gen-ts-ext.nu
@@ -16,7 +16,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 # generate typescript from nushell commands
 def gen-ts-cmds [] {
-    let cmds = (scope commands | where usage != '' | select name usage)
+    let cmds = (scope commands | where description != '' | select name description)
     let updated_cmds = (echo $cmds | insert camel {|it| $it.name + 'Completion' | str camel-case } )
 
     let ts = (echo $updated_cmds |
@@ -38,10 +38,10 @@ def gen-ts-cmds [] {
 
 # generate typescript from nushell subcommands
 def gen-ts-subs [] {
-    let cmds = (scope commands | where is_sub == true | select name usage | insert base { get name | split column ' ' base sub } | flatten --all)
+    let cmds = (scope commands | where is_sub == true | select name description | insert base { get name | split column ' ' base sub } | flatten --all)
     let updated_cmds = (echo $cmds | insert camelProvider {|row| $row.base + 'SubCommandsProvider' | str camel-case } | insert method {|row| $row.name | str camel-case})
-    let subs_count = (scope commands | where is_sub == true | select name usage | insert base { get name | split column ' ' base sub} | flatten --all | group-by base | transpose cmd cmd_count | update cmd_count { get cmd_count | length })
-    let subs_collection = (scope commands | where is_sub == true | select name usage | insert base { get name | split column ' ' base sub} | flatten --all | group-by base | transpose  cmd sub_cmds)
+    let subs_count = (scope commands | where is_sub == true | select name description | insert base { get name | split column ' ' base sub} | flatten --all | group-by base | transpose cmd cmd_count | update cmd_count { get cmd_count | length })
+    let subs_collection = (scope commands | where is_sub == true | select name description | insert base { get name | split column ' ' base sub} | flatten --all | group-by base | transpose  cmd sub_cmds)
 
     let ts = ($subs_collection | each {|it|
         let preamble = (get sub_cmds | enumerate | each {|it|
@@ -55,11 +55,11 @@ def gen-ts-subs [] {
                 let line05 = ([ "                const linePrefix = document.lineAt(position).text.substr(0, position.character);" (char nl) ] | str join)
                 let line06 = ([ "                if (linePrefix.endsWith('" $it.item.base " ')) {" (char nl) (char nl) ] | str join)
                 let line07 = ([ "                    const " $method " = new vscode.CompletionItem('" $it.item.sub "', vscode.CompletionItemKind.Method);" (char nl) ] | str join)
-                let line08 = ([ '                    ' $method '.detail = "' $it.item.usage '";' (char nl) (char nl) ] | str join)
+                let line08 = ([ '                    ' $method '.detail = "' $it.item.description '";' (char nl) (char nl) ] | str join)
                 $line01 + $line02 + $line03 + $line04 + $line05 + $line06 + $line07 + $line08
             } else {
                 let line07 = ([ "                    const " $method " = new vscode.CompletionItem('" $it.item.sub "', vscode.CompletionItemKind.Method);" (char nl) ] | str join)
-                let line08 = ([ '                    ' $method '.detail = "' $it.item.usage '";' (char nl) (char nl) ] | str join)
+                let line08 = ([ '                    ' $method '.detail = "' $it.item.description '";' (char nl) (char nl) ] | str join)
                 $line07 + $line08
             }
         } | str join)

--- a/modules/fuzzy/fuzzy_command_search.nu
+++ b/modules/fuzzy/fuzzy_command_search.nu
@@ -17,7 +17,7 @@ export def fuzzy-command-search [] {
     let max_indent = ($max_len / $tablen | into int)
     let command = ((help commands | each {|it|
         let name = ($it.name | str trim | ansi strip)
-        $"($name)(pad-tabs $name $max_indent)($it.usage)"
+        $"($name)(pad-tabs $name $max_indent)($it.description)"
     }) | str join (char nl) | fzf | split column (char tab) | get column1.0)
     if ($command | is-not-empty) {
         help $command


### PR DESCRIPTION
`usage` column under the `scope commands` table has been renamed to description since  nushell version 0.98.0