### PR TITLE
conda activate should expand $env.PATH to a connection of absolute paths

### DIFF
--- a/modules/virtual_environments/conda.nu
+++ b/modules/virtual_environments/conda.nu
@@ -139,7 +139,7 @@ def conda-create-path-unix [env_dir: path] {
         ([$env_dir "bin"] | path join)
     ]
 
-    let new_path = ([$env_path $env.PATH]
+    let new_path = ([$env_path (system-path)]
         | flatten
         | str join (char esep))
 
@@ -151,7 +151,7 @@ def windows? [] {
 }
 
 def system-path [] {
-    if "PATH" in $env { $env.PATH } else { $env.Path }
+    if "PATH" in $env { $env.PATH } else { $env.Path } | path expand
 }
 
 def has-env [name: string] {

--- a/modules/virtual_environments/conda.nu
+++ b/modules/virtual_environments/conda.nu
@@ -151,7 +151,7 @@ def windows? [] {
 }
 
 def system-path [] {
-    if "PATH" in $env { $env.PATH } else { $env.Path } | path expand
+    if "PATH" in $env { $env.PATH } else { $env.Path } | path expand -n
 }
 
 def has-env [name: string] {


### PR DESCRIPTION
Noticed an issue in `conda.nu`.

It modified `$env.PATH` from list of string to a string, without **expanding** it.  It may be a problem if I have a path which is relative:
```nushell
$env.PATH = ($env.PATH | split row (char esep) | prepend '~/.cargo/bin')
```
After activating an env, it's impossible to find executables in `~/.cargo/bin`.  So this pr is going to make sure the path is expanded while converting.

For more context: https://github.com/nushell/nushell/pull/14615?notification_referrer_id=NT_kwDOAVOaGrQxMzkwODcxMjU3NjoyMjI1NjE1NA#issuecomment-2552696978