### PR TITLE
Fix failing lints on source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
               # nix STUB_IDE_CHECK when nushell/nushell#12208 fixed
               run: |
                   use ${{ github.workspace }}/toolkit.nu *
-                  STUB_IDE_CHECK=true check pr --and-exit
+                  check pr --and-exit


### PR DESCRIPTION
Since #791 (and possibly before), any non-module Nushell file pushed to `nu_scripts` will fail CI since it attempts to `use <file.nu>` during linting.

In addition, the #791 implementation could execute code during linting, since it actually imported potentially working code.

This PR updates the toolkit testing to:

* Determine whether to lint as a module or source file based on the presence of any `export ` line in the file.
* Run `nu-check` on files before linting with `use <file>` or `source <file>`
* Updates the environment variable to `TEST_METHOD` with options for `ide-check` or `import-or-source`.
* Updates the default to `import-or-source` (was `ide-check`) to match CI
* Removes environment variable from CI since this test method is now the default.

With this in place we should have far fewer (false positive) failing CI runs.