### PR TITLE
Provide completion for git subcommands

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -798,3 +798,7 @@ export extern "git grep" [
   --quiet(-q)                           # Do not output matched lines; instead, exit with status 0 when there is a match and with non-zero status when there isn’t.
   ...pathspecs: string                  # Target pathspecs to limit the scope of the search.
 ]
+
+export extern "git" [
+  command?: string@"nu-complete git subcommands"       # subcommand to show help for
+]

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -32,13 +32,6 @@ export def "check pr" [
             { test }
          ] | par-each { |task| $files | do $task } # TODO: buffer output
     }
-
-    test-stdlib-candidate
-}
-
-export def test-stdlib-candidate [] {
-    use stdlib-candidate/testing.nu
-    testing run-tests --allow-no-tests --path stdlib-candidate
 }
 
 # View subcommands.
@@ -78,14 +71,13 @@ export def "lint ide-check" []: path -> int {
     let file = $in
     let stub = $env.STUB_IDE_CHECK? | default false | into bool
     const current_path = (path self)
-    let candidate_path = $current_path | path dirname | path join "stdlib-candidate"
     let diagnostics = if $stub {
-        do { nu -I $candidate_path --no-config-file --commands $"use '($file)'" }
+        do { nu --no-config-file --commands $"use '($file)'" }
             | complete
             | [[severity message]; [$in.exit_code $in.stderr]]
             | where severity != 0
     } else {
-        nu -I $candidate_path --ide-check 10 $file
+        nu --ide-check 10 $file
             | $"[($in)]"
             | from nuon
             | where type == diagnostic

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -32,6 +32,13 @@ export def "check pr" [
             { test }
          ] | par-each { |task| $files | do $task } # TODO: buffer output
     }
+
+    test-stdlib-candidate
+}
+
+export def test-stdlib-candidate [] {
+    use stdlib-candidate/testing.nu
+    testing run-tests --allow-no-tests --path stdlib-candidate
 }
 
 # View subcommands.
@@ -71,13 +78,14 @@ export def "lint ide-check" []: path -> int {
     let file = $in
     let stub = $env.STUB_IDE_CHECK? | default false | into bool
     const current_path = (path self)
+    let candidate_path = $current_path | path dirname | path join "stdlib-candidate"
     let diagnostics = if $stub {
-        do { nu --no-config-file --commands $"use '($file)'" }
+        do { nu -I $candidate_path --no-config-file --commands $"use '($file)'" }
             | complete
             | [[severity message]; [$in.exit_code $in.stderr]]
             | where severity != 0
     } else {
-        nu --ide-check 10 $file
+        nu -I $candidate_path --ide-check 10 $file
             | $"[($in)]"
             | from nuon
             | where type == diagnostic


### PR DESCRIPTION
This is to provide completion for when user types `git [Tab]`.
There is already completion for `git help [Tab]` but I don't know why author don't add it to `git` alone.

Fixes #1043 