### PR TITLE
add `clip copy` and `clip paste`

### DIFF
--- a/stdlib-candidate/nupm.nuon
+++ b/stdlib-candidate/nupm.nuon
@@ -3,6 +3,6 @@
     description: "Official candidates for Nushell standard library"
     documentation: "https://github.com/nushell/nu_scripts/blob/main/stdlib-candidate/std-rfc/README.md"
     license: "https://github.com/nushell/nu_scripts/blob/main/LICENSE"
-    version: 0.4.1
+    version: 0.4.2
     type: "module"
 }

--- a/stdlib-candidate/std-rfc/clip/mod.nu
+++ b/stdlib-candidate/std-rfc/clip/mod.nu
@@ -1,0 +1,35 @@
+# Commands for interacting with the system clipboard
+#
+# > These commands require your terminal to support OSC 52
+# > Terminal multiplexers such as screen, tmux, zellij etc may interfere with this command
+
+# Copy input to system clipboard
+#
+# # Example
+# ```nushell
+# >_ "Hello" | clip copy
+# ```
+export def copy []: [string -> nothing] {
+	print -n $'(ansi osc)52;c;($in | encode base64)(ansi st)'
+}
+
+# Paste contenst of system clipboard
+#
+# # Example
+# ```nushell
+# >_ clip paste
+# "Hello"
+# ```
+export def paste []: [nothing -> string] {
+	try {
+		term query $'(ansi osc)52;c;?(ansi st)' -p $'(ansi osc)52;c;' -t (ansi st)
+	} catch {
+		error make -u {
+			msg: "Terminal did not responds to OSC 52 paste request."
+			help: $"Check if your terminal supports OSC 52."
+		}
+	}
+	| decode
+	| decode base64
+	| decode
+}

--- a/stdlib-candidate/std-rfc/mod.nu
+++ b/stdlib-candidate/std-rfc/mod.nu
@@ -1,0 +1,2 @@
+export module aggregate
+export module clip


### PR DESCRIPTION
# Description
Add `clip copy` and `clip paste` for interacting with system clipboard, making use of OSC 52.

I'm not sure how to write tests for these commands.

> [!TIP]
> No platform specific external binary is required.

> [!WARNING]
> - Not all terminal emulators will support this
> - Terminal multiplexers may interfere with it, depending on their configuration.

# Related
- https://github.com/nushell/nushell/pull/11131
- https://github.com/nushell/nu_scripts/pull/674