### PR TITLE
Fix datetime theme color

### DIFF
--- a/themes/nu-themes/3024-day.nu
+++ b/themes/nu-themes/3024-day.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#cdab53' } else { '#fded02' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#db2d20' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/3024-night.nu
+++ b/themes/nu-themes/3024-night.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#cdab53' } else { '#fded02' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#db2d20' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/3024r.nu
+++ b/themes/nu-themes/3024r.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b5e4f4' } else { '#fded02' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#db2d20' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/abyss.nu
+++ b/themes/nu-themes/abyss.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2592d3' } else { '#1f6ca1' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#48697e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/aci.nu
+++ b/themes/nu-themes/aci.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1eff8e' } else { '#ff8308' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0883' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/aco.nu
+++ b/themes/nu-themes/aco.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1eff8e' } else { '#ff8308' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0883' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/adventuretime.nu
+++ b/themes/nu-themes/adventuretime.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c8faf4' } else { '#e7741e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bd0013' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/afterglow.nu
+++ b/themes/nu-themes/afterglow.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7dd6cf' } else { '#d3a04d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a53c23' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/alien-blood.nu
+++ b/themes/nu-themes/alien-blood.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00e0c4' } else { '#717f24' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#7f2b27' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/alucard.nu
+++ b/themes/nu-themes/alucard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ae9fc' } else { '#7f0a1f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff5555' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/amora.nu
+++ b/themes/nu-themes/amora.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c4d1f5' } else { '#eacac0' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ed3f7f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/apathy.nu
+++ b/themes/nu-themes/apathy.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#963e4c' } else { '#3e4c96' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#3e9688' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/apprentice.nu
+++ b/themes/nu-themes/apprentice.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5f875f' } else { '#5f8787' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/argonaut.nu
+++ b/themes/nu-themes/argonaut.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#67fff0' } else { '#ffb900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff000f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/arthur.nu
+++ b/themes/nu-themes/arthur.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b0c4de' } else { '#e8ae5b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cd5c5c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ashes.nu
+++ b/themes/nu-themes/ashes.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#95aec7' } else { '#aec795' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c7ae95' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-cave-light.nu
+++ b/themes/nu-themes/atelier-cave-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#398bc6' } else { '#a06e3b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#be4678' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-cave.nu
+++ b/themes/nu-themes/atelier-cave.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#398bc6' } else { '#a06e3b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#be4678' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-dune-light.nu
+++ b/themes/nu-themes/atelier-dune-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1fad83' } else { '#ae9513' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d73737' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-dune.nu
+++ b/themes/nu-themes/atelier-dune.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1fad83' } else { '#ae9513' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d73737' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-estuary-light.nu
+++ b/themes/nu-themes/atelier-estuary-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5b9d48' } else { '#a5980d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ba6236' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-estuary.nu
+++ b/themes/nu-themes/atelier-estuary.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5b9d48' } else { '#a5980d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ba6236' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-forest-light.nu
+++ b/themes/nu-themes/atelier-forest-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3d97b8' } else { '#c38418' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f22c40' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-forest.nu
+++ b/themes/nu-themes/atelier-forest.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3d97b8' } else { '#c38418' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f22c40' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-heath-light.nu
+++ b/themes/nu-themes/atelier-heath-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#159393' } else { '#bb8a35' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ca402b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-heath.nu
+++ b/themes/nu-themes/atelier-heath.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#159393' } else { '#bb8a35' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ca402b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-lakeside-light.nu
+++ b/themes/nu-themes/atelier-lakeside-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2d8f6f' } else { '#8a8a0f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d22d72' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-lakeside.nu
+++ b/themes/nu-themes/atelier-lakeside.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2d8f6f' } else { '#8a8a0f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d22d72' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-plateau-light.nu
+++ b/themes/nu-themes/atelier-plateau-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5485b6' } else { '#a06e3b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ca4949' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-plateau.nu
+++ b/themes/nu-themes/atelier-plateau.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5485b6' } else { '#a06e3b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ca4949' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-savanna-light.nu
+++ b/themes/nu-themes/atelier-savanna-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1c9aa0' } else { '#a07e3b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b16139' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-savanna.nu
+++ b/themes/nu-themes/atelier-savanna.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1c9aa0' } else { '#a07e3b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b16139' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-seaside-light.nu
+++ b/themes/nu-themes/atelier-seaside-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1999b3' } else { '#98981b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e6193c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-seaside.nu
+++ b/themes/nu-themes/atelier-seaside.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1999b3' } else { '#98981b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e6193c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-sulphurpool-light.nu
+++ b/themes/nu-themes/atelier-sulphurpool-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#22a2c9' } else { '#c08b30' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c94922' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atelier-sulphurpool.nu
+++ b/themes/nu-themes/atelier-sulphurpool.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#22a2c9' } else { '#c08b30' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c94922' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atlas.nu
+++ b/themes/nu-themes/atlas.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#14747e' } else { '#ffcc1b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff5a67' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atom-one-light.nu
+++ b/themes/nu-themes/atom-one-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3e953a' } else { '#d2b67b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#de3d35' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/atom.nu
+++ b/themes/nu-themes/atom.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#85befd' } else { '#ffd7b1' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fd5ff1' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ayu-light.nu
+++ b/themes/nu-themes/ayu-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7ff0cb' } else { '#f19618' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff3333' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ayu-mirage-simple-cursor.nu
+++ b/themes/nu-themes/ayu-mirage-simple-cursor.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#95e6cb' } else { '#fad07b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ed8274' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ayu-mirage.nu
+++ b/themes/nu-themes/ayu-mirage.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#95e6cb' } else { '#fad07b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ed8274' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ayu.nu
+++ b/themes/nu-themes/ayu.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c7fffc' } else { '#e6c446' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff3333' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/azu.nu
+++ b/themes/nu-themes/azu.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b8d6d3' } else { '#aca46d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ac6d74' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/batman.nu
+++ b/themes/nu-themes/batman.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a2a2a5' } else { '#f3fd21' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e6db43' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/belafonte-day.nu
+++ b/themes/nu-themes/belafonte-day.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#989a9c' } else { '#eaa549' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#be100e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/belafonte-night.nu
+++ b/themes/nu-themes/belafonte-night.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#989a9c' } else { '#eaa549' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#be100e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/bespin.nu
+++ b/themes/nu-themes/bespin.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#afc4db' } else { '#f9ee98' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cf6a4c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/bim.nu
+++ b/themes/nu-themes/bim.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#81eeb2' } else { '#f5a255' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f557a0' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/birds-of-paradise.nu
+++ b/themes/nu-themes/birds-of-paradise.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#93cfd7' } else { '#e99d2a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#be2d26' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-bathory.nu
+++ b/themes/nu-themes/black-metal-bathory.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#e78a53' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-burzum.nu
+++ b/themes/nu-themes/black-metal-burzum.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#99bbaa' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-dark-funeral.nu
+++ b/themes/nu-themes/black-metal-dark-funeral.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#5f81a5' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-gorgoroth.nu
+++ b/themes/nu-themes/black-metal-gorgoroth.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#8c7f70' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-immortal.nu
+++ b/themes/nu-themes/black-metal-immortal.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#556677' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-khold.nu
+++ b/themes/nu-themes/black-metal-khold.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#974b46' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-marduk.nu
+++ b/themes/nu-themes/black-metal-marduk.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#626b67' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-mayhem.nu
+++ b/themes/nu-themes/black-metal-mayhem.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#eecc6c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-nile.nu
+++ b/themes/nu-themes/black-metal-nile.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#777755' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal-venom.nu
+++ b/themes/nu-themes/black-metal-venom.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#79241f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/black-metal.nu
+++ b/themes/nu-themes/black-metal.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aaaaaa' } else { '#a06666' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f8787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/blazer.nu
+++ b/themes/nu-themes/blazer.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#bddbdb' } else { '#b8b87a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b87a7a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/borland.nu
+++ b/themes/nu-themes/borland.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#dfdffe' } else { '#ffffb6' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff6c60' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/brewer.nu
+++ b/themes/nu-themes/brewer.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#80b1d3' } else { '#dca060' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e31a1c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/bright-lights.nu
+++ b/themes/nu-themes/bright-lights.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#6cbeb5' } else { '#ffc150' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff355b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/bright.nu
+++ b/themes/nu-themes/bright.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#76c7b7' } else { '#fda331' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb0120' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/broadcast.nu
+++ b/themes/nu-themes/broadcast.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a0cef0' } else { '#ffd24a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#da4939' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/brogrammer.nu
+++ b/themes/nu-themes/brogrammer.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1081d6' } else { '#1dd361' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d6dbe5' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/brushtrees-dark.nu
+++ b/themes/nu-themes/brushtrees-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#86b3b3' } else { '#aab386' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b38686' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/brushtrees.nu
+++ b/themes/nu-themes/brushtrees.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#86b3b3' } else { '#aab386' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b38686' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/c64.nu
+++ b/themes/nu-themes/c64.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#67b6bd' } else { '#bfce72' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#883932' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/cai.nu
+++ b/themes/nu-themes/cai.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8de9d4' } else { '#caa427' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ca274d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/catppuccin-latte.nu
+++ b/themes/nu-themes/catppuccin-latte.nu
@@ -50,7 +50,7 @@ export def main [] {
                 $color_palette.red
             }
         }
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 $color_palette.green
             } else if $in < 1day {

--- a/themes/nu-themes/catppuccin-macchiato.nu
+++ b/themes/nu-themes/catppuccin-macchiato.nu
@@ -50,7 +50,7 @@ export def main [] {
                 $color_palette.red
             }
         }
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 $color_palette.green
             } else if $in < 1day {

--- a/themes/nu-themes/catppuccin-mocha.nu
+++ b/themes/nu-themes/catppuccin-mocha.nu
@@ -50,7 +50,7 @@ export def main [] {
                 $color_palette.red
             }
         }
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 $color_palette.green
             } else if $in < 1day {

--- a/themes/nu-themes/chalk.nu
+++ b/themes/nu-themes/chalk.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#12cfc0' } else { '#ddb26f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb9fb1' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/chalkboard.nu
+++ b/themes/nu-themes/chalkboard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#aadadb' } else { '#c2c372' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c37372' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/challenger-deep.nu
+++ b/themes/nu-themes/challenger-deep.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#63f2f1' } else { '#ffe9aa' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff8080' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ciapre.nu
+++ b/themes/nu-themes/ciapre.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#f3dbb2' } else { '#cc8b3f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#810009' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/circus.nu
+++ b/themes/nu-themes/circus.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4bb1a7' } else { '#c3ba63' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dc657d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/classic-dark.nu
+++ b/themes/nu-themes/classic-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#75b5aa' } else { '#f4bf75' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ac4142' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/classic-light.nu
+++ b/themes/nu-themes/classic-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#75b5aa' } else { '#f4bf75' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ac4142' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/clone-of-ubuntu.nu
+++ b/themes/nu-themes/clone-of-ubuntu.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#34e2e2' } else { '#c4a000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/clrs.nu
+++ b/themes/nu-themes/clrs.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3ad5ce' } else { '#fa701d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f8282a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/cobalt-neon.nu
+++ b/themes/nu-themes/cobalt-neon.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#6cbc67' } else { '#e9e75c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff2320' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/cobalt2.nu
+++ b/themes/nu-themes/cobalt2.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#6ae3fa' } else { '#ffe50a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/codeschool.nu
+++ b/themes/nu-themes/codeschool.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b02f30' } else { '#a03b1e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#2a5491' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/corvine.nu
+++ b/themes/nu-themes/corvine.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5fd7d7' } else { '#d7d7af' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d78787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/crayon-pony-fish.nu
+++ b/themes/nu-themes/crayon-pony-fish.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ffceaf' } else { '#ab311b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#91002b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/cupcake.nu
+++ b/themes/nu-themes/cupcake.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#69a9a7' } else { '#dcb16c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d57e85' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/cupertino.nu
+++ b/themes/nu-themes/cupertino.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#318495' } else { '#826b28' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c41a15' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/danqing.nu
+++ b/themes/nu-themes/danqing.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#30dff3' } else { '#f0c239' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f9906f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/darcula.nu
+++ b/themes/nu-themes/darcula.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#629755' } else { '#bbb529' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#4eade5' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/dark-pastel.nu
+++ b/themes/nu-themes/dark-pastel.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#55ffff' } else { '#ffff55' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff5555' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/darkmoss.nu
+++ b/themes/nu-themes/darkmoss.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#66d9ef' } else { '#fdb11f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff4658' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/darkside.nu
+++ b/themes/nu-themes/darkside.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3d97e2' } else { '#f2d42c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e8341c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/darktooth.nu
+++ b/themes/nu-themes/darktooth.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ba59b' } else { '#fac03b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb543f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/darkviolet.nu
+++ b/themes/nu-themes/darkviolet.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#40dfff' } else { '#f29df2' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a82ee6' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/decaf.nu
+++ b/themes/nu-themes/decaf.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#bed6ff' } else { '#ffd67c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff7f7b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/default-dark.nu
+++ b/themes/nu-themes/default-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#86c1b9' } else { '#f7ca88' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ab4642' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/default-light.nu
+++ b/themes/nu-themes/default-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#86c1b9' } else { '#f7ca88' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ab4642' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/desert-night.nu
+++ b/themes/nu-themes/desert-night.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#bfab36' } else { '#e18245' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e56b55' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/desert.nu
+++ b/themes/nu-themes/desert.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ffd700' } else { '#f0e68c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff2b2b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/dimmed-monokai.nu
+++ b/themes/nu-themes/dimmed-monokai.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2e706d' } else { '#c5a635' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#be3f48' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/dirtysea.nu
+++ b/themes/nu-themes/dirtysea.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#755b00' } else { '#755b00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#840000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/dot-gov.nu
+++ b/themes/nu-themes/dot-gov.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8bd1ed' } else { '#f6bb33' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bf081d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/dracula.nu
+++ b/themes/nu-themes/dracula.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a1efe4' } else { '#00f769' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ea51b2' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/dumbledore.nu
+++ b/themes/nu-themes/dumbledore.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#25de50' } else { '#f0c75e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ae0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/duotone-dark.nu
+++ b/themes/nu-themes/duotone-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2388ff' } else { '#d8b76e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d8393d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/e-n-c-o-m.nu
+++ b/themes/nu-themes/e-n-c-o-m.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00cdcd' } else { '#ffcf00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9f0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/earthsong.nu
+++ b/themes/nu-themes/earthsong.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#84f088' } else { '#f5ae2e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c94234' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/edge-dark.nu
+++ b/themes/nu-themes/edge-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5ebaa5' } else { '#dbb774' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e77171' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/edge-light.nu
+++ b/themes/nu-themes/edge-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#509c93' } else { '#d69822' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#db7070' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/eighties.nu
+++ b/themes/nu-themes/eighties.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#66cccc' } else { '#ffcc66' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f2777a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/elemental.nu
+++ b/themes/nu-themes/elemental.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#59d599' } else { '#7f7111' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#98290f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/elementary.nu
+++ b/themes/nu-themes/elementary.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4bb8fd' } else { '#ffc005' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e1321a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/elic.nu
+++ b/themes/nu-themes/elic.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4bb8fd' } else { '#ffc005' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e1321a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/elio.nu
+++ b/themes/nu-themes/elio.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4bb8fd' } else { '#ffc005' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e1321a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/embark.nu
+++ b/themes/nu-themes/embark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#63f2f1' } else { '#ffe6b3' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f48fb1' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/embers.nu
+++ b/themes/nu-themes/embers.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#576d82' } else { '#6d8257' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#826d57' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/equilibrium-dark.nu
+++ b/themes/nu-themes/equilibrium-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00948b' } else { '#bb8801' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f04339' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/equilibrium-gray-dark.nu
+++ b/themes/nu-themes/equilibrium-gray-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00948b' } else { '#bb8801' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f04339' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/equilibrium-gray-light.nu
+++ b/themes/nu-themes/equilibrium-gray-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#007a72' } else { '#9d6f00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d02023' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/equilibrium-light.nu
+++ b/themes/nu-themes/equilibrium-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#007a72' } else { '#9d6f00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d02023' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/espresso-libre.nu
+++ b/themes/nu-themes/espresso-libre.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#34e2e2' } else { '#f0e53a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/espresso.nu
+++ b/themes/nu-themes/espresso.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#bed6ff' } else { '#ffc66d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d25252' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/eva-dim.nu
+++ b/themes/nu-themes/eva-dim.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4b8f77' } else { '#cfd05d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c4676c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/eva.nu
+++ b/themes/nu-themes/eva.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4b8f77' } else { '#ffff66' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c4676c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/everforest-light.nu
+++ b/themes/nu-themes/everforest-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#35a77c' } else { '#dfa000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f85552' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/everforest.nu
+++ b/themes/nu-themes/everforest.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#83c092' } else { '#dbbc7f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e67e80' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/falcon.nu
+++ b/themes/nu-themes/falcon.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8bccbf' } else { '#ffc552' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff3600' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/farin.nu
+++ b/themes/nu-themes/farin.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#66ffdd' } else { '#ffbb33' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff1155' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ffive.nu
+++ b/themes/nu-themes/ffive.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#6dd8d8' } else { '#f8f800' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ea2639' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/fideloper.nu
+++ b/themes/nu-themes/fideloper.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#81908f' } else { '#b7aa9a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ca1d2c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/fishtank.nu
+++ b/themes/nu-themes/fishtank.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a5bd86' } else { '#fecd5e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c6004a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/flat.nu
+++ b/themes/nu-themes/flat.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1abc9c' } else { '#f1c40f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e74c3c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/flatland.nu
+++ b/themes/nu-themes/flatland.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#d63865' } else { '#f4ef6d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f18339' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/floraverse.nu
+++ b/themes/nu-themes/floraverse.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#62caa8' } else { '#cd751c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#64002c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/forest-night.nu
+++ b/themes/nu-themes/forest-night.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a9dd9d' } else { '#f0aa8a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fd8489' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/foxnightly.nu
+++ b/themes/nu-themes/foxnightly.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c4a000' } else { '#729fcf' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b98eff' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/framer.nu
+++ b/themes/nu-themes/framer.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#acddfd' } else { '#fecb6e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fd886b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/freya.nu
+++ b/themes/nu-themes/freya.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2aa198' } else { '#b58900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dc322f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/frontend-delight.nu
+++ b/themes/nu-themes/frontend-delight.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4fbce6' } else { '#fa771d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f8511b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/frontend-fun-forrest.nu
+++ b/themes/nu-themes/frontend-fun-forrest.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#e6a96b' } else { '#be8a13' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d6262b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/frontend-galaxy.nu
+++ b/themes/nu-themes/frontend-galaxy.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3979bc' } else { '#fef02a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f9555f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/fruit-soda.nu
+++ b/themes/nu-themes/fruit-soda.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#0f9cfd' } else { '#f7e203' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fe3e31' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gigavolt.nu
+++ b/themes/nu-themes/gigavolt.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#fb6acb' } else { '#ffdc2d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff661a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/github-dark-colorblind.nu
+++ b/themes/nu-themes/github-dark-colorblind.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#56d4dd' } else { '#d29922' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff7b72' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/github-dark-default.nu
+++ b/themes/nu-themes/github-dark-default.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#56d4dd' } else { '#d29922' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff7b72' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/github-dark.nu
+++ b/themes/nu-themes/github-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#56d4dd' } else { '#ffea7f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ea4a5a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/github-dimmed.nu
+++ b/themes/nu-themes/github-dimmed.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#56d4dd' } else { '#c69026' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f47067' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/github-light-colorblind.nu
+++ b/themes/nu-themes/github-light-colorblind.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3192aa' } else { '#4d2d00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cf222e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/github-light-default.nu
+++ b/themes/nu-themes/github-light-default.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3192aa' } else { '#4d2d00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cf222e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/github-light.nu
+++ b/themes/nu-themes/github-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3192aa' } else { '#dbab09' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d73a49' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/github.nu
+++ b/themes/nu-themes/github.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#183691' } else { '#795da3' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ed6a43' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/glacier.nu
+++ b/themes/nu-themes/glacier.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a0b6d3' } else { '#fb9435' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bd0f2f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/goa-base.nu
+++ b/themes/nu-themes/goa-base.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c8f9f3' } else { '#f40000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f78000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gooey.nu
+++ b/themes/nu-themes/gooey.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c0b7f9' } else { '#c65e3d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bb4f6c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/google-dark.nu
+++ b/themes/nu-themes/google-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3971ed' } else { '#fba922' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc342b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/google-light.nu
+++ b/themes/nu-themes/google-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3971ed' } else { '#fba922' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc342b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/grape.nu
+++ b/themes/nu-themes/grape.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#9de3eb' } else { '#8ddc20' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ed2261' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/grass.nu
+++ b/themes/nu-themes/grass.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#55ffff' } else { '#e7b000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bb0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/grayscale-dark.nu
+++ b/themes/nu-themes/grayscale-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#868686' } else { '#a0a0a0' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#7c7c7c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/grayscale-light.nu
+++ b/themes/nu-themes/grayscale-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#868686' } else { '#a0a0a0' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#7c7c7c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/green-screen.nu
+++ b/themes/nu-themes/green-screen.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#005500' } else { '#007700' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#007700' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/greenscreen.nu
+++ b/themes/nu-themes/greenscreen.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#005500' } else { '#007700' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#007700' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbit.nu
+++ b/themes/nu-themes/gruvbit.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#e9593d' } else { '#dc9656' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fabd2f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-dark-hard.nu
+++ b/themes/nu-themes/gruvbox-dark-hard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ec07c' } else { '#fabd2f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb4934' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-dark-medium.nu
+++ b/themes/nu-themes/gruvbox-dark-medium.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ec07c' } else { '#fabd2f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb4934' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-dark-pale.nu
+++ b/themes/nu-themes/gruvbox-dark-pale.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#85ad85' } else { '#ffaf00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d75f5f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-dark-soft.nu
+++ b/themes/nu-themes/gruvbox-dark-soft.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ec07c' } else { '#fabd2f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb4934' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-dark.nu
+++ b/themes/nu-themes/gruvbox-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ec07c' } else { '#d79921' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc241d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-light-hard.nu
+++ b/themes/nu-themes/gruvbox-light-hard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#427b58' } else { '#b57614' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9d0006' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-light-medium.nu
+++ b/themes/nu-themes/gruvbox-light-medium.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#427b58' } else { '#b57614' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9d0006' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-light-soft.nu
+++ b/themes/nu-themes/gruvbox-light-soft.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#427b58' } else { '#b57614' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9d0006' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-material-dark-hard.nu
+++ b/themes/nu-themes/gruvbox-material-dark-hard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#89b482' } else { '#d8a657' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ea6962' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-material-dark-medium.nu
+++ b/themes/nu-themes/gruvbox-material-dark-medium.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#89b482' } else { '#d8a657' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ea6962' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-material-dark-soft.nu
+++ b/themes/nu-themes/gruvbox-material-dark-soft.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#89b482' } else { '#d8a657' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ea6962' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-material-light-hard.nu
+++ b/themes/nu-themes/gruvbox-material-light-hard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4c7a5d' } else { '#b47109' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c14a4a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-material-light-medium.nu
+++ b/themes/nu-themes/gruvbox-material-light-medium.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4c7a5d' } else { '#b47109' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c14a4a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-material-light-soft.nu
+++ b/themes/nu-themes/gruvbox-material-light-soft.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4c7a5d' } else { '#b47109' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c14a4a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-mix-dark-hard.nu
+++ b/themes/nu-themes/gruvbox-mix-dark-hard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8bba7f' } else { '#e9b143' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f2594b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-mix-dark-medium.nu
+++ b/themes/nu-themes/gruvbox-mix-dark-medium.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8bba7f' } else { '#e9b143' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f2594b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-mix-dark-soft.nu
+++ b/themes/nu-themes/gruvbox-mix-dark-soft.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8bba7f' } else { '#e9b143' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f2594b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-mix-light-hard.nu
+++ b/themes/nu-themes/gruvbox-mix-light-hard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#477a5b' } else { '#b4730e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#af2528' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-mix-light-medium.nu
+++ b/themes/nu-themes/gruvbox-mix-light-medium.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#477a5b' } else { '#b4730e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#af2528' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-mix-light-soft.nu
+++ b/themes/nu-themes/gruvbox-mix-light-soft.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#477a5b' } else { '#b4730e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#af2528' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-original-dark-hard.nu
+++ b/themes/nu-themes/gruvbox-original-dark-hard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ec07c' } else { '#fabd2f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb4934' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-original-dark-medium.nu
+++ b/themes/nu-themes/gruvbox-original-dark-medium.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ec07c' } else { '#fabd2f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb4934' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-original-dark-soft.nu
+++ b/themes/nu-themes/gruvbox-original-dark-soft.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ec07c' } else { '#fabd2f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb4934' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-original-light-hard.nu
+++ b/themes/nu-themes/gruvbox-original-light-hard.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#427b58' } else { '#b57614' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9d0006' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-original-light-medium.nu
+++ b/themes/nu-themes/gruvbox-original-light-medium.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#427b58' } else { '#b57614' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9d0006' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox-original-light-soft.nu
+++ b/themes/nu-themes/gruvbox-original-light-soft.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#427b58' } else { '#b57614' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9d0006' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/gruvbox.nu
+++ b/themes/nu-themes/gruvbox.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#427b58' } else { '#d79921' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc241d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/hardcore.nu
+++ b/themes/nu-themes/hardcore.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#708387' } else { '#e6db74' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f92672' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/harmonic-dark.nu
+++ b/themes/nu-themes/harmonic-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#568bbf' } else { '#8bbf56' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bf8b56' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/harmonic-light.nu
+++ b/themes/nu-themes/harmonic-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#568bbf' } else { '#8bbf56' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bf8b56' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/harmonic16-dark.nu
+++ b/themes/nu-themes/harmonic16-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#568bbf' } else { '#8bbf56' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bf8b56' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/harmonic16-light.nu
+++ b/themes/nu-themes/harmonic16-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#568bbf' } else { '#8bbf56' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bf8b56' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/harper.nu
+++ b/themes/nu-themes/harper.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#f5bfd7' } else { '#d6da25' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f8b63f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/heetch-light.nu
+++ b/themes/nu-themes/heetch-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c33678' } else { '#5ba2b6' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#27d9d5' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/heetch.nu
+++ b/themes/nu-themes/heetch.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#f80059' } else { '#8f6c97' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#27d9d5' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/helios.nu
+++ b/themes/nu-themes/helios.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1ba595' } else { '#f19d1a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d72638' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/hemisu-dark.nu
+++ b/themes/nu-themes/hemisu-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b6e0e5' } else { '#9d895e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0054' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/hemisu-light.nu
+++ b/themes/nu-themes/hemisu-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#85b2aa' } else { '#503d15' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0055' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/highway.nu
+++ b/themes/nu-themes/highway.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5d504a' } else { '#ffcb3e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d00e18' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/hipster-green.nu
+++ b/themes/nu-themes/hipster-green.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00e5e5' } else { '#bfbf00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b6214a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/homebrew.nu
+++ b/themes/nu-themes/homebrew.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00e5e5' } else { '#999900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#990000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/hopscotch.nu
+++ b/themes/nu-themes/hopscotch.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#149b93' } else { '#fdcc59' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dd464c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/horizon-dark.nu
+++ b/themes/nu-themes/horizon-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#24a8b4' } else { '#efb993' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e93c58' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/horizon-light.nu
+++ b/themes/nu-themes/horizon-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#dc3318' } else { '#fbe0d9' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f7939b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/horizon-terminal-dark.nu
+++ b/themes/nu-themes/horizon-terminal-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#59e1e3' } else { '#fac29a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e95678' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/horizon-terminal-light.nu
+++ b/themes/nu-themes/horizon-terminal-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#59e1e3' } else { '#fadad1' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e95678' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/humanoid-dark.nu
+++ b/themes/nu-themes/humanoid-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#0dd9d6' } else { '#ffb627' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f11235' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/humanoid-light.nu
+++ b/themes/nu-themes/humanoid-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#008e8e' } else { '#ffb627' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b0151a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/hurtado.nu
+++ b/themes/nu-themes/hurtado.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#86eafe' } else { '#fbe74a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff1b00' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/hybrid.nu
+++ b/themes/nu-themes/hybrid.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8abeb7' } else { '#de935f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a54242' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ia-dark.nu
+++ b/themes/nu-themes/ia-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7c9cae' } else { '#b99353' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d88568' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ia-light.nu
+++ b/themes/nu-themes/ia-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2d6bb1' } else { '#c48218' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9c5a02' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ibm3270.nu
+++ b/themes/nu-themes/ibm3270.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#9ce2e2' } else { '#f0d824' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f01818' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ic-green-ppl.nu
+++ b/themes/nu-themes/ic-green-ppl.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#22ff71' } else { '#659b25' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb002a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ic-orange-ppl.nu
+++ b/themes/nu-themes/ic-orange-ppl.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c69752' } else { '#caaf00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c13900' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/iceberg-light.nu
+++ b/themes/nu-themes/iceberg-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#327698' } else { '#c57339' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc517a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/icy.nu
+++ b/themes/nu-themes/icy.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#26c6da' } else { '#80deea' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#16c1d9' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/idle-toes.nu
+++ b/themes/nu-themes/idle-toes.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#dcf4ff' } else { '#ffc66d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d25252' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/idm_3b.nu
+++ b/themes/nu-themes/idm_3b.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#caa0f0' } else { '#ffb060' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b04060' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ir-black.nu
+++ b/themes/nu-themes/ir-black.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c6c5fe' } else { '#ffffb6' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff6c60' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/irblack.nu
+++ b/themes/nu-themes/irblack.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#c6c5fe' } else { '#ffffb6' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff6c60' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/isotope.nu
+++ b/themes/nu-themes/isotope.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00ffff' } else { '#ff0099' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/jackie-brown.nu
+++ b/themes/nu-themes/jackie-brown.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00e5e5' } else { '#bebf00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ef5734' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/japanesque.nu
+++ b/themes/nu-themes/japanesque.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#76bbca' } else { '#e9b32a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cf3f61' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/jellybeans.nu
+++ b/themes/nu-themes/jellybeans.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1ab2a8' } else { '#ffba7b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e27373' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/jet-brains-darcula.nu
+++ b/themes/nu-themes/jet-brains-darcula.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#60d3d1' } else { '#c2c300' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fa5355' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/jup.nu
+++ b/themes/nu-themes/jup.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#74ffb9' } else { '#dd6f00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dd006f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/kibble.nu
+++ b/themes/nu-themes/kibble.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#68f2e0' } else { '#d8e30e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c70031' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/kimber.nu
+++ b/themes/nu-themes/kimber.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#78b4b4' } else { '#d8b56d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c88c8c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/later-this-evening.nu
+++ b/themes/nu-themes/later-this-evening.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5fc0ae' } else { '#e5d289' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d45a60' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/lavandula.nu
+++ b/themes/nu-themes/lavandula.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#9ad4e0' } else { '#7f6f49' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#7d1625' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/liquid-carbon-transparent.nu
+++ b/themes/nu-themes/liquid-carbon-transparent.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7ac4cc' } else { '#ccac00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff3030' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/liquid-carbon.nu
+++ b/themes/nu-themes/liquid-carbon.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7ac4cc' } else { '#ccac00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff3030' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/london-tube.nu
+++ b/themes/nu-themes/london-tube.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#85cebc' } else { '#ffd204' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ee2e24' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/macintosh.nu
+++ b/themes/nu-themes/macintosh.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#02abea' } else { '#fbf305' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dd0907' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/maia.nu
+++ b/themes/nu-themes/maia.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00d1d1' } else { '#4c4f4d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ba2922' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/man-page.nu
+++ b/themes/nu-themes/man-page.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00e5e5' } else { '#999900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mar.nu
+++ b/themes/nu-themes/mar.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#73cda0' } else { '#b57b40' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b5407b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/marrakesh.nu
+++ b/themes/nu-themes/marrakesh.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#75a738' } else { '#a88339' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c35359' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/materia.nu
+++ b/themes/nu-themes/materia.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#80cbc4' } else { '#ffcc00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ec5f67' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/material-dark.nu
+++ b/themes/nu-themes/material-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#26bad1' } else { '#f5971d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b7141e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/material-darker.nu
+++ b/themes/nu-themes/material-darker.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#89ddff' } else { '#ffcb6b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f07178' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/material-lighter.nu
+++ b/themes/nu-themes/material-lighter.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#39adb5' } else { '#ffb62c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff5370' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/material-palenight.nu
+++ b/themes/nu-themes/material-palenight.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#89ddff' } else { '#ffcb6b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f07178' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/material-vivid.nu
+++ b/themes/nu-themes/material-vivid.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00bcd4' } else { '#ffeb3b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f44336' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/material.nu
+++ b/themes/nu-themes/material.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#89ddff' } else { '#ffcb6b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f07178' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mathias.nu
+++ b/themes/nu-themes/mathias.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#55ffff' } else { '#fc951e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e52222' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/medallion.nu
+++ b/themes/nu-themes/medallion.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ffbc51' } else { '#d3bd26' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b64c00' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mellow-purple.nu
+++ b/themes/nu-themes/mellow-purple.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b900b1' } else { '#955ae7' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#00d9e9' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mexico-light.nu
+++ b/themes/nu-themes/mexico-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4b8093' } else { '#f79a0e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ab4642' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/miramare.nu
+++ b/themes/nu-themes/miramare.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#87c095' } else { '#d9bb80' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e68183' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/misterioso.nu
+++ b/themes/nu-themes/misterioso.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00ede1' } else { '#ffad29' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff4242' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/miu.nu
+++ b/themes/nu-themes/miu.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#bddbdb' } else { '#b8b87a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b87a7a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mocha.nu
+++ b/themes/nu-themes/mocha.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7bbda4' } else { '#f4bc87' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cb6077' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/molokai.nu
+++ b/themes/nu-themes/molokai.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ffce51' } else { '#60d4df' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#7325fa' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mona-lisa.nu
+++ b/themes/nu-themes/mona-lisa.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8acd8f' } else { '#c36e28' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9b291c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mono-amber.nu
+++ b/themes/nu-themes/mono-amber.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ff9400' } else { '#ff9400' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff9400' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mono-cyan.nu
+++ b/themes/nu-themes/mono-cyan.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00ccff' } else { '#00ccff' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#00ccff' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mono-green.nu
+++ b/themes/nu-themes/mono-green.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#0bff00' } else { '#0bff00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#0bff00' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mono-red.nu
+++ b/themes/nu-themes/mono-red.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ff3600' } else { '#ff3600' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff3600' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mono-white.nu
+++ b/themes/nu-themes/mono-white.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#fafafa' } else { '#fafafa' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fafafa' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mono-yellow.nu
+++ b/themes/nu-themes/mono-yellow.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ffd300' } else { '#ffd300' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ffd300' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/monokai-dark.nu
+++ b/themes/nu-themes/monokai-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2aa198' } else { '#f4bf75' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f92672' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/monokai-soda.nu
+++ b/themes/nu-themes/monokai-soda.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#58d1eb' } else { '#fa8419' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f4005f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/monokai.nu
+++ b/themes/nu-themes/monokai.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a1efe4' } else { '#f4bf75' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f92672' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mountaineer-grey.nu
+++ b/themes/nu-themes/mountaineer-grey.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8abeb7' } else { '#f0c674' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc6666' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/mountaineer.nu
+++ b/themes/nu-themes/mountaineer.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8abeb7' } else { '#f0c674' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc6666' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/n0tch2k.nu
+++ b/themes/nu-themes/n0tch2k.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#dcdcdc' } else { '#a98051' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a95551' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nebula.nu
+++ b/themes/nu-themes/nebula.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#226f68' } else { '#4f9062' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#777abc' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/neon-night.nu
+++ b/themes/nu-themes/neon-night.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8ce8ff' } else { '#fcad3f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff8e8e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/neopolitan.nu
+++ b/themes/nu-themes/neopolitan.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8da6ce' } else { '#fbde2d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#800000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nep.nu
+++ b/themes/nu-themes/nep.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#74b9ff' } else { '#6fdd00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dd6f00' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/neutron.nu
+++ b/themes/nu-themes/neutron.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3f94a8' } else { '#deb566' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b54036' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nightfly.nu
+++ b/themes/nu-themes/nightfly.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7fdbca' } else { '#e7d37a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fc514e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nightlion-v1.nu
+++ b/themes/nu-themes/nightlion-v1.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#55ffff' } else { '#f3f167' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bb0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nightlion-v2.nu
+++ b/themes/nu-themes/nightlion-v2.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00ccd8' } else { '#f3f167' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bb0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nighty.nu
+++ b/themes/nu-themes/nighty.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#70d2a4' } else { '#808020' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#9b3e46' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nord-alt.nu
+++ b/themes/nu-themes/nord-alt.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b48ead' } else { '#4c566a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#3b4252' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nord-light.nu
+++ b/themes/nu-themes/nord-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#96dcda' } else { '#dab752' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e64569' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nord.nu
+++ b/themes/nu-themes/nord.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#88c0d0' } else { '#ebcb8b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bf616a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nova.nu
+++ b/themes/nu-themes/nova.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#f2c38f' } else { '#a8ce93' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#83afe5' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/novel.nu
+++ b/themes/nu-themes/novel.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#0087cc' } else { '#d06b00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/nushell-dark.nu
+++ b/themes/nu-themes/nushell-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
       } else { 'blue' }
     }
     duration: white
-    date: {|| (date now) - $in |
+    datetime: {|| (date now) - $in |
       if $in < 1hr {
         'purple'
       } else if $in < 6hr {

--- a/themes/nu-themes/nushell-light.nu
+++ b/themes/nu-themes/nushell-light.nu
@@ -18,7 +18,7 @@ export def main [] {
       } else { 'blue_bold' }
     }
     duration: dark_gray
-  date: {|| (date now) - $in |
+  datetime: {|| (date now) - $in |
     if $in < 1hr {
       'purple'
     } else if $in < 6hr {

--- a/themes/nu-themes/obsidian.nu
+++ b/themes/nu-themes/obsidian.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#55ffff' } else { '#fecd22' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a60001' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ocean-dark.nu
+++ b/themes/nu-themes/ocean-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#dfdffd' } else { '#e5c079' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#af4b57' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ocean.nu
+++ b/themes/nu-themes/ocean.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#96b5b4' } else { '#ebcb8b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bf616a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/oceanic-material.nu
+++ b/themes/nu-themes/oceanic-material.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#42c6d9' } else { '#fee92e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ee2a29' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/oceanic-next.nu
+++ b/themes/nu-themes/oceanic-next.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#50a5a4' } else { '#f7bd51' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e44754' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/oceanicnext.nu
+++ b/themes/nu-themes/oceanicnext.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5fb3b3' } else { '#fac863' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ec5f67' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ollie.nu
+++ b/themes/nu-themes/ollie.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1ffaff' } else { '#ac4300' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ac2e31' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/one-dark.nu
+++ b/themes/nu-themes/one-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#56b6c2' } else { '#d19a66' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e06c75' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/one-half-black.nu
+++ b/themes/nu-themes/one-half-black.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#56b6c2' } else { '#e5c07b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e06c75' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/one-half-light.nu
+++ b/themes/nu-themes/one-half-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#0997b3' } else { '#c18401' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e45649' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/one-light.nu
+++ b/themes/nu-themes/one-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#0184bc' } else { '#c18401' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ca1243' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/onedark.nu
+++ b/themes/nu-themes/onedark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#56b6c2' } else { '#e5c07b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e06c75' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/orbital.nu
+++ b/themes/nu-themes/orbital.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#005faf' } else { '#d7af87' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#5f5f5f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/outrun-dark.nu
+++ b/themes/nu-themes/outrun-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#0ef0f0' } else { '#f3e877' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff4242' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/pali.nu
+++ b/themes/nu-themes/pali.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4bb8fd' } else { '#8fab74' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ab8f74' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/palmtree.nu
+++ b/themes/nu-themes/palmtree.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3fdcee' } else { '#f2a272' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f37f97' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/papercolor-dark.nu
+++ b/themes/nu-themes/papercolor-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ffaf00' } else { '#afd700' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#585858' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/papercolor-light.nu
+++ b/themes/nu-themes/papercolor-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#d75f00' } else { '#d70087' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bcbcbc' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/paraiso-dark.nu
+++ b/themes/nu-themes/paraiso-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5bc4bf' } else { '#fec418' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ef6155' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/paraiso.nu
+++ b/themes/nu-themes/paraiso.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5bc4bf' } else { '#fec418' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ef6155' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/pasque.nu
+++ b/themes/nu-themes/pasque.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7263aa' } else { '#804ead' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a92258' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/paul-millr.nu
+++ b/themes/nu-themes/paul-millr.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7adff2' } else { '#d3bf00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/pencil-dark.nu
+++ b/themes/nu-themes/pencil-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4fb8cc' } else { '#a89c14' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c30771' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/pencil-light.nu
+++ b/themes/nu-themes/pencil-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#4fb8cc' } else { '#a89c14' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c30771' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/peppermint.nu
+++ b/themes/nu-themes/peppermint.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#96dcda' } else { '#dab752' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e64569' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/phd.nu
+++ b/themes/nu-themes/phd.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#72b9bf' } else { '#fbd461' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d07346' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/piatto-light.nu
+++ b/themes/nu-themes/piatto-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#829428' } else { '#cc6e33' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b23670' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/pico.nu
+++ b/themes/nu-themes/pico.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#29adff' } else { '#fff024' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff004d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/pnevma.nu
+++ b/themes/nu-themes/pnevma.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b1e7dd' } else { '#d7af87' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a36666' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/pop.nu
+++ b/themes/nu-themes/pop.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00aabb' } else { '#f8ca12' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#eb008a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/porple.nu
+++ b/themes/nu-themes/porple.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#64878f' } else { '#efa16b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f84547' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/pro.nu
+++ b/themes/nu-themes/pro.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00e5e5' } else { '#999900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#990000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/railscasts.nu
+++ b/themes/nu-themes/railscasts.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#519f50' } else { '#ffc66d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#da4939' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/rebecca.nu
+++ b/themes/nu-themes/rebecca.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8eaee0' } else { '#ae81ff' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a0a0c5' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/red-alert.nu
+++ b/themes/nu-themes/red-alert.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b7dfdd' } else { '#beb86b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d62e4e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/red-sands.nu
+++ b/themes/nu-themes/red-sands.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#55ffff' } else { '#e7b000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff3f00' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/relaxed-afterglow.nu
+++ b/themes/nu-themes/relaxed-afterglow.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#acbbd0' } else { '#ebc17a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#bc5653' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/renault-style-light.nu
+++ b/themes/nu-themes/renault-style-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a4d4f8' } else { '#ffd249' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#da4839' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/rippedcasts.nu
+++ b/themes/nu-themes/rippedcasts.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8c9bc4' } else { '#bfbb1f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cdaf95' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/rose-pine-dawn.nu
+++ b/themes/nu-themes/rose-pine-dawn.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#286983' } else { '#ea9d34' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#1f1d2e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/rose-pine-moon.nu
+++ b/themes/nu-themes/rose-pine-moon.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3e8fb0' } else { '#f6c177' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ecebf0' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/rose-pine.nu
+++ b/themes/nu-themes/rose-pine.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#31748f' } else { '#f6c177' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e2e1e7' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/royal.nu
+++ b/themes/nu-themes/royal.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#acd4eb' } else { '#b49d27' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#91284c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/sagelight.nu
+++ b/themes/nu-themes/sagelight.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a2d6f5' } else { '#ffdc61' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fa8480' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/sandcastle.nu
+++ b/themes/nu-themes/sandcastle.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#83a598' } else { '#a07e3b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#83a598' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/sat.nu
+++ b/themes/nu-themes/sat.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#74fffa' } else { '#ddd600' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dd0007' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/sea-shells.nu
+++ b/themes/nu-themes/sea-shells.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#87acb4' } else { '#fca02f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d15123' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/seafoam-pastel.nu
+++ b/themes/nu-themes/seafoam-pastel.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ade0e0' } else { '#ada16d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#825d4d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/selenized-black.nu
+++ b/themes/nu-themes/selenized-black.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#56d8c9' } else { '#dbb32d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ed4a46' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/selenized-dark.nu
+++ b/themes/nu-themes/selenized-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#53d6c7' } else { '#dbb32d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fa5750' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/selenized-light.nu
+++ b/themes/nu-themes/selenized-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00978a' } else { '#ad8900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d2212d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/selenized-white.nu
+++ b/themes/nu-themes/selenized-white.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#009a8a' } else { '#c49700' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d6000c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/seoul256.nu
+++ b/themes/nu-themes/seoul256.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#87d7d7' } else { '#d8af5f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d68787' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/seti-ui.nu
+++ b/themes/nu-themes/seti-ui.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#55dbbe' } else { '#e6cd69' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#Cd3f45' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/seti.nu
+++ b/themes/nu-themes/seti.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#55dbbe' } else { '#e6cd69' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cd3f45' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/shaman.nu
+++ b/themes/nu-themes/shaman.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#98d028' } else { '#5e8baa' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b2302d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/shapeshifter.nu
+++ b/themes/nu-themes/shapeshifter.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#23edda' } else { '#dddd13' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e92f2f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/shel.nu
+++ b/themes/nu-themes/shel.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8feeb9' } else { '#ab6423' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ab2463' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/sierra.nu
+++ b/themes/nu-themes/sierra.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#a17140' } else { '#7f7f60' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#515a45' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/silk-dark.nu
+++ b/themes/nu-themes/silk-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3fb2b9' } else { '#fce380' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb6953' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/silk-light.nu
+++ b/themes/nu-themes/silk-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#329ca2' } else { '#cfad25' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cf432e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/slate.nu
+++ b/themes/nu-themes/slate.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8cdfe0' } else { '#c4c9c0' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e2a8bf' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/smyck.nu
+++ b/themes/nu-themes/smyck.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#77dfd8' } else { '#d0b03c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c75646' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/snazzy.nu
+++ b/themes/nu-themes/snazzy.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#9aedfe' } else { '#f3f99d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff5c57' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/snow-dark.nu
+++ b/themes/nu-themes/snow-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5da19f' } else { '#ab916d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#be868c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/snow-light.nu
+++ b/themes/nu-themes/snow-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#008483' } else { '#906c33' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ae5865' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/soft-server.nu
+++ b/themes/nu-themes/soft-server.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#64e39c' } else { '#a3906a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a2686a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/solar-flare.nu
+++ b/themes/nu-themes/solar-flare.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#52CBB0' } else { '#E4B51C' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#EF5253' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/solarflare-light.nu
+++ b/themes/nu-themes/solarflare-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#52cbb0' } else { '#e4b51c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ef5253' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/solarflare.nu
+++ b/themes/nu-themes/solarflare.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#52cbb0' } else { '#e4b51c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ef5253' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/solarized-darcula.nu
+++ b/themes/nu-themes/solarized-darcula.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#15968d' } else { '#b68800' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f24840' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/solarized-dark-higher-contrast.nu
+++ b/themes/nu-themes/solarized-dark-higher-contrast.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00b39e' } else { '#a57706' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d11c24' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/solarized-dark.nu
+++ b/themes/nu-themes/solarized-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2aa198' } else { '#b58900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dc322f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/solarized-light.nu
+++ b/themes/nu-themes/solarized-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2aa198' } else { '#b58900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dc322f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/source-code-x.nu
+++ b/themes/nu-themes/source-code-x.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#83d2c0' } else { '#fc8e3e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb695d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/sourcerer.nu
+++ b/themes/nu-themes/sourcerer.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#87ceeb' } else { '#ff9800' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#aa4450' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/sourcerer2.nu
+++ b/themes/nu-themes/sourcerer2.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#87ceeb' } else { '#ff9800' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#aa4450' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/spaceduck.nu
+++ b/themes/nu-themes/spaceduck.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7a5ccc' } else { '#b3a1e6' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e33400' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/spacedust.nu
+++ b/themes/nu-themes/spacedust.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#83a7b4' } else { '#e3cd7b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e35b00' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/spacegray-eighties-dull.nu
+++ b/themes/nu-themes/spacegray-eighties-dull.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#58c2c1' } else { '#c6735a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b24a56' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/spacegray-eighties.nu
+++ b/themes/nu-themes/spacegray-eighties.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#83e9e4' } else { '#fec254' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ec5f67' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/spacegray.nu
+++ b/themes/nu-themes/spacegray.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#85a7a5' } else { '#e5c179' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b04b57' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/spacemacs.nu
+++ b/themes/nu-themes/spacemacs.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2d9574' } else { '#b1951d' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f2241f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/spiderman.nu
+++ b/themes/nu-themes/spiderman.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#6083ff' } else { '#e24655' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e60712' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/spring.nu
+++ b/themes/nu-themes/spring.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3e999f' } else { '#1fc95b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff4d83' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/square.nu
+++ b/themes/nu-themes/square.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#d7d9fc' } else { '#ecebbe' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e9897c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/srcery.nu
+++ b/themes/nu-themes/srcery.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2be4d0' } else { '#fbb829' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ef2f27' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/substrata.nu
+++ b/themes/nu-themes/substrata.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7dc2c7' } else { '#ab924c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cf8164' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/summercamp.nu
+++ b/themes/nu-themes/summercamp.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5aebbc' } else { '#f2ff27' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e35142' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/summerfruit-dark.nu
+++ b/themes/nu-themes/summerfruit-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1faaaa' } else { '#aba800' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0086' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/summerfruit-light.nu
+++ b/themes/nu-themes/summerfruit-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1faaaa' } else { '#aba800' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0086' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/sundried.nu
+++ b/themes/nu-themes/sundried.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#fad484' } else { '#9d602a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a7463d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/symphonic.nu
+++ b/themes/nu-themes/symphonic.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ccccff' } else { '#ff8400' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dc322f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/synth-midnight-dark.nu
+++ b/themes/nu-themes/synth-midnight-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#42fff9' } else { '#c9d364' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b53b50' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/synth-midnight-light.nu
+++ b/themes/nu-themes/synth-midnight-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#42fff9' } else { '#c9d364' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b53b50' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tango-dark.nu
+++ b/themes/nu-themes/tango-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#34e2e2' } else { '#c4a000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tango-light.nu
+++ b/themes/nu-themes/tango-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#34e2e2' } else { '#c4a000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tango.nu
+++ b/themes/nu-themes/tango.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#06989a' } else { '#c4a000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/teerb.nu
+++ b/themes/nu-themes/teerb.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b1e7dd' } else { '#d7af87' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d68686' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-autumn.nu
+++ b/themes/nu-themes/tempus-autumn.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2aa4ad' } else { '#ac9440' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f16c50' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-classic.nu
+++ b/themes/nu-themes/tempus-classic.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7aa880' } else { '#b1942b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d2813d' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-dawn.nu
+++ b/themes/nu-themes/tempus-dawn.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#106e8c' } else { '#745300' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a32a3a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-day.nu
+++ b/themes/nu-themes/tempus-day.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#337087' } else { '#806000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c81000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-dusk.nu
+++ b/themes/nu-themes/tempus-dusk.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8caeb6' } else { '#a79c46' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cb8d56' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-fugit.nu
+++ b/themes/nu-themes/tempus-fugit.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00786a' } else { '#825e00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c61a14' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-future.nu
+++ b/themes/nu-themes/tempus-future.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2cbab6' } else { '#bfa01a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff778a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-night.nu
+++ b/themes/nu-themes/tempus-night.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00ca9a' } else { '#b0a800' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fb7e8e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-past.nu
+++ b/themes/nu-themes/tempus-past.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#07737a' } else { '#a6403a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c00c50' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-rift.nu
+++ b/themes/nu-themes/tempus-rift.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#10c480' } else { '#7fad00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c19904' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-spring.nu
+++ b/themes/nu-themes/tempus-spring.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3cbaa6' } else { '#a6af1a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff855a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-summer.nu
+++ b/themes/nu-themes/tempus-summer.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#2aa9b6' } else { '#af9a0a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f76f6e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-tempest.nu
+++ b/themes/nu-themes/tempus-tempest.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#9bdfc4' } else { '#bfc94a' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c6c80a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-totus.nu
+++ b/themes/nu-themes/tempus-totus.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#005589' } else { '#714900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a80000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-warp.nu
+++ b/themes/nu-themes/tempus-warp.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1da1af' } else { '#9e8100' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fa3333' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tempus-winter.nu
+++ b/themes/nu-themes/tempus-winter.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#1ba2a0' } else { '#959721' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#eb6a58' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tender.nu
+++ b/themes/nu-themes/tender.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#73cef4' } else { '#ffc24b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f43753' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/terminal-basic.nu
+++ b/themes/nu-themes/terminal-basic.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00e5e5' } else { '#999900' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#990000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/terminix-dark.nu
+++ b/themes/nu-themes/terminix-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#86c1b9' } else { '#de935f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a54242' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/thayer-bright.nu
+++ b/themes/nu-themes/thayer-bright.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#23cfd5' } else { '#f4fd22' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f92672' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/the-hulk.nu
+++ b/themes/nu-themes/the-hulk.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3f85a5' } else { '#62e456' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#259d1a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tin.nu
+++ b/themes/nu-themes/tin.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#78b0b5' } else { '#888d4e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#8d534e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tokyo-day.nu
+++ b/themes/nu-themes/tokyo-day.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#007197' } else { '#8c6c3e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f52a65' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tokyo-moon.nu
+++ b/themes/nu-themes/tokyo-moon.nu
@@ -15,7 +15,7 @@ export def main [] {
             } else {{ fg: "#7aa2f7" }}
         }
         duration: "#a9b1d6"
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: "#f7768e" attr: "b" }
             } else if $in < 6hr {

--- a/themes/nu-themes/tokyo-night.nu
+++ b/themes/nu-themes/tokyo-night.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7dcfff' } else { '#e0af68' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f7768e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tokyo-storm.nu
+++ b/themes/nu-themes/tokyo-storm.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#7dcfff' } else { '#e0af68' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f7768e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tomorrow-night-blue.nu
+++ b/themes/nu-themes/tomorrow-night-blue.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#99ffff' } else { '#ffeead' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff9da3' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tomorrow-night-bright.nu
+++ b/themes/nu-themes/tomorrow-night-bright.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#70c0b1' } else { '#e7c547' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d54e53' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tomorrow-night-eighties.nu
+++ b/themes/nu-themes/tomorrow-night-eighties.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#66cccc' } else { '#ffcc66' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#f2777a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tomorrow-night.nu
+++ b/themes/nu-themes/tomorrow-night.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#8abeb7' } else { '#f0c674' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc6666' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tomorrow.nu
+++ b/themes/nu-themes/tomorrow.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3e999f' } else { '#eab700' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c82829' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/toy-chest.nu
+++ b/themes/nu-themes/toy-chest.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#42c3ae' } else { '#db8e27' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#be2d26' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/treehouse.nu
+++ b/themes/nu-themes/treehouse.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#f07d14' } else { '#aa820c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b2270e' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/tube.nu
+++ b/themes/nu-themes/tube.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#85cebc' } else { '#ffd204' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ee2e24' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/twilight.nu
+++ b/themes/nu-themes/twilight.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#afc4db' } else { '#f9ee98' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cf6a4c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/two-firewatch.nu
+++ b/themes/nu-themes/two-firewatch.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#56b6c2' } else { '#e5c07b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e06c75' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/unikitty-dark.nu
+++ b/themes/nu-themes/unikitty-dark.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#149bda' } else { '#dc8a0e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d8137f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/unikitty-light.nu
+++ b/themes/nu-themes/unikitty-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#149bda' } else { '#dc8a0e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d8137f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/ura.nu
+++ b/themes/nu-themes/ura.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#84eeb9' } else { '#c26f1b' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c21b6f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/urple.nu
+++ b/themes/nu-themes/urple.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#eaeaea' } else { '#ad5c42' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b0425b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/vag.nu
+++ b/themes/nu-themes/vag.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3b76b0' } else { '#71a839' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a87139' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/vaughn.nu
+++ b/themes/nu-themes/vaughn.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#93e0e3' } else { '#dfaf8f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#705050' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/vibrant-ink.nu
+++ b/themes/nu-themes/vibrant-ink.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00ffff' } else { '#ffcc00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff6600' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/vs-code-dark-plus.nu
+++ b/themes/nu-themes/vs-code-dark-plus.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5fffff' } else { '#e5b684' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e9653b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/vulcan.nu
+++ b/themes/nu-themes/vulcan.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#977d7c' } else { '#adb4b9' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#818591' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/warm-neon.nu
+++ b/themes/nu-themes/warm-neon.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#5ed1e5' } else { '#dae145' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e24346' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/wez.nu
+++ b/themes/nu-themes/wez.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#55ffff' } else { '#cdcd55' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#cc5555' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/wild-cherry.nu
+++ b/themes/nu-themes/wild-cherry.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ff919d' } else { '#ffd16f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d94085' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/windows-10-light.nu
+++ b/themes/nu-themes/windows-10-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#3a96dd' } else { '#c19c00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#c50f1f' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/windows-10.nu
+++ b/themes/nu-themes/windows-10.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#61d6d6' } else { '#f9f1a5' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#e74856' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/windows-95-light.nu
+++ b/themes/nu-themes/windows-95-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00a8a8' } else { '#a85400' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#a80000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/windows-95.nu
+++ b/themes/nu-themes/windows-95.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#54fcfc' } else { '#fcfc54' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fc5454' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/windows-highcontrast-light.nu
+++ b/themes/nu-themes/windows-highcontrast-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#008080' } else { '#808000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#800000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/windows-highcontrast.nu
+++ b/themes/nu-themes/windows-highcontrast.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#54fcfc' } else { '#fcfc54' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#fc5454' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/windows-nt-light.nu
+++ b/themes/nu-themes/windows-nt-light.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#008080' } else { '#808000' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#800000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/windows-nt.nu
+++ b/themes/nu-themes/windows-nt.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00ffff' } else { '#ffff00' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff0000' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/wombat.nu
+++ b/themes/nu-themes/wombat.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#b7fff9' } else { '#ebd99c' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#ff615a' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/woodland.nu
+++ b/themes/nu-themes/woodland.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#6eb958' } else { '#e0ac16' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#d35c5c' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/wryan.nu
+++ b/themes/nu-themes/wryan.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#6096bf' } else { '#7c7c99' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#8c4665' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/xcode-dusk.nu
+++ b/themes/nu-themes/xcode-dusk.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#00a0be' } else { '#438288' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#b21889' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/yachiyo.nu
+++ b/themes/nu-themes/yachiyo.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#ff9c9c' } else { '#d4b34e' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#86b79b' attr: 'b' }
             } else if $in < 6hr {

--- a/themes/nu-themes/zenburn.nu
+++ b/themes/nu-themes/zenburn.nu
@@ -18,7 +18,7 @@ export def main [] {
 
         bool: {|| if $in { '#93e0e3' } else { '#e0cf9f' } }
 
-        date: {|| (date now) - $in |
+        datetime: {|| (date now) - $in |
             if $in < 1hr {
                 { fg: '#dca3a3' attr: 'b' }
             } else if $in < 6hr {


### PR DESCRIPTION
In Nushell 0.104.0, `date` are now `datetime` ([see blog](https://www.nushell.sh/blog/2025-04-29-nushell_0_104_0.html#date-is-now-datetime-toc)).

I just change all `date` prop to `datetime` in all themes to fix them