### PR TITLE
Twin Script Updates

### DIFF
--- a/make_release/this_week_in_nu_weekly.nu
+++ b/make_release/this_week_in_nu_weekly.nu
@@ -84,7 +84,7 @@ def generate-twin [
 
                 for pr in $user.prs {
                     $twin_text += $"
-                      - [($pr.title) \(#($pr.number)]\)\(($pr.url)\)
+                      - [($pr.title) \(#($pr.number)\)]\(($pr.url)\)
 
                     " | str dedent
                 }

--- a/make_release/twin-tweaks.nu
+++ b/make_release/twin-tweaks.nu
@@ -1,6 +1,15 @@
-def "twin format" [filename] {
+def "twin format" [filename?] {
   use std/clip
   use std-rfc/str
+
+  let input = $in
+
+  let twin_content = (
+    match $filename {
+      null => $input
+      _ => { open --raw $filename }
+    }
+  )
 
   {
     Authorization: $'Bearer (kv get -u OPENROUTER_API_KEY)'
@@ -11,7 +20,7 @@ def "twin format" [filename] {
     Rewrite the following auto-generated changelog so it's more natural. For example, change things like 'rgwood created [Bump dependencies...' to 'rgwood [bumped dependencies...'. Keep the inline links. Make sure to keep ALL original URLs! When returning the text, do not include any explaination of the change or the surrounding backticks around the result:
 
     ```
-    (open --raw $filename)
+    ($twin_content)
     ```
   "
   | str unindent


### PR DESCRIPTION
* Fixes an issue with PR brackets in the generation of TWiN
* Adds the ability to accept TWiN as input rather than just a file. This allows a single step:

  ```nushell
  generate-twin | twin format | save 2025-09-19-twin0317.md
  ```