### PR TITLE
Use path join to join path parts

### DIFF
--- a/nu-hooks/nu-hooks/rusty-paths/rusty-paths.nu
+++ b/nu-hooks/nu-hooks/rusty-paths/rusty-paths.nu
@@ -16,8 +16,8 @@ $env.config = ($env.config | update hooks.env_change.PWD {
 		code: {
 			$env.PATH = (
 				$env.PATH
-					| prepend ($env.PWD | path join 'target/debug')
-					| prepend ($env.PWD | path join 'target/release')
+					| prepend ($env.PWD | path join 'target' 'debug')
+					| prepend ($env.PWD | path join 'target' 'release')
 					| uniq
 				)
 		}


### PR DESCRIPTION
Use system specific path separator instead of always `/` leading to a path with mixed separators on Windows.