### PR TITLE
Fix table of contents generation for release notes

### DIFF
--- a/make_release/release-note/notes.nu
+++ b/make_release/release-note/notes.nu
@@ -74,6 +74,7 @@ export def write-toc [file: path] {
             get line | split chars | take while { $in == '#' } | length
         }
         | insert nocomment {
+            # We assume that comments only have one `#`
             if ($in.level != 1) {
                 return true
             }
@@ -83,6 +84,8 @@ export def write-toc [file: path] {
             if ($known_h1s | any {|| $line =~ $in}) {
                 return true
             }
+
+            # We don't know so let's ask
             let user = ([Ignore Accept] |
                 input list $"Is this a code comment or a markdown h1 heading:(char nl)(ansi blue)($line)(ansi reset)(char nl)Choose if we include it in the TOC!")
             match $user {

--- a/make_release/release-note/notes.nu
+++ b/make_release/release-note/notes.nu
@@ -83,13 +83,7 @@ export def write-toc [file: path] {
             let link = (
                 $text
                 | str downcase
-                | str replace -a '`' ''
-                | str replace -a '+' ''
-                | str replace -a '.' ''
-                | str replace -a '?' ''
-                | str replace -a ' ' '-'
-                | str replace -a '_' '-'
-                | str replace -a -r '--+' '-'
+                | str kebab-case
             )
 
             $"($indent)[_($text)_]\(#($link)-toc\)"

--- a/make_release/release-note/notes.nu
+++ b/make_release/release-note/notes.nu
@@ -44,7 +44,7 @@ export def pr-table [] {
     | to md
 }
 
-const toc = '[[toc](#table-of-content)]'
+const toc = '[[toc](#table-of-contents)]'
 
 # Generate and write the table of contents to a release notes file
 export def write-toc [file: path] {
@@ -82,8 +82,13 @@ export def write-toc [file: path] {
 
             let link = (
                 $text
+                | str downcase
                 | str replace -a '`' ''
+                | str replace -a '+' ''
+                | str replace -a '.' ''
+                | str replace -a '?' ''
                 | str replace -a ' ' '-'
+                | str replace -a '_' '-'
                 | str replace -a -r '--+' '-'
             )
 

--- a/make_release/release-note/notes.nu
+++ b/make_release/release-note/notes.nu
@@ -94,8 +94,6 @@ export def write-toc [file: path] {
         }
     )
 
-    print $data
-
     let table_of_contents = (
         $data
         | where level in 1..=3 and nocomment == true

--- a/make_release/release-note/notes.nu
+++ b/make_release/release-note/notes.nu
@@ -74,23 +74,22 @@ export def write-toc [file: path] {
             get line | split chars | take while { $in == '#' } | length
         }
         | insert nocomment {
-            if ($in.level == 1) {
-                let line = $in.line
-
-                # Try to use the whitelist first
-                if ($known_h1s | any {|| $line =~ $in}) {
-                    return true
-                }
-                let user = ([Ignore Accept] |
-                    input list $"Is this a code comment or a markdown h1 heading:(char nl)(ansi blue)($line)(ansi reset)(char nl)Choose if we include it in the TOC!")
-                match $user {
-                    "Accept" => {true}
-                    "Ignore" => {false}
-                }
-
-            } else {
+            if ($in.level != 1) {
                 return true
             }
+            let line = $in.line
+
+            # Try to use the whitelist first
+            if ($known_h1s | any {|| $line =~ $in}) {
+                return true
+            }
+            let user = ([Ignore Accept] |
+                input list $"Is this a code comment or a markdown h1 heading:(char nl)(ansi blue)($line)(ansi reset)(char nl)Choose if we include it in the TOC!")
+            match $user {
+                "Accept" => {true}
+                "Ignore" => {false}
+            }
+
         }
     )
 


### PR DESCRIPTION
- [x] fixed typo: `table-of-content` in the backreference
- [x] missing sanitization of `_`,`+`,`.`,`?`
- [x] handling the confusion of h1 `#` and comment `#`
