### PR TITLE
Fix error in non-home paths

### DIFF
--- a/modules/prompt/panache-git.nu
+++ b/modules/prompt/panache-git.nu
@@ -29,7 +29,7 @@ export def current-dir [] {
   let current_dir = ($env.PWD)
 
   let current_dir_relative_to_home = (
-    do --ignore-errors { $current_dir | path relative-to $nu.home-path } | str join
+    do --ignore-errors { $current_dir | path relative-to $nu.home-path  | str join }
   )
 
   let in_sub_dir_of_home = ($current_dir_relative_to_home | is-not-empty)


### PR DESCRIPTION
Before it would fail in paths outside the home directory with

```
 × Pipeline empty.
    ╭─[/home/filipp/.config/nushell/panache-git.nu:32:76]
 31 │   let current_dir_relative_to_home = (
 32 │     do --ignore-errors { $current_dir | path relative-to $nu.home-path } | str join
    ·                                                                            ────┬───
    ·                                                                                ╰── no input value was piped in
 33 │   )
    ╰────
```