### PR TITLE
Fix when lftp bookmark file is not readable

### DIFF
--- a/custom-completions/lftp/lftp-completions.nu
+++ b/custom-completions/lftp/lftp-completions.nu
@@ -73,7 +73,8 @@ module lftp-completion-utils {
 
     export def get-bookmark-sites []: nothing -> table<value: string, description: string> {
       const FILE_PATH = '~/.local/share/lftp/bookmarks' | path expand
-      let sites = open --raw $FILE_PATH | lines | split column -n 2 -r \s+ value description
+      let sites = try { open --raw $FILE_PATH | lines } catch { [] }
+        | split column -n 2 -r \s+ value description
       $sites | update value { $"bm:($in)" }
     }
 }


### PR DESCRIPTION
Sorry, in the #1113 , I forgot to test the case that `lftp`'s bookmark file is not readable.