### PR TITLE
Drop generated highlight.nu which has no source anymore

### DIFF
--- a/custom-completions/auto-generate/completions/highlight.nu
+++ b/custom-completions/auto-generate/completions/highlight.nu
@@ -1,7 +1,0 @@
-# Output file in given format
-extern "highlight" [
-	--out-format(-O)					# Output file in given format
-	--syntax(-S)					# Set type of the source code
-	--style(-s)					# Highlight style
-	...args
-]


### PR DESCRIPTION
`highlight.fish` has been removed upstream in 2cb60bed1000a781bf427b56108bba2e7c68ba32

> Remove share/completions/highlight.fish
>
> Highlight ships its own completion script:
> https://gitlab.com/saalen/highlight/-/blob/master/sh-completion/highlight.fish

https://github.com/fish-shell/fish-shell/commit/2cb60bed1000a781bf427b56108bba2e7c68ba32