### PR TITLE
Add md-to-clip custom completions

### DIFF
--- a/custom-completions/md-to-clip/README.md
+++ b/custom-completions/md-to-clip/README.md
@@ -1,0 +1,28 @@
+# `md-to-clip` completions
+
+Custom completions for the [`md-to-clip` command line tool](https://github.com/command-line-interface-pages/v2-tooling/tree/main/md-to-clip).
+
+## Usage
+
+Import the custom completions with:
+
+```nushell
+source path/to/md-to-clip-completions.nu
+```
+
+Afterwards, when you enter `md-to-clip -` and then press tab, the available flags will be displayed:
+
+```nushell
+nu ❯ | md-to-clip -
+--author                      Display author
+--email                       Display author email
+--help                        Display help
+--no-file-save                Whether to display conversion result in stdout instead of writing it to a file
+--output-directory            Directory where conversion result will be written
+--special-placeholder-config  Config with special placeholders
+--version                     Display version
+-a                            Display author
+-e                            Display author email
+-h                            Display help
+-v                            Display version
+```

--- a/custom-completions/md-to-clip/md-to-clip-completions.nu
+++ b/custom-completions/md-to-clip/md-to-clip-completions.nu
@@ -1,0 +1,22 @@
+# Converter from TlDr format to Command Line Interface Pages format.
+# https://github.com/command-line-interface-pages/v2-tooling/tree/main/md-to-clip
+export extern "md-to-clip" [
+    file: path@"nu-complete md-to-clip mdfiles" # Source tldr page to convert
+    --help (-h)     # Display help
+    --version (-v)  # Display version
+    --author (-a)   # Display author
+    --email (-e)    # Display author email
+    --no-file-save  # Whether to display conversion result in stdout instead of writing it to a file
+    --output-directory : path@"nu-complete md-to-clip dirs"  # Directory where conversion result will be written
+    --special-placeholder-config: path  # Config with special placeholders
+]
+# "old-style long switch" flags are not covered because Nushell does not currently support them https://github.com/nushell/nushell/issues/5959
+# `-nfs`, `-od`, `-spc`
+
+def "nu-complete md-to-clip dirs" [] {
+  ls | where type == 'dir' | get name
+}
+
+def "nu-complete md-to-clip mdfiles" [] {
+  ls | where type == 'dir' or name ends-with '.md' | get name
+}


### PR DESCRIPTION
Resolves #414

* Syntax source https://github.com/command-line-interface-pages/v2-tooling/tree/main/md-to-clip

---

I used the descriptions from the Fish completions on the referenced page/docs.

```nushell
nu ❯ help md-to-clip
Converter from TlDr format to Command Line Interface Pages format.
https://github.com/command-line-interface-pages/v2-tooling/tree/main/md-to-clip

Usage:
  > md-to-clip {flags} <file> ...(args)

Flags:
  -h, --help: Display help
  -v, --version: Display version
  -a, --author: Display author
  -e, --email: Display author email
  --no-file-save: Whether to display conversion result in stdout instead of writing it to a file
  --output-directory <path>: Directory where conversion result will be written
  --special-placeholder-config <path>: Config with special placeholders

Parameters:
  file <path>: Source tldr page to convert
  ...args <external-argument>: all other arguments to the command
```