### PR TITLE
Port `before_v0.60` `parse_aws_s3_ls.nu`

### DIFF
--- a/before_v0.60/cool_oneliners/parse_aws_s3_ls.nu
+++ b/before_v0.60/cool_oneliners/parse_aws_s3_ls.nu
@@ -1,3 +1,0 @@
-# transform the aligned text output of aws s3 ls into something useful
-# presumes you have the aws CLI
-aws s3 ls s3://your-bucket-and-path | lines | each { echo $it | str find-replace '  ' ' ' | str find-replace '  ' ' ' } | split column ' '

--- a/sourced/cool-oneliners/parse_aws_s3_ls.nu
+++ b/sourced/cool-oneliners/parse_aws_s3_ls.nu
@@ -1,0 +1,3 @@
+# transform the aligned text output of aws s3 ls into something useful
+# presumes you have the aws CLI
+aws s3 ls s3://your-bucket-and-path | lines | each { str replace '  ' ' ' | str replace '  ' ' ' } | split column ' '


### PR DESCRIPTION
Tested with https://docs.aws.amazon.com/cli/latest/reference/s3/ls.html example output

Note that the script has a placeholder parameter `s3://your-bucket-and-path`. The script is moved into the `sourced` folder like all the other ported scripts from the cool_oneliners folder before it, but sourcing it as-is is not meaningful.

This ports the last file in `before_v0.60`, consequently resolving #221.