### PR TITLE
Allow wildcard expansion in eza completions

### DIFF
--- a/custom-completions/eza/eza-completions.nu
+++ b/custom-completions/eza/eza-completions.nu
@@ -41,8 +41,6 @@ def "nu-complete eza color-scale-mode" [] {
 	eza --long --tree --level=3
 }
 export extern "eza" [
-    path?: path                                             # folder to list
-
     --help(-?)                                              # show list of command-line options
     --version(-v)                                           # show version of eza
 


### PR DESCRIPTION
I noticed that when I copy `custom-completions/eza/eza-completions.nu` into my `autoload` dir, then wildcards don't work any more. For example, in a folder that contains nu scripts, the command

```nu
eza *.nu
```

Produces an error `"*.nu" file not found` instead of listing all the nu scripts.

The problem seems to be with `path?` argument. nushell does not expand wildcards for arguments of the `path` type and sends `*.nu` as is to the command. Moreover, `path` is only a single parameter, while eza can accept a list of file or folder arguments.

---

For the reference, nushell own `ls -h` uses different argument type:

```
Parameters:
  ...pattern <oneof<glob, string>>: The glob pattern to use.
```

So, one solution could have been modifying the `path` argument to a similar signature.

However, `export extern` seems to be doing something similar by default for all unspecified arguments anyway. So, a simpler solution is to get rid of the `path` argument altogether and rely on the default behaviour. 