### PR TITLE
:heavy_minus_sign: remove `gstat` dependency from `git-aliases`

### DIFF
--- a/aliases/git/git-aliases.nu
+++ b/aliases/git/git-aliases.nu
@@ -1,5 +1,6 @@
+# returns the name of the current branch
 export def git_current_branch [] {
-    (gstat).branch
+    ^git rev-parse --abbrev-ref HEAD
 }
 
 export def git_main_branch [] {

--- a/aliases/git/git-aliases.nu
+++ b/aliases/git/git-aliases.nu
@@ -50,14 +50,19 @@ export alias gca = git commit --verbose --all
 export alias gca! = git commit --verbose --all --amend
 export alias gcan! = git commit --verbose --all --no-edit --amend
 export alias gcans! = git commit --verbose --all --signoff --no-edit --amend
-export alias gcam = git commit --all --message
-export alias gcsm = git commit --signoff --message
+export def gcam [message: string] {
+    git commit --all --message $message
+}
+export def gcsm [message: string] {
+    git commit --all --signoff $message
+}
 export alias gcas = git commit --all --signoff
-export alias gcasm = git commit --all --signoff --message
+export def gcasm [message: string] {
+    git commit --all --signoff --message $message
+}
 export alias gcb = git checkout -b
 export alias gcd = git checkout develop
 export alias gcf = git config --list
-
 export alias gcl = git clone --recurse-submodules
 export alias gclean = git clean --interactive -d
 export def gpristine [] {
@@ -65,7 +70,9 @@ export def gpristine [] {
     git clean -d --force -x
 }
 export alias gcm = git checkout (git_main_branch)
-export alias gcmsg = git commit --message
+export def gcmsg [message: string] {
+    git commit --message $message
+}
 export alias gco = git checkout
 export alias gcor = git checkout --recurse-submodules
 export alias gcount = git shortlog --summary --numbered
@@ -74,8 +81,9 @@ export alias gcpa = git cherry-pick --abort
 export alias gcpc = git cherry-pick --continue
 export alias gcs = git commit --gpg-sign
 export alias gcss = git commit --gpg-sign --signoff
-export alias gcssm = git commit --gpg-sign --signoff --message
-
+export def gcssm [message: string] {
+    git commit --gpg-sign --signoff --message $message
+}
 export alias gd = git diff
 export alias gdca = git diff --cached
 export alias gdcw = git diff --cached --word-diff
@@ -130,7 +138,12 @@ export def gpoat [] {
 }
 export alias gpod = git push origin --delete
 export alias gpodc = git push origin --delete (git_current_branch)
-export alias gpr = git pull --rebase
+def "nu-complete git pull rebase" [] {
+  ["false","true","merges","interactive"]
+}
+export def gpr [rebase_type: string@"nu-complete git pull rebase"] {
+    git pull --rebase $rebase_type
+}
 export alias gpu = git push upstream
 export alias gpv = git push --verbose
 
@@ -154,8 +167,12 @@ export alias grhh = git reset --hard
 export alias groh = git reset $"origin/(git_current_branch)" --hard
 export alias grm = git rm
 export alias grmc = git rm --cached
-export alias grmv = git remote rename
-export alias grrm = git remote remove
+export def grmv [remote: string, new_name: string] {
+    git remote rename $remote $new_name
+}
+export def grrm [remote: string] {
+    git remote remove $remote
+}
 export alias grs = git restore
 export alias grset = git remote set-url
 export alias grss = git restore --source

--- a/aliases/git/git-aliases.nu
+++ b/aliases/git/git-aliases.nu
@@ -174,7 +174,9 @@ export def grrm [remote: string] {
     git remote remove $remote
 }
 export alias grs = git restore
-export alias grset = git remote set-url
+export def grset [remote: string, url: string] {
+    git remote set-url $remote $url
+}
 export alias grss = git restore --source
 export alias grst = git restore --staged
 export alias grt = cd (git rev-parse --show-toplevel or echo .)
@@ -212,7 +214,9 @@ export def gtv [] {
 export alias glum = git pull upstream (git_main_branch)
 
 export alias gunignore = git update-index --no-assume-unchanged
-export alias gup = git pull --rebase
+export def gup [rebase_type: string@"nu-complete git pull rebase"] {
+    git pull --rebase $rebase_type
+}
 export alias gupv = git pull --rebase --verbose
 export alias gupa = git pull --rebase --autostash
 export alias gupav = git pull --rebase --autostash --verbose
@@ -220,10 +224,14 @@ export alias gupav = git pull --rebase --autostash --verbose
 export alias gwch = git whatchanged -p --abbrev-commit --pretty=medium
 
 export alias gwt = git worktree
-export alias gwta = git worktree add
+export def gwta [path: path, branch: string] {
+    git worktree add $path $branch
+}
 export alias gwtls = git worktree list
 export alias gwtmv = git worktree move
-export alias gwtrm = git worktree remove
+export def gwtm [worktree: string] {
+    git worktree remove $worktree
+}
 
 export alias gam = git am
 export alias gamc = git am --continue

--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -62,6 +62,7 @@ def "nu-complete git checkout" [] {
   | append (nu-complete git remote branches with prefix
             | parse "{value}"
             | insert description "remote branch")
+  | append (nu-complete git files | where description != "Untracked" | select value | insert description "git file")
   | append (nu-complete git commits all)
   | append (nu-complete git files | where description != "Untracked" | select value)
 }
@@ -463,7 +464,7 @@ export extern "git commit" [
   --dry-run                                           # show paths to be committed without committing
   --status                                            # include git-status output in commit message
   --no-status                                         # do not include git-status output
-  --gpg-sign(-S):string                               # GPG-sign commit
+  --gpg-sign(-S)                                      # GPG-sign commit
   --no-gpg-sign                                       # do not GPG-sign commit
   ...pathspec: string                                 # commit files matching pathspec
 ]
@@ -576,7 +577,7 @@ export extern "git bisect reset" [
 
 # Show help for a git subcommand
 export extern "git help" [
-  command: string@"nu-complete git subcommands"       # subcommand to show help for
+  command?: string@"nu-complete git subcommands"       # subcommand to show help for
 ]
 
 # git worktree
@@ -687,7 +688,7 @@ export extern "git clone" [
   --single-branch               # clone commit history from a single branch
   --no-single-Branch            # do not clone only one branch
   --no-tags                     # do not clone any tags
-  --recurse-submodules: string  # clone the submodules
+  --recurse-submodules          # clone the submodules. Also accepts paths
   --shallow-submodules          # shallow clone submodules with depth 1
   --no-shallow-submodules       # do not shallow clone submodules
   --remote-submodules           # submodules are updating using their remote tracking branch


### PR DESCRIPTION
I removed `gstat` plugin dependency need by replacing the command.

~~The only problem is that the aliases don't work for the current nushell version~~
Done!


fixes #973 and closes #974