### PR TITLE
fix(fnm): simplify config and respect package.json

### DIFF
--- a/modules/fnm/fnm.nu
+++ b/modules/fnm/fnm.nu
@@ -1,25 +1,8 @@
 export-env {
-  def fnm-env [] {
-    mut env_vars = {}
-    let pwsh_vars = (
-      ^fnm env --shell power-shell | lines | parse "$env:{key} = \"{value}\""
-    )
-
-    # fnm-prefixed vars
-    for v in ($pwsh_vars | slice 1..) {
-      $env_vars = ($env_vars | insert $v.key $v.value)
-    }
-
-    # path
-    let env_used_path = ($env | columns | where { str downcase | $in == "path" } | get 0)
-    let path_value = ($pwsh_vars | get 0.value | split row (char esep))
-    $env_vars = ($env_vars | insert $env_used_path $path_value)
-
-    return $env_vars
-  }
-
   if not (which fnm | is-empty) {
-    fnm-env | load-env
+    ^fnm env --json | from json | load-env
+
+    $env.PATH = $env.PATH | prepend ($env.FNM_MULTISHELL_PATH | path join (if $nu.os-info.name == 'windows' {''} else {'bin'}))
 
     $env.config = (
       $env.config?
@@ -32,11 +15,13 @@ export-env {
       $env.config.hooks.env_change.PWD | any { try { get __fnm_hook } catch { false } }
     )
     if not $__fnm_hooked {
+      let version_files = [.nvmrc .node-version package.json]
+
       $env.config.hooks.env_change.PWD = (
         $env.config.hooks.env_change.PWD | append {
           __fnm_hook: true
           code: {|before, after|
-            if ('FNM_DIR' in $env) and ([.nvmrc .node-version] | path exists | any {|it| $it }) {
+            if ('FNM_DIR' in $env) and ($version_files | path exists | any {|it| $it }) {
               ^fnm use
             }
           }


### PR DESCRIPTION
- Simplify fnm config parsing: it can be done with json output.
- Add `package.json` file as a trigger. It can specify node version as well.

Based on improvements from https://github.com/Schniz/fnm/issues/463 