### PR TITLE
Add compatibility note about Nu version

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -1,3 +1,5 @@
+# nu-version: 0.102.0
+
 module git-completion-utils {
   export const GIT_SKIPABLE_FLAGS = ['-v', '--version', '-h', '--help', '-p', '--paginate', '-P', '--no-pager', '--no-replace-objects', '--bare']
 
@@ -106,8 +108,8 @@ module git-completion-utils {
     let floating_remotes = $lines | filter { "\t" not-in $in and $in not-in $tracked_remotes }
     $floating_remotes | each {
       let v = $in | split row -n 2 '/' | get 1
-      if $v != $current { [$v] } else []
-    } | flatten
+      if $v == $current { null } else $v
+    }
   }
 
   export def extract-mergable-sources [current: string]: list<string> -> list<record<value: string, description: string>> {
@@ -268,7 +270,7 @@ def "nu-complete git files" [] {
 def "nu-complete git built-in-refs" [] {
   [HEAD FETCH_HEAD ORIG_HEAD]
 }
- 
+
 def "nu-complete git refs" [] {
   nu-complete git local branches
   | parse "{value}"

--- a/custom-completions/ssh/ssh-completions.nu
+++ b/custom-completions/ssh/ssh-completions.nu
@@ -1,3 +1,5 @@
+# nu-version: 0.102.0
+
 export extern "ssh" [
     destination?: string@"nu-complete ssh-host"
     -4            # Forces ssh to use IPv4 addresses only.
@@ -41,11 +43,12 @@ module ssh-completion-utils {
         # │ 4 │                              │
         # ╰───┴──────────────────────────────╯
         let host = $in
-        let name = $host | get 0 | str trim | split row -r '\s+' | get 1
+        let $first_line = try { $host | first | str trim } catch { null }
         # Don't accept blocks like "Host *"
-        if ('*' in $name) {
+        if ($first_line | is-empty) or '*' in $first_line {
             null
         } else {
+            let name = $first_line |  split row -r '\s+' | get 1
             # May not contain hostname
             match ($host | slice 1.. | find -ir '^\s*Hostname\s') {
                 [] => null,
@@ -68,7 +71,7 @@ module ssh-completion-utils {
             includes: $include_lines
         }
     }
-    
+
 }
 
 


### PR DESCRIPTION
This is my response for #1051 

The syntax of this note is inspired by Rust _Cargo.toml_ and Python _pyproject.toml_.