### PR TITLE
:bug: fix additional `+ ` in `git local branches`

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -24,7 +24,7 @@ def "nu-complete git commits current branch" [] {
 
 # Yield local branches like `main`, `feature/typo_fix`
 def "nu-complete git local branches" [] {
-  ^git branch --no-color | lines | each { |line| $line | str replace '* ' "" | str trim }
+  ^git branch --no-color | lines | each { |line| $line | str replace '* ' "" | str replace '+ ' ""  | str trim }
 }
 
 # Yield remote branches like `origin/main`, `upstream/feature-a`


### PR DESCRIPTION
Hi! I realized if you use worktrees, with at least one branch checked out and you:
```
git switch <tab>
```
the autocompletion is wrong, putting a `+ ` before the branch, and piping it into the cmdline. 

This comes from `nu-complete git local branches` function, it which it only replaces `* ` for the current branch, but it doesn't for `+ ` for worktrees.
Here is a sample:

![image](https://github.com/user-attachments/assets/814c728b-82da-4d15-9f22-ff0fd5a92ae1)

I tested on my pc and works allright!
