### PR TITLE
Autojump argument parsing

### DIFF
--- a/nu-hooks/nu-hooks/filesystem/autojump.nu
+++ b/nu-hooks/nu-hooks/filesystem/autojump.nu
@@ -14,9 +14,9 @@ def autojump_add_to_database [dir] {
         $env.AUTOJUMP_SOURCED = 1
         autojump --add $dir
 }
-def --env j [dir] {
+def --env j [...dir] {
         $env.AUTOJUMP_SOURCED = 1
-        cd (autojump $dir)
+        cd (autojump ...$dir)
 }
 $env.config = ($env.config | upsert hooks.env_change.PWD {|config|
     let val = ($config | get -i hooks.env_change.PWD)


### PR DESCRIPTION
I've changed the number of arguments of `def --env j [dir]` to `def --env j [...dir]`, this change makes the behaviour more like the `j` autojump you can find in other shells where an arbitrary number of inputs are given to it. 

ie. 
In zsh:
![image](https://github.com/user-attachments/assets/5de5611e-2681-46a0-93c4-d6e68922df13)

In nushell old j:
![image](https://github.com/user-attachments/assets/966dc6b0-cd9f-4d19-b662-e561c42bca83)

In nushell new j:
![image](https://github.com/user-attachments/assets/a73d10a1-1313-4dd8-815e-9e8a15a16101)

