### PR TITLE
fix(kubernetes): syntax for custom completions - <shape>@<completer>

### DIFF
--- a/modules/kubernetes/resources.nu
+++ b/modules/kubernetes/resources.nu
@@ -3,7 +3,7 @@ use complete *
 ### refine kubernetes resources
 export def kube-refine [
     ...namespace: string@"nu-complete kube ns"
-    --kind(-k): list<string@"nu-complete kube kind">
+    --kind(-k): list<string>@"nu-complete kube kind"
 ] {
     use lg
     let config = $env.KUBERNETES_REFINE


### PR DESCRIPTION
```
Error: nu::parser::unclosed_delimiter

  × Unclosed delimiter.
   ╭─[/nix/store/2vdywiymhxd8dl4xfflpix5nrpky6b2i-source/modules/kubernetes/resources.nu:6:17]
 5 │     ...namespace: string@"nu-complete kube ns"
 6 │     --kind(-k): list<string@"nu-complete kube kind">
   ·                 ─────┬─────
   ·                      ╰── unclosed >
 7 │ ] {
   ╰────
```