### PR TITLE
fix(winget-completion): update for nu 0.106.0

### DIFF
--- a/custom-completions/winget/winget-completions.nu
+++ b/custom-completions/winget/winget-completions.nu
@@ -90,10 +90,10 @@ def "nu-complete winget parse table" [lines: any] {
     let lengths = {
         name: ($header.name | str length),
         id: ($header.id | str length),
-        version: ($header.version | str length),
-        match: ($header.match | str length),
-        available: ($header.available | str length),
-        source: ($header.source | str length)
+        version: ($header.version | default "" | str length),
+        match: ($header.match | default "" | str length),
+        available: ($header.available | default "" | str length),
+        source: ($header.source | default "" | str length)
     }
     $lines | skip 2 | each { |it|
         let it = ($it | split chars)


### PR DESCRIPTION
because of [new changes](https://www.nushell.sh/blog/2025-07-23-nushell_0_106_0.html#parse-unmatched-optional-capture-groups-are-now-null-toc) to `parse`. winget completion throws error.  This pr fixes that by providing default value for optional parameters. 