### PR TITLE
Remove some outdated comments

### DIFF
--- a/modules/prompt/oh-my-minimal.nu
+++ b/modules/prompt/oh-my-minimal.nu
@@ -6,7 +6,7 @@
 # nerd fonts repo https://github.com/ryanoasis/nerd-fonts
 # i use "FiraCode Nerd Font Mono" on mac
 #
-# you also must have the engine-q gstat plugin installed and registered
+# you also must have the gstat plugin installed and registered
 
 # ATTRIBUTION #
 # A little fancier prompt with git information

--- a/modules/prompt/oh-my.nu
+++ b/modules/prompt/oh-my.nu
@@ -3,7 +3,7 @@
 # nerd fonts repo https://github.com/ryanoasis/nerd-fonts
 # i use "FiraCode Nerd Font Mono" on mac
 #
-# you also must have the engine-q gstat plugin installed and registered
+# you also must have the gstat plugin installed and registered
 
 # ATTRIBUTION #
 # A little fancier prompt with git information
@@ -290,7 +290,6 @@ def get_repo_status [gs os] {
 }
 
 def git_left_prompt [gs os] {
-  # replace this 30 with whatever the width of the terminal is
   let display_path = (path_abbrev_if_needed (home_abbrev $os.name) (term size).columns)
   let branch_name = (get_branch_name $gs)
   let R = (ansi reset)


### PR DESCRIPTION
Nitpick, but I've noticed it a few times so figured I'd just go ahead and get rid of it.

* Mainly, removed the comment about changing the hardcoded 30-width terminal since it's now handled dynamically (at least in this module)
* Also removed references to engine-q

I notice there are a lot of other engine-q references when I grep `nu_scripts`, but I'll leave those for another day.  Some of those are probably pretty outdated (e.g., `init.nu` in the example config) and need to be culled.