### PR TITLE
don't return anything from `toolkit` command

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -36,7 +36,7 @@ export def "check pr" [
 
 # View subcommands.
 export def main []: nothing -> nothing {
-    help toolkit
+    print (help toolkit)
 }
 
 # Wrap file lookup and exit codes.

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -35,8 +35,8 @@ export def "check pr" [
 }
 
 # View subcommands.
-export def main []: nothing -> nothing {
-    print (help toolkit)
+export def main []: nothing -> string {
+    help toolkit
 }
 
 # Wrap file lookup and exit codes.


### PR DESCRIPTION
i get the following LSP error in my editor, because it's true `main` does not return a `string` :thinking: 

![image](https://github.com/user-attachments/assets/787f62f8-ef66-4ac4-ba30-c396d3cdd4d2)


in this PR, i propose to truely return `nothing` from this _main_ command by `print`ing the help page.

### alternative
we could also change the signature to `nothing -> string`