### PR TITLE
fix(gh): list my stars wrong sorting (52 seconds ago) <Francesc Elies>

### DIFF
--- a/custom-completions/gh/gh-completions.nu
+++ b/custom-completions/gh/gh-completions.nu
@@ -600,5 +600,5 @@ export def "gh my stars" [] {
             break
         }
     }
-    $stars | flatten | update cells --columns [starredAt] {$in| date humanize} | sort-by starredAt
+    $stars | flatten | update cells --columns [starredAt] { $in | into datetime } | sort-by starredAt
 }


### PR DESCRIPTION

github stars listing was wrong because humanized date strings were being sorted instead datetime objects.

Ref. https://github.com/nushell/nu_scripts/pull/1109#discussion_r2070528888
