### PR TITLE
feat: add new cargo aliases and fix autocompletion

### DIFF
--- a/custom-completions/cargo/cargo-completions.nu
+++ b/custom-completions/cargo/cargo-completions.nu
@@ -30,7 +30,7 @@ def "nu-complete cargo features" [] {
 # `cargo --list` is slow, `open` is faster.
 # TODO: Add caching.
 def "nu-complete cargo subcommands" [] {
-  ^cargo --list | lines | skip 1 | str join "\n" | from ssv --noheaders | get column1
+  ^cargo --list | lines | skip 1 | str join "\n" | from ssv --noheaders | get column0
 }
 def "nu-complete cargo vcs" [] {
   [
@@ -584,3 +584,11 @@ export extern "cargo add" [
   --target                # Add as dependency to the given target platform
   ...args
 ]
+
+# Cargo aliases
+export alias "cargo b"  = cargo build
+export alias "cargo c"  = cargo check
+export alias "cargo d"  = cargo doc
+export alias "cargo r"  = cargo run
+export alias "cargo rm" = cargo remove
+export alias "cargo t"  = cargo test


### PR DESCRIPTION
Added official Cargo aliases locally:
- b  -> cargo build
- c  -> cargo check
- d  -> cargo doc
- r  -> cargo run
- rm -> cargo remove
- t  -> cargo test

These aliases already exist in Cargo; this just adds convenient shortcuts.

Fixed the Nushell cargo autocompletion function: changed from 'column1' to 'column0' so that subcommands are correctly suggested instead of returning nothing.