### PR TITLE
Fix custom completion for `pass` by converting the path pattern string to glob

### DIFF
--- a/custom-completions/pass/nu-complete/mod.nu
+++ b/custom-completions/pass/nu-complete/mod.nu
@@ -8,7 +8,7 @@ def pass_completions_directory [] {
 
 export def "nu-complete pass-files" [] {
     let dir = (pass_completions_directory)
-	ls ($dir | path join "**" | path join "*.gpg")
+	ls ($dir | path join "**" | path join "*.gpg" | into glob)
 		| get name 
 		| each {|it| ( $it
             | path relative-to $dir


### PR DESCRIPTION
Password file completion for `pass` no longer worked as the pattern was passed to `ls` as a string.
Fixed it by converting the pattern to a glob.