### PR TITLE
Blank lines around headings in generated release notes

### DIFF
--- a/make_release/notes/create-pr.nu
+++ b/make_release/notes/create-pr.nu
@@ -52,6 +52,7 @@ by opening PRs against the `release-notes-($version)` branch.
 - [ ] add the full changelog
 - [ ] categorize each PR
 - [ ] write all the sections and complete all the `TODO`s
+
 [deprecations]: https://github.com/nushell/nushell/labels/deprecation
 [removals]: https://github.com/nushell/nushell/pulls?q=is%3Apr+is%3Aopen+label%3Aremoval-after-deprecation"
 


### PR DESCRIPTION
Add blank lines around headings in generated release notes (or rather, add blank lines *after* bodies).

The change to `create-pr.nu` is unrelated. I just noticed that the refs were being considered part of the list by GitHub's Markdown parser, so I added a blank line to separate them.

## Testing

Used to generate the release notes for the v0.110.0 release: https://github.com/nushell/nushell.github.io/pull/2108 (specifically this commit: https://github.com/nushell/nushell.github.io/pull/2108/changes/f159656b92227d2d45967696938bded2dcaf0fbe)