### PR TITLE
feat(task.nu): Trim `|` from the closure

### DIFF
--- a/modules/background_task/task.nu
+++ b/modules/background_task/task.nu
@@ -52,6 +52,7 @@ export def spawn [
   (
     view source $command
     | str trim --left --char "{"
+    | str trim --left --char "|"
     | str trim --right --char "}"
   )
   | save --force $source_path


### PR DESCRIPTION
Also trim pipe characters (`|`) so it doesn't error out if the closure is defined with empty args.
```nu
let $task = {||
	...
}
```