### PR TITLE
panache-git: fix bugs showing modified files and non-home dirs

### DIFF
--- a/modules/prompt/panache-git.nu
+++ b/modules/prompt/panache-git.nu
@@ -29,7 +29,7 @@ export def current-dir [] {
   let current_dir = ($env.PWD)
 
   let current_dir_relative_to_home = (
-    do --ignore-errors { $current_dir | path relative-to $nu.home-path  | str join }
+    do --ignore-errors { $current_dir | path relative-to $nu.home-path }
   )
 
   let in_sub_dir_of_home = ($current_dir_relative_to_home | is-not-empty)
@@ -159,8 +159,8 @@ export def repo-structured [] {
   let staging_worktree_table = (if $has_staging_or_worktree_changes {
     $status
     | where ($it | str starts-with '1') or ($it | str starts-with '2')
-    | split column ' '
-    | get column2
+    | split column ' ' col1 sw
+    | get sw
     | split column '' staging worktree --collapse-empty
   } else {
     [[]]


### PR DESCRIPTION
This PR fixes two bugs in the panache-git prompt:

First, modified file counts were not being properly shown after updating to Nushell v0.109, which contained a breaking change in `split column`: https://www.nushell.sh/blog/2025-11-29-nushell_v0_109_0.html#switch-split-column-to-0-index-like-other-commands-toc

panache-git relied on the old default column names when splitting columns to count modified files. This has been fixed with explicit column names so that the default names no longer matter.

Second, when the current working directory was outside the home directory, panache-git would throw an error.

The code was attempting to join path strings that didn't exist, and the `str join` in question turned out to be unnecessary, so it was removed, avoiding the error.