### PR TITLE
fix(git): git worktree add - branch is optional

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -787,7 +787,7 @@ export extern "git worktree" [
 # create a new working tree
 export extern "git worktree add" [
   path: path            # directory to clone the branch
-  branch: string@"nu-complete git available upstream" # Branch to clone
+  branch?: string@"nu-complete git available upstream" # Branch to clone
   --help(-h)            # display the help message for this command
   --force(-f)           # checkout <branch> even if already checked out in other worktree
   -b                    # create a new branch


### PR DESCRIPTION
Fix #1153

The completion script wrongly made the `branch` argument required, blocking Nushell from loading when both `git-completions.nu` and `git-aliases.nu` are used.