### PR TITLE
Fix `from env` custom command

### DIFF
--- a/modules/formats/from-env.nu
+++ b/modules/formats/from-env.nu
@@ -7,10 +7,12 @@ def "from env" []: string -> record {
     | get column1
     | parse "{key}={value}"
     | update value {
-        str trim -c '"' | # unquote values
-        str replace -a "\\n" "\n" # replace `\n` with newline char
-        str replace -a "\\r" "\r" # replace `\r` with carriage return
-        str replace -a "\\t" "\t" # replace `\t` with tab
+        str trim                        # Trim whitespace between value and inline comments
+          | str trim -c '"'             # unquote double-quoted values
+          | str trim -c "'"             # unquote single-quoted values
+          | str replace -a "\\n" "\n"   # replace `\n` with newline char
+          | str replace -a "\\r" "\r"   # replace `\r` with carriage return
+          | str replace -a "\\t" "\t"   # replace `\t` with tab
     }
     | transpose -r -d
 }


### PR DESCRIPTION
Fix `from env` custom command

#### Description

This pull request addresses issues with the `from env` custom command in the Nushell script, improving the handling and sanitization of parsed environment variable values. The main focus of this update is to enhance the parsing behavior to handle edge cases and ensure proper formatting of output.