### PR TITLE
:bug: fix some parser issues with type signatures

### DIFF
--- a/custom-completions/auto-generate/parse-fish.nu
+++ b/custom-completions/auto-generate/parse-fish.nu
@@ -84,11 +84,10 @@ def make-commands-completion [] {
     }
 }
 
-let quote = '"' # "
-
 # make the action nu completion string from subcommand and args
 # subcommand can be empty which will be the root command
 def make-subcommands-completion [parents: list] {
+    let quote = '"' # "
     let fishes = $in
     $fishes
     | group-by a                                                                      # group by sub command (a flag)

--- a/custom-completions/auto-generate/parse-fish.nu
+++ b/custom-completions/auto-generate/parse-fish.nu
@@ -60,7 +60,7 @@ def pair-args [] {
             {$"($pair.0 | str trim -c '-')": ($pair.1 | unquote)}   # turn into a [{<flag> :<arg>}] removing quotes
         ]
     }
-    | reduce { |it, acc| $acc | merge { $it }}                      # merge the list of records into one big record
+    | reduce { |it, acc| $acc | merge $it }                         # merge the list of records into one big record
 }
 
 def unquote [] {

--- a/custom-completions/op/op-completions.nu
+++ b/custom-completions/op/op-completions.nu
@@ -109,7 +109,7 @@ export extern "op account forget" [
     --help(-h)                                              # help for forget
     --all                                                   # Forget all authenticated accounts.
 
-    account?: string: string@"nu completion account"       # The account to forget.
+    account?: string@"nu completion account"       # The account to forget.
 ]
 
 # Manage Connect server instances and tokens in your 1Password account
@@ -2124,7 +2124,7 @@ def "nu completion item" [] {
 
 def parse_args_rg [] { "(?<opening_quote>['\"`]?)(?<content>.*?)(?<closing_quote>\\k<opening_quote>)(?<separator>\\s+)" }
 
-def "nu completion parse-context" [] string -> {cmd: string, args: list<string>} {
+def "nu completion parse-context" []: string -> record {
     # context strings starts at cursor position
     let ctx = $in + ' ' # add space to end to ensure last part is parsed🙄
     mut parse = $ctx | parse --regex (parse_args_rg)
@@ -2177,7 +2177,7 @@ def "nu completion parse-context" [] string -> {cmd: string, args: list<string>}
 def "nu completion output" [
         ctx: string,    # entered command [sub command, args, + options]
         --complete (-c) # if the copletion should have a closing quote and terminating space
-    ] list<string> -> list<string>, string -> list<string> {
+    ]: list<string> -> list<string>, string -> list<string> {
 
         let output = $in
         let parse = $ctx + ` `

--- a/custom-completions/poetry/poetry-completions.nu
+++ b/custom-completions/poetry/poetry-completions.nu
@@ -1,28 +1,28 @@
 # Python versions
 #
 # Used by the add command to specify for which Python version the dependency must be installed
-def "nu-complete poetry python-versions" [] nothing -> list<string> {
+def "nu-complete poetry python-versions" []: nothing -> list<string> {
     ["3.8" "3.9" "3.10" "3.11" "3.12" "3.13"]
 }
 
 # Default package source names
 #
 # The default package source names available to install packages from
-def "nu-complete poetry default-package-source-names" [] nothing -> list<string> {
+def "nu-complete poetry default-package-source-names" []: nothing -> list<string> {
     [pypi test test.pypi.org internal-pypi]
 }
 
 # Default package source urls
 #
 # The default package source urls available to install packages from
-def "nu-complete poetry default-package-source-urls" [] nothing -> list<string> {
+def "nu-complete poetry default-package-source-urls" []: nothing -> list<string> {
     ["https://" "https://test.pypi.org/legacy/" "https://pypi.org/legacy"]
 }
 
 # Default package sources
 #
 # The default sources to use to install the package, beyond the ones defined within pyproject.toml available for the add command
-def "nu-complete poetry default-package-sources" [] nothing -> list<string> {
+def "nu-complete poetry default-package-sources" []: nothing -> list<string> {
     (nu-complete poetry default-package-source-names) | append (
         nu-complete poetry default-package-source-urls
     )
@@ -31,21 +31,21 @@ def "nu-complete poetry default-package-sources" [] nothing -> list<string> {
 # Build formats
 #
 # Used by the build command to limit the built package to either sdist or wheel
-def "nu-complete poetry build-formats" [] nothing -> list<string> {
+def "nu-complete poetry build-formats" []: nothing -> list<string> {
     [sdist wheel]
 }
 
 # Default usernames
 #
 # The current username which is the default suggestion for logging in to services with a username
-def "nu-complete poetry default-usernames" [] nothing -> list<string> {
+def "nu-complete poetry default-usernames" []: nothing -> list<string> {
     [(whoami)]
 }
 
 # Setting keys
 #
 # The available setting keys that can be retrieved/changed by the config command
-def "nu-complete poetry setting-keys" [] nothing -> list<string> {
+def "nu-complete poetry setting-keys" []: nothing -> list<string> {
     [
         cache-dir
         experimental.system-git-client
@@ -87,7 +87,7 @@ def "nu-complete poetry setting-keys" [] nothing -> list<string> {
 # Setting keys
 #
 # The possible values for the given setting key, that the config command can chenge the respective setting key to
-def "nu-complete poetry setting-values" [context: string] nothing -> list<any> {
+def "nu-complete poetry setting-values" [context: string]: nothing -> list<any> {
     let $final_context: string = ($context | str trim | split row " " | last)
 
     if (
@@ -173,21 +173,21 @@ def "nu-complete poetry setting-values" [context: string] nothing -> list<any> {
 # Export formats
 #
 # The list of possible formats supported by the export command
-def "nu-complete poetry export-formats" [] nothing -> list<string> {
+def "nu-complete poetry export-formats" []: nothing -> list<string> {
     ["requirements.txt" "constraints.txt"]
 }
 
 # Default dependency groups
 #
 # A default selection of dependency groups
-def "nu-complete poetry default-dependency-groups" [] nothing -> list<string> {
+def "nu-complete poetry default-dependency-groups" []: nothing -> list<string> {
     [main dev deploy test testing tests development developing deployment deploying]
 }
 
 # Commands
 #
 # The list of command names available to have a help message displayed using the help command
-def "nu-complete poetry commands" [] nothing -> list<string> {
+def "nu-complete poetry commands" []: nothing -> list<string> {
     [
         about
         add
@@ -233,35 +233,35 @@ def "nu-complete poetry commands" [] nothing -> list<string> {
 # Licenses
 #
 # The available license IDs for project.toml
-def "nu-complete poetry licenses" [] nothing -> list<string> {
+def "nu-complete poetry licenses" []: nothing -> list<string> {
     http get https://spdx.org/licenses/licenses.json | get licenses | get licenseId
 }
 
 # ReadMe file formats
 #
 # A default selection of file extensions used for ReadMe files
-def "nu-complete poetry readme-file-formats" [] nothing -> list<string> {
+def "nu-complete poetry readme-file-formats" []: nothing -> list<string> {
     [md txt adoc rst rft pdf html dbk odf tex latex texi asciidoc markdown xhtml xht htm xml]
 }
 
 # Namespaces
 #
 # The list of namespaces available to list poetry commands about
-def "nu-complete poetry namespaces" [] nothing -> list<string> {
+def "nu-complete poetry namespaces" []: nothing -> list<string> {
     [cache debug env self source]
 }
 
 # Default repositories
 #
 # The default set of repositories available to publish this projects package to
-def "nu-complete poetry default-repositories" [] nothing -> list<string> {
+def "nu-complete poetry default-repositories" []: nothing -> list<string> {
     nu-complete poetry default-package-sources
 }
 
 # Default dist directories
 #
 # The default set of directories where build artifacts may be stored
-def "nu-complete poetry default-dist-directories" [] nothing -> list<string> {
+def "nu-complete poetry default-dist-directories" []: nothing -> list<string> {
     (
         ls | get name | where (($it | path type) == "dir") | each {|it| $it | path expand}
     ) | prepend ($env.PWD | path join "dist")
@@ -270,21 +270,21 @@ def "nu-complete poetry default-dist-directories" [] nothing -> list<string> {
 # Caches
 #
 # The list of available poetry caches, used to remove one that is listed
-def "nu-complete poetry caches" [] nothing -> list<string> {
+def "nu-complete poetry caches" []: nothing -> list<string> {
     poetry cache list | lines
 }
 
 # Virtual environments
 #
 # The list of available virtual environements, used to remove one that is listed
-def "nu-complete poetry virtual-environments" [] nothing -> list<string> {
+def "nu-complete poetry virtual-environments" []: nothing -> list<string> {
     poetry env list --full-path | lines | each {|| (split row " ").0}
 }
 
 # Source priorities
 #
 # Used by the source commands to set/display the priority of the source
-def "nu-complete poetry source-priorities" [] nothing -> list<string> {
+def "nu-complete poetry source-priorities" []: nothing -> list<string> {
     [default primary secondary supplemental explicit]
 }
 

--- a/custom-completions/poetry/poetry-completions.nu
+++ b/custom-completions/poetry/poetry-completions.nu
@@ -8,7 +8,7 @@ def "nu-complete poetry python-versions" []: nothing -> list<string> {
 # Default package source names
 #
 # The default package source names available to install packages from
-def "nu-complete poetry default-package-source-names" []: nothing -> list<string> {
+def "nu-complete poetry default-package-source-names" [] nothing -> list<string> {
     [pypi test test.pypi.org internal-pypi]
 }
 

--- a/custom-completions/poetry/poetry-completions.nu
+++ b/custom-completions/poetry/poetry-completions.nu
@@ -8,7 +8,7 @@ def "nu-complete poetry python-versions" []: nothing -> list<string> {
 # Default package source names
 #
 # The default package source names available to install packages from
-def "nu-complete poetry default-package-source-names" [] nothing -> list<string> {
+def "nu-complete poetry default-package-source-names" []: nothing -> list<string> {
     [pypi test test.pypi.org internal-pypi]
 }
 

--- a/make_release/gen-js-ext.nu
+++ b/make_release/gen-js-ext.nu
@@ -12,10 +12,6 @@ def gen_keywords [] {
     let postamble = ')\\b'
     $'"match": "($var_with_dash_or_under_regex)|($preamble)($cmds)($postamble)",'
 }
-print $"Generating keywords(char nl)"
-print (gen_keywords)
-print (char nl)
-print (char nl)
 
 def gen_sub_keywords [] {
     let sub_cmds = (scope commands
@@ -33,9 +29,6 @@ def gen_sub_keywords [] {
     } | str join '|')
     $'"match": "($preamble)($cmds)($postamble)",'
 }
-print $"Generating sub keywords(char nl)"
-print (gen_sub_keywords)
-print (char nl)
 
 def gen_keywords_alphabetically [] {
     let alphabet = [a b c d e f g h i j k l m n o p q r s t u v w x y z]
@@ -64,9 +57,6 @@ def gen_keywords_alphabetically [] {
     } | str join "\n"
 }
 
-print "Generating keywords alphabetically\n"
-print (gen_keywords_alphabetically)
-print (char nl)
 
 def gen_sub_keywords_alphabetically [] {
     let alphabet = [a b c d e f g h i j k l m n o p q r s t u v w x y z]
@@ -96,6 +86,21 @@ def gen_sub_keywords_alphabetically [] {
     } | str join "\n"
 }
 
-print "Generating sub keywords alphabetically\n"
-print (gen_sub_keywords_alphabetically)
-print (char nl)
+export def main [] {
+    print $"Generating keywords(char nl)"
+    print (gen_keywords)
+    print (char nl)
+    print (char nl)
+
+    print $"Generating sub keywords(char nl)"
+    print (gen_sub_keywords)
+    print (char nl)
+
+    print "Generating keywords alphabetically\n"
+    print (gen_keywords_alphabetically)
+    print (char nl)
+
+    print "Generating sub keywords alphabetically\n"
+    print (gen_sub_keywords_alphabetically)
+    print (char nl)
+}

--- a/make_release/gen-js-ext.nu
+++ b/make_release/gen-js-ext.nu
@@ -3,7 +3,7 @@ def gen_keywords [] {
                 | where is_extern == false
                 and is_custom == false
                 and category !~ deprecated
-                and ($it.name | str contains -n ' ')
+                and not ($it.name | str contains ' ')
                 | get name
                 | str join '|')
 
@@ -43,7 +43,7 @@ def gen_keywords_alphabetically [] {
                 | where is_extern == false
                 and is_custom == false
                 and category !~ deprecated
-                and ($it.name | str contains -n ' ')
+                and not ($it.name | str contains ' ')
                 | get name)
 
     let preamble = '\\b('

--- a/modules/cwdhist/mod.nu
+++ b/modules/cwdhist/mod.nu
@@ -64,7 +64,7 @@ def __cwdhist_switching [] {
 export def empty-sqlite [] {
     # sqlite3 empty.db "VACUUM;"; cat empty.db | gzip | encode base64
     'H4sIAAAAAAAAAwsO9MksSVVIyy/KTSxRMGYQYGBkZHBQUGBgYGCEYhhAZhMLGBn0ihbwglgCZOgeBaNgFIyCUTAKRsEoGAWjYBSMglEwCkYBVQAANHgbMAAQAAA='
-    | decode base64 --binary | gzip -d
+    | decode base64 | gzip -d
 }
 
 export def 'cwd history delete' [cwd] {


### PR DESCRIPTION
When I updated nu to 101, the completions of poetry failed because of a missing `:` 
this
```nu
def "nu-complete poetry python-versions" [] nothing -> list<string> {
```
for this

```nu
def "nu-complete poetry python-versions" []: nothing -> list<string> {
```

Fixed a couple of places and some other parser issues