### PR TITLE
fix(scoop-completion): mark `scoop cache rm` apps parameter as optional

### DIFF
--- a/custom-completions/scoop/scoop-completions.nu
+++ b/custom-completions/scoop/scoop-completions.nu
@@ -679,7 +679,7 @@ export extern "scoop cache show" [
 
 # Clear the download cache
 export extern "scoop cache rm" [
-  apps: string@scoopInstalledAppsWithStar # apps in question
+  apps?: string@scoopInstalledAppsWithStar # apps in question
   --all (-a) # Clear all apps (alternative to '*')
 ]
 


### PR DESCRIPTION
It doesn’t make sense having to pass `apps` when the `--all` parameter is on.