### PR TITLE
:sparkles: unsort the completions in `git checkout`

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -53,7 +53,7 @@ def "nu-complete git switch" [] {
 }
 
 def "nu-complete git checkout" [] {
-  (nu-complete git local branches)
+  let table_of_checkouts = (nu-complete git local branches)
   | parse "{value}"
   | insert description "local branch"
   | append (nu-complete git remote branches nonlocal without prefix
@@ -64,7 +64,15 @@ def "nu-complete git checkout" [] {
             | insert description "remote branch")
   | append (nu-complete git files | where description != "Untracked" | select value | insert description "git file")
   | append (nu-complete git commits all)
-  | append (nu-complete git files | where description != "Untracked" | select value)
+
+  return {
+    options: {
+        case_sensitive: false,
+        completion_algorithm: prefix,
+        sort: false,
+    },
+    completions: $table_of_checkouts
+  }
 }
 
 # Arguments to `git rebase --onto <arg1> <arg2>`
@@ -125,7 +133,7 @@ def "nu-complete git files" [] {
 def "nu-complete git built-in-refs" [] {
   [HEAD FETCH_HEAD ORIG_HEAD]
 }
-
+# 
 def "nu-complete git refs" [] {
   nu-complete git local branches
   | parse "{value}"

--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -133,7 +133,7 @@ def "nu-complete git files" [] {
 def "nu-complete git built-in-refs" [] {
   [HEAD FETCH_HEAD ORIG_HEAD]
 }
-# 
+ 
 def "nu-complete git refs" [] {
   nu-complete git local branches
   | parse "{value}"


### PR DESCRIPTION
### motivation
Hi! This is something I wanted since [#14424 of nushell/nushell](https://github.com/nushell/nushell/pull/14424) landed.
Unsorted completions on the `git checkout` command

### The problem
 is that git checkout accepts lots of things: commits hashes, filenames, local branches and remote branches. Since the mentioned pr all the completions were sorted, but for this command it didn't make sense.
I used `git switch` to checkout a branch for the time being, but it's a little annoying that you can't push "unsorted" completions on a command.

### the result

With the help of ysthakur and weirdan, I managed to achieve this:
```
git checkout <tab>
```

before: (these are sorted)
![image](https://github.com/user-attachments/assets/ad495b29-e418-426f-9bbe-2056f34b819f)

after: (these aren't)
![image](https://github.com/user-attachments/assets/e2b5d647-cccb-4e0b-b1c2-b80781ada3ec)

### How?
Citing the docs:
https://www.nushell.sh/book/custom_completions.html#options-for-custom-completions

```
    {
        options: {
            case_sensitive: false,
            completion_algorithm: prefix,
            positional: false,
            sort: false,
        },
        completions: [cat, rat, bat]
    }
}
```

and I passed **a table** to the `completions` key, instead of a _list_.

```
    completions: $table_of_checkouts
```