### PR TITLE
Fix input-output signatures

### DIFF
--- a/modules/background_task/task.nu
+++ b/modules/background_task/task.nu
@@ -19,7 +19,7 @@ export def spawn [
   --after (-a): int                   # Start the task once all specified tasks have successfully finished. As soon as one of the dependencies fails, this task will fail as well.
   --priority (-o): string             # Start this task with a higher priority. The higher the number, the faster it will be processed.
   --label (-l): string                # Label the task. This string will be shown in the `status` column of `task status`.
-] -> int {
+]: nothing -> int {
   mut args = []
 
   if $working_directory != null {

--- a/modules/recursion/README.md
+++ b/modules/recursion/README.md
@@ -43,7 +43,7 @@ use tramp.nu
 # This version just returns either the value or a thunk.
 # Meant to be used in a trampoline
 # But still uses APS
-def fact [n: int, acc=1] -> int {
+def fact [n: int, acc=1]: nothing -> int {
   if $n <= 1 { return $acc } else {
     {|| fact ($n - 1) ($n * $acc) } # The thunk being returned to the trampoline
   }

--- a/modules/recursion/countdown.nu
+++ b/modules/recursion/countdown.nu
@@ -2,7 +2,7 @@
 # Simple countdown counter from some number n to 0. Returns 0 at end
 # Designed to be used with the tramp module to avoid stack overflows via the
 # use of the Trampoline method.
-def countdown [n: int] -> int {
+def countdown [n: int]: nothing -> int {
   if $n == 0 {
     0
   } else {

--- a/modules/recursion/even-odd.nu
+++ b/modules/recursion/even-odd.nu
@@ -12,7 +12,7 @@
 
 # Return true if number is even. Calls mutually recursive odd function
 # if number is greater than 1.
-def even [n: int, acc=true] -> any {
+def even [n: int, acc=true]: nothing -> any {
   if $n == 0 { return $acc } else if $n == 1 {
     return (not $acc) } else {
     {|| odd ($n - 2) (not $acc) }
@@ -22,7 +22,7 @@ def even [n: int, acc=true] -> any {
 
 # Returns true if number is odd. Will cooperate with even in a mutually recursive fashion.
 # Warning: do not pass any numbers less than 0
-def odd [n: int, acc=true] -> bool {
+def odd [n: int, acc=true]: nothing -> bool {
   if $n == 0 { return (not $acc) } else if $n == 1 { 
     return $acc } else {
     {|| even ($n - 2) (not $acc) }

--- a/modules/recursion/fact.nu
+++ b/modules/recursion/fact.nu
@@ -2,7 +2,7 @@
 # This version just returns either the value or a thunk.
 # Meant to be used in a trampoline
 # But still uses APS
-def fact [n: int, acc=1] -> int {
+def fact [n: int, acc=1]: nothing -> int {
   if $n <= 1 { return $acc } else {
     {|| fact ($n - 1) ($n * $acc) } # The thunk being returned to the trampoline
   }

--- a/modules/recursion/fib.nu
+++ b/modules/recursion/fib.nu
@@ -4,7 +4,7 @@
 # This version is non-tail call optimized and might consume large values
 # of stack space even for small values of n. It is also not memoized so run time
 # performance for even quite small values of N is very poor.
-def fib-nontail [n: int] -> int {
+def fib-nontail [n: int]: nothing -> int {
   if $n == 0 {
   0
   } else if $n == 1 {
@@ -21,7 +21,7 @@ def fib-nontail [n: int] -> int {
 
 # Returns the Fibonacci number for the index n. Uses the double APS method to
 # ensure the recursive call is in thetail position.
-def fib-aps [n: int, acc: int=1, accp: int=1] -> int {
+def fib-aps [n: int, acc: int=1, accp: int=1]: nothing -> int {
   if ($n == 0) or ($n == 1) {
     $n
   } else if $n == 2 {
@@ -35,7 +35,7 @@ def fib-aps [n: int, acc: int=1, accp: int=1] -> int {
 
 # Return the Fibonacci number for given index n
 # This version relies on the trampoline helper
-def fib [n: int, acc: int=1, accp: int=1] -> int {
+def fib [n: int, acc: int=1, accp: int=1]: nothing -> int {
   if ($n == 0) or ($n == 1) {
     $n
   } else if $n == 2 {

--- a/modules/recursion/gcd.nu
+++ b/modules/recursion/gcd.nu
@@ -2,7 +2,7 @@
 # Based on this clear explanation from Rutgers: https://sites.math.rutgers.edu/~greenfie/gs2004/euclid.html
 
 # Returns the GCD of its 2 arguments
-def gcd [i1: int, i2: int] -> int {
+def gcd [i1: int, i2: int]: nothing -> int {
   mut a = $i1; mut b = $i2
   if $a < $b { let tmp = $a; $a = $b; $b = $tmp }
   let q = $a // $b; let r = $a mod $b

--- a/modules/recursion/merge.nu
+++ b/modules/recursion/merge.nu
@@ -1,7 +1,7 @@
 # merge 2 sorted lists
 
 # Merge 2 sorted lists
-def merge-2 [l: list, r: list] -> list {
+def merge-2 [l: list, r: list]: nothing -> list {
   mut ol = []
 mut lprime = $l; mut rprime = $r
   let mx = ($l | length) + ($r | length)
@@ -24,7 +24,7 @@ mut lprime = $l; mut rprime = $r
 # Merge sort a list
 # This version is non tail call optimized and might blow the stack for
 # large lists.
-def sort-nontail [x: list] -> list {
+def sort-nontail [x: list]: nothing -> list {
   let $n = ($x | length)
  let n_2: int = $n // 2
 

--- a/modules/recursion/tramp.nu
+++ b/modules/recursion/tramp.nu
@@ -26,7 +26,7 @@ export def create [thunk: any] {
 # The parameter val must be either a terminating value or closure, which will get run until
 # the terminating value is returned from the current closure which
 # is returned from this function.
-export def test [val: any] -> any {
+export def test [val: any]: nothing -> any {
   let cl = (create $val)
   do $cl
 }
@@ -43,7 +43,7 @@ export def test [val: any] -> any {
 
 # Explicitly bounces the trampoline over a recursive function without first
 # creating a closure .
-export def recurse [val: any] -> any {
+export def recurse [val: any]: nothing -> any {
   mut maybe_thunk = $val
   while ($maybe_thunk | describe) == closure {
     $maybe_thunk = (do $maybe_thunk)

--- a/modules/yadm/mod.nu
+++ b/modules/yadm/mod.nu
@@ -4,7 +4,7 @@
 
 def generate_viable_bash_string_flags [
 flag_record:record # A object filled all known flags and their values.
-] -> list<string> {
+]: nothing -> list<string> {
 
 
 


### PR DESCRIPTION
Since 0.101.0 we will finally catch more illegal `def` signatures. As the grammar for input/output types is rather restricted, this would error otherwise
