### PR TITLE
Add `winget upgrades` command

### DIFF
--- a/custom-completions/winget/winget-completions.nu
+++ b/custom-completions/winget/winget-completions.nu
@@ -341,10 +341,14 @@ export def "winget list" [
 export alias "winget ls" = winget list
 
 def "winget upgrades" [] {
-    let output = ^winget upgrade | nu-complete winget trimLoadingSymbol | lines
+    let output = ^winget upgrade | nu-complete winget trimLoadingSymbol
     
-    let head = $output | first
-    let rest = $output | skip 2
+    # Do nothing when no upgrades available
+    if ( ($output | str starts-with 'No') or ($output | str starts-with '0') ) { return }
+    
+    let lines = $output | lines
+    let head = $lines | first
+    let rest = $lines | skip 2
     
     let colnames = [ Name Id Version Available Source ]
     # We must be unicode aware in determining and using index; winget uses `…` elippses to hide overflow


### PR DESCRIPTION
`winget upgrade` has two modes:

* No parameters (at all) lists available upgrades
* Any parameter attempts to match and upgrade a package

Much like `winget list`, `winget upgrade` prints a spinner, then a table, and then additionally a footer.

The `winget list` completions handle output through `detect columns --guess` and return structured data.

Presumably because `detect columns --guess` does not work on `winget upgrade`, no output handling was done until now.

1. Split off trimLoadingSymbol as a common function between two, now three, commands
2. Implement a separate command `winget upgrades` instead of handling `winget upgrade` because of overloaded behavior complicating implementation

Now, `winget upgrades` can be used to get structured data of available upgrades, while `winget upgrade` behaves like before, without parameters has text output, and with parameters upgrades packages.

While introducing a separate command is not strictly completions [for external commands], this one is very close to the completions, logic, and use cases. Keeping it close will help discovery and future development which may integrate returning structured data into the "normal" completions.

---

I was not able to test for “no updates” output.

---

```nushell
winget upgrades
# => ╭───┬──────────────────────────────────┬─────────────────────┬───────────────────────────────┬───────────────────────────────┬────────╮
# => │ # │               name               │         id          │            version            │           available           │ source │
# => ├───┼──────────────────────────────────┼─────────────────────┼───────────────────────────────┼───────────────────────────────┼────────┤
# => │ 0 │ Go Programming Language amd64 g… │ GoLang.Go           │ 1.25.1                        │ 1.25.2                        │ winget │
# => ╰───┴──────────────────────────────────┴─────────────────────┴───────────────────────────────┴───────────────────────────────┴────────╯
```