### PR TITLE
Fix issue with testing.nu in 0.101.1

### DIFF
--- a/stdlib-candidate/testing.nu
+++ b/stdlib-candidate/testing.nu
@@ -22,7 +22,7 @@ def valid-annotations [] {
 # Returns a table containing the list of function names together with their annotations (comments above the declaration)
 def get-annotated [
     file: path
-]: path -> table<function_name: string, annotation: string> {
+]: nothing -> table<function_name: string, annotation: string> {
     let raw_file = (
         open $file
         | lines


### PR DESCRIPTION
https://github.com/nushell/nushell/pull/14741 has surfaced an issue with an incorrect signature in `testing.nu` which caused it to fail completely.  This fixes the signature and allows tests to run properly.