### PR TITLE
Fix zellij layouts completions on MacOS

### DIFF
--- a/custom-completions/zellij/zellij-completions.nu
+++ b/custom-completions/zellij/zellij-completions.nu
@@ -94,7 +94,13 @@ def "nu-complete zellij layouts" [] {
 	} else {
 		match $nu.os-info.name {
 			"linux" => "~/.config/zellij/layouts/"
-			"mac" => "~/Library/Application Support/org.Zellij-Contributors.Zellij/layouts"
+			"macos" => {
+				if ("~/.config/zellij/layouts/" | path exists) {
+					"~/.config/zellij/layouts/"
+				} else {
+					"~/Library/Application Support/org.Zellij-Contributors.Zellij/layouts"
+				}
+			}
 			_ => (error make { msg: "Unsupported OS for zellij" })
 		}
 	}


### PR DESCRIPTION
According to the [documentation](https://zellij.dev/documentation/configuration.html#where-does-zellij-look-for-the-config-file) `~/.config/zellij` will take precedence even on MacOS.