### PR TITLE
Drop added PATHs on folder leave

### DIFF
--- a/nu-hooks/nu-hooks/rusty-paths/rusty-paths.nu
+++ b/nu-hooks/nu-hooks/rusty-paths/rusty-paths.nu
@@ -13,11 +13,22 @@
 $env.config = ($env.config | upsert hooks.env_change.PWD {
 	append {
 		condition: {|_, after| ($after | path join 'Cargo.lock' | path exists) }
-		code: {
+		code: {|_, after|
 			$env.PATH = (
 				$env.PATH
-					| prepend ($env.PWD | path join 'target' 'debug')
-					| prepend ($env.PWD | path join 'target' 'release')
+					| prepend ($after | path join 'target' 'debug')
+					| prepend ($after | path join 'target' 'release')
+					| uniq
+			)
+		}
+	}
+  | append {
+		condition: {|before, _| ($before | default '' | path join 'Cargo.lock' | path exists) }
+		code: {|before, _|
+			$env.PATH = (
+				$env.PATH
+					| where $it != ($before | path join 'target' 'debug')
+					| where $it != ($before | path join 'target' 'release')
 					| uniq
 			)
 		}

--- a/nu-hooks/nu-hooks/rusty-paths/rusty-paths.nu
+++ b/nu-hooks/nu-hooks/rusty-paths/rusty-paths.nu
@@ -19,7 +19,7 @@ $env.config = ($env.config | upsert hooks.env_change.PWD {
 					| prepend ($env.PWD | path join 'target' 'debug')
 					| prepend ($env.PWD | path join 'target' 'release')
 					| uniq
-				)
+			)
 		}
 	}
 })


### PR DESCRIPTION
Resolves #1078

Previous behavior: Navigating into a folder with a `Cargo.yml` prepends the target folders to `PATH`. They never get removed. Navigating into different cargo folders one after the other leads to repeated PATH extensions.

New behavior: Navigating into a folder with a `Cargo.yml` prepends the target folders to `PATH`. Leaving a folder with a `Cargo.yml` drops the target folders from `PATH`.

There is no guarantee that they were added by the script when entering. The PATH could have had the target entries before entering. However, when using this hook, it seems reasonable to assume that this prepend and drop behavior is desired. It also seems reasonable to assume that build target folders would not be used for normal util operations.