### PR TITLE
Fix heading in zoxide completions README

### DIFF
--- a/custom-completions/zoxide/README.md
+++ b/custom-completions/zoxide/README.md
@@ -1,4 +1,4 @@
-# pytest completions
+# zoxide completions
 
 Completions for [zoxide](https://github.com/ajeetdsouza/zoxide). ``zoxide`` is a smarter cd command, inspired by z and autojump. It remembers which directories you use most frequently, so you can "jump" to them in just a few keystrokes. zoxide works on all major shells.
 


### PR DESCRIPTION
This PR corrects the heading in `custom-completions/zoxide/README.md`, changing it from "pytest completions" to "zoxide completions" to match the intended content.