### PR TITLE
Fix $env.PATH for direnv

### DIFF
--- a/nu-hooks/nu-hooks/direnv/config.nu
+++ b/nu-hooks/nu-hooks/direnv/config.nu
@@ -24,5 +24,5 @@
 
     direnv export json | from json | default {} | load-env
     # Direnv outputs $PATH as a string, but nushell silently breaks if isn't a list-like table.
-    $env.PATH = $env.PATH | split row ':'
+    $env.PATH = $env.PATH | split row (char env_sep)
 }

--- a/nu-hooks/nu-hooks/direnv/config.nu
+++ b/nu-hooks/nu-hooks/direnv/config.nu
@@ -23,4 +23,6 @@
     }
 
     direnv export json | from json | default {} | load-env
+    # Direnv outputs $PATH as a string, but nushell silently breaks if isn't a list-like table.
+    $env.PATH = $env.PATH | split row ':'
 }

--- a/nu-hooks/nu-hooks/direnv/config.nu
+++ b/nu-hooks/nu-hooks/direnv/config.nu
@@ -24,6 +24,7 @@
 
     direnv export json | from json | default {} | load-env
     # Direnv outputs $PATH as a string, but nushell silently breaks if isn't a list-like table.
-    # The following behemoth of Nu code turns this into nu's format while following the standards of how to handle quotes
-    $env.PATH = $env.PATH | parse --regex ('' + `((?:(?:"(?:(?:\\[\\"])|.)*?")|(?:'.*?')|[^` + (char env_sep) + `]*)*)`) | each {|x| $x.capture0 | parse --regex `(?:"((?:(?:\\"|.))*?)")|(?:'(.*?)')|([^'"]*)` | each {|y| if ($y.capture0 != "") { $y.capture0 | str replace -ar `\\([\\"])` `$1` } else if ($y.capture1 != "") { $y.capture1 } else $y.capture2 } | str join }
+    # The following behemoth of Nu code turns this into nu's format while following the standards of how to handle quotes, use it if you need quote handling instead of the line below it:
+    # $env.PATH = $env.PATH | parse --regex ('' + `((?:(?:"(?:(?:\\[\\"])|.)*?")|(?:'.*?')|[^` + (char env_sep) + `]*)*)`) | each {|x| $x.capture0 | parse --regex `(?:"((?:(?:\\"|.))*?)")|(?:'(.*?)')|([^'"]*)` | each {|y| if ($y.capture0 != "") { $y.capture0 | str replace -ar `\\([\\"])` `$1` } else if ($y.capture1 != "") { $y.capture1 } else $y.capture2 } | str join }
+    $env.PATH = $env.PATH | split row (char env_sep)
 }

--- a/nu-hooks/nu-hooks/direnv/config.nu
+++ b/nu-hooks/nu-hooks/direnv/config.nu
@@ -24,5 +24,6 @@
 
     direnv export json | from json | default {} | load-env
     # Direnv outputs $PATH as a string, but nushell silently breaks if isn't a list-like table.
-    $env.PATH = $env.PATH | split row (char env_sep)
+    # The following behemoth of Nu code turns this into nu's format while following the standards of how to handle quotes
+    $env.PATH = $env.PATH | parse --regex ('' + `((?:(?:"(?:(?:\\[\\"])|.)*?")|(?:'.*?')|[^` + (char env_sep) + `]*)*)`) | each {|x| $x.capture0 | parse --regex `(?:"((?:(?:\\"|.))*?)")|(?:'(.*?)')|([^'"]*)` | each {|y| if ($y.capture0 != "") { $y.capture0 | str replace -ar `\\([\\"])` `$1` } else if ($y.capture1 != "") { $y.capture1 } else $y.capture2 } | str join }
 }


### PR DESCRIPTION
While using direnv with nushell, I noticed that my autocompletion for external programs stopped working as soon as I entered a directory and direnv loaded.

Turns out, direnv exports $PATH as a string, and nushell stores $PATH as a table and expects it to be one. Worse, nu just silently fails any operations with the $PATH (except for running programs) instead of reporting an error.

This PR fixes that by adding a line in the direnv config.nu script that parses that string into the appropriate table.
Testing it on my system (NixOS, nushell, direnv + lorri) it seems to work perfectly fine and the $PATH works again.