### PR TITLE
Update toolkit.nu per removal of stdlib-candidate

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -32,13 +32,6 @@ export def "check pr" [
             { test }
          ] | par-each { |task| $files | do $task } # TODO: buffer output
     }
-
-    test-stdlib-candidate
-}
-
-export def test-stdlib-candidate [] {
-    use stdlib-candidate/testing.nu
-    testing run-tests --allow-no-tests --path stdlib-candidate
 }
 
 # View subcommands.
@@ -78,14 +71,13 @@ export def "lint ide-check" []: path -> int {
     let file = $in
     let stub = $env.STUB_IDE_CHECK? | default false | into bool
     const current_path = (path self)
-    let candidate_path = $current_path | path dirname | path join "stdlib-candidate"
     let diagnostics = if $stub {
-        do { nu -I $candidate_path --no-config-file --commands $"use '($file)'" }
+        do { nu --no-config-file --commands $"use '($file)'" }
             | complete
             | [[severity message]; [$in.exit_code $in.stderr]]
             | where severity != 0
     } else {
-        nu -I $candidate_path --ide-check 10 $file
+        nu --ide-check 10 $file
             | $"[($in)]"
             | from nuon
             | where type == diagnostic


### PR DESCRIPTION
stdlib-candidate was removed in #1042 but test script still refer on it.

The concensus is to [remove](https://github.com/nushell/nu_scripts/pull/1044#discussion_r1954636683) the test case.