### PR TITLE
fix(npm): update incompatible npm scripts

### DIFF
--- a/custom-completions/npm/npm-completions.nu
+++ b/custom-completions/npm/npm-completions.nu
@@ -1,4 +1,4 @@
-def "nu-complete npm db cache" [] {
+def "nu-complete npm" [] {
   let db = stor open
 
   try {
@@ -20,7 +20,7 @@ def "nu-complete npm db cache" [] {
 }
 
 export extern "npm" [
-  command?: string@"nu-complete npm db cache"
+  command?: string@"nu-complete npm"
 ]
 
 def "nu-complete npm run" [] {


### PR DESCRIPTION
I use Nushell and npm, and noticed that the npm section hasn't been updated for a long time, to the point where it no longer works with current npm versions. In fact, the current script produces the following result:
![image](https://github.com/user-attachments/assets/272a6a37-c623-452a-94ab-2f3c0ee54beb)

So I've updated the npm-related scripts to fix this issue. Now it works correctly:
![image](https://github.com/user-attachments/assets/fcf8b590-0ede-4571-bd52-611cf4c9fdd3)


Additionally, since npm -l | lines generates over 900 lines of output, this causes each run to take a long time (at least on my machine). Therefore, I've implemented caching using stor to store the results, which significantly reduces the execution time for subsequent calls. With caching enabled, the delay is now barely noticeable.