### PR TITLE
fix "from env" newline handling

### DIFF
--- a/modules/formats/from-env.nu
+++ b/modules/formats/from-env.nu
@@ -2,10 +2,15 @@
 # may be used like this: open .env | load-env
 # works with quoted and unquoted .env files
 def "from env" []: string -> record {
-  lines 
+  lines
     | split column '#' # remove comments
-    | get column1 
+    | get column1
     | parse "{key}={value}"
-    | str trim value -c '"' # unquote values
+    | update value {
+        str trim -c '"' | # unquote values
+        str replace -a "\\n" "\n" # replace `\n` with newline char
+        str replace -a "\\r" "\r" # replace `\r` with carriage return
+        str replace -a "\\t" "\t" # replace `\t` with tab
+    }
     | transpose -r -d
 }


### PR DESCRIPTION
Many (at least the ones I have encountered) env loaders replace "\n" with a
literal newline character when loading an env variable. I need this change in
my personal config and I think others would also prefer this default. 
