### PR TITLE
Fixed `rusty-paths.nu` entering into rust folder

### DIFF
--- a/nu-hooks/nu-hooks/rusty-paths/rusty-paths.nu
+++ b/nu-hooks/nu-hooks/rusty-paths/rusty-paths.nu
@@ -23,7 +23,7 @@ $env.config = ($env.config | upsert hooks.env_change.PWD {
 		}
 	}
   | append {
-		condition: {|before, _| ($before | default '' | path join 'Cargo.lock' | path exists) }
+		condition: {|before, _| ($before | default '' | path join 'Cargo.lock' | path exists) and ($before | is-not-empty)}
 		code: {|before, _|
 			$env.PATH = (
 				$env.PATH


### PR DESCRIPTION
When starting a new shell session inside a rust folder you'd get this error:

![image](https://github.com/user-attachments/assets/dd6ad06c-fc82-4a92-b0cd-18e41c1d3254)

This pr fixes this issue.

Entering a folder without having a previous folder happen when you for example start a new terminal or starts a multiplexer already inside that folder.