### PR TITLE
Add pipefail module

### DIFF
--- a/stdlib-candidate/std-rfc/pipefail/mod.nu
+++ b/stdlib-candidate/std-rfc/pipefail/mod.nu
@@ -1,0 +1,16 @@
+export alias default-run-external = run-external
+
+export def --wrapped run-external [...rest: string] {
+  let results = default-run-external ($rest | first) ...($rest | skip 1) | complete
+  if $results.exit_code != 0 {
+    error make {
+      msg: "External command failed"
+      label: {
+        text: "command had a non-zero exit code",
+        span: (metadata $rest).span
+      }
+    }
+  } else {
+    $results.stdout
+  }
+}


### PR DESCRIPTION
Allows users to trade external command streaming for pipefail. This is a workaround until we have proper pipefail handling.

Still need to add docs/tests.

Usage:
```nushell
use std-rfc/pipefail *
^false | print foo; print bar
# => Error: 
# =>   × External command failed
# =>    ╭─[entry #3:2:2]
# =>  2 │ ^false | print foo; print bar
# =>    ·  ──┬──
# =>    ·    ╰── command had a non-zero exit code
# =>    ╰────
```