### PR TITLE
panache-git: exclude prompt indicator so user can choose their own

### DIFF
--- a/modules/prompt/panache-git.nu
+++ b/modules/prompt/panache-git.nu
@@ -6,11 +6,13 @@
 # - In your Nushell config:
 #   - Import the main command from the panache-git.nu module file
 #   - Set panache-git as your prompt command
-#   - Disable the separate prompt indicator by setting it to an empty string
+#   - (optional) Reset the text color for your prompt indicator
 # - For example, with this file in your home directory:
 #     use ~/panache-git.nu main
 #     $env.PROMPT_COMMAND = {|| panache-git }
-#     $env.PROMPT_INDICATOR = {|| "" }
+#     $env.PROMPT_INDICATOR = {|| $"(ansi reset)> "}
+#     $env.PROMPT_INDICATOR_VI_INSERT = {|| $"(ansi reset): " }
+#     $env.PROMPT_INDICATOR_VI_NORMAL = {|| $"(ansi reset)> " }
 # - Restart Nushell
 #
 # For more documentation or to file an issue, see https://github.com/ehdevries/panache-git
@@ -19,7 +21,7 @@
 # An opinionated Git prompt for Nushell, styled after posh-git
 export def main [] {
   let prompt = ($'(current-dir) (repo-styled)' | str trim)
-  $'($prompt)> '
+  $prompt
 }
 
 # Get the current directory with home abbreviated


### PR DESCRIPTION
Previously, panache-git included a prompt indicator (`> `) out of the box, and the advice for the user was to remove Nushell's own configurable prompt indicator by setting it to the empty string.

However, this conflicted with some of Nushell's intended functionality, such as the ability to use a different prompt indicator in each vi mode.

With this change, panache-git does not include a prompt indicator. The advice is for the user to use the prompt indicator they like, but to reset the color so it better matches panache-git's colors.

This is something of a breaking change, in that users who update to the latest panache-git.nu without making corresponding changes to their Nushell config might see two prompt indicators (`> > `), but my hope is that giving users (especially vi mode users) more flexibility with their prompt indicators will be worth any temporary confusion.