### PR TITLE
Strip ANSI from the main branch name

### DIFF
--- a/aliases/git/git-aliases.nu
+++ b/aliases/git/git-aliases.nu
@@ -9,6 +9,7 @@ export def git_main_branch [] {
         | str trim
         | find --regex 'HEAD .*?[：: ].+'
         | first
+        | ansi strip
         | str replace --regex 'HEAD .*?[：: ]\s*(.+)' '$1'
 }
 


### PR DESCRIPTION
`find` highlights the returned value,
which breaks the `gcm` macro,
it returns 
```
error: pathspec '?[37m?[0m?[41;37mmain?[0m?[37m?[0m' did not match any file(s) known to git
```

I opted in to using `ansi strip` instead of `--no-highlight`, because I think it covers wider range of nu shell versions