### PR TITLE
Prepend INCLUDE env, instead of override

### DIFF
--- a/modules/virtual_environments/nu_msvs/nu_msvs.nu
+++ b/modules/virtual_environments/nu_msvs/nu_msvs.nu
@@ -162,12 +162,8 @@ export def --env activate [
   }
   load-env {
     $env.PATH_VAR: $env_path,
-    INCLUDE: (if $env.INCLUDE_BEFORE == null {
-      $env.MSVS_INCLUDE_PATH
-    } else {
-      $env.MSVS_INCLUDE_PATH | append $env.INCLUDE_BEFORE
-    }),
-    LIB: $lib_path
+    INCLUDE: ($env.MSVS_INCLUDE_PATH | append $env.INCLUDE_BEFORE),
+    LIB: $lib_path,
   }
 
   # Debug Information

--- a/modules/virtual_environments/nu_msvs/nu_msvs.nu
+++ b/modules/virtual_environments/nu_msvs/nu_msvs.nu
@@ -2,6 +2,7 @@ def --env find_msvs [] {
   export-env {
     $env.MSVS_BASE_PATH = $env.Path
     $env.PATH_VAR = (if "Path" in $env { "Path" } else { "PATH" })
+    $env.INCLUDE_BEFORE = ($env.INCLUDE | split row (char esep))
 
     # According to https://github.com/microsoft/vswhere/wiki/Installing, vswhere should always be in this location.
     let vswhere_cmd = ($'($env."ProgramFiles(x86)")\Microsoft Visual Studio\Installer\vswhere.exe')
@@ -37,7 +38,7 @@ def --env find_msvs [] {
       $'($env.MSVS_MSDK_ROOT)Include\($env.MSVS_MSDK_VER)\ucrt',
       $'($env.MSVS_MSDK_ROOT)Include\($env.MSVS_MSDK_VER)\um',
       $'($env.MSVS_MSDK_ROOT)Include\($env.MSVS_MSDK_VER)\winrt'
-    ] | str join (char esep))
+    ] | append $env.INCLUDE_BEFORE | str join (char esep))
 
     let esep_path_converter = {
       from_string: { |s| $s | split row (char esep) }
@@ -179,10 +180,11 @@ export def --env deactivate [] {
 
   load-env {
     $env.PATH_VAR: $env.MSVS_BASE_PATH,
+    INCLUDE: ($env.INCLUDE_BEFORE | path expand | str join (char esep)),
   }
 
-  hide-env INCLUDE
   hide-env LIB
+  hide-env INCLUDE_BEFORE
   hide-env MSVS_BASE_PATH
   hide-env MSVS_ROOT
   hide-env MSVS_MSVC_ROOT


### PR DESCRIPTION
This small fix prepends the `INCLUDE` environment variable instead of overriding it.

This is important if one has already added paths to this environment, for example, in cases where one needs a common set of codebase that gets included in all C/C++ projects (such as utility functions and such).