### PR TITLE
Use path-columns in result metadata hook

### DIFF
--- a/modules/result/mod.nu
+++ b/modules/result/mod.nu
@@ -16,7 +16,7 @@ def display [
     meta: record = {}
 ] {
     # the metadata *MUST* be set *FIRST* since the output of `table` is just a string
-    if $meta.source? == ls { metadata set --datasource-ls } else {}
+    if $meta.source? == ls { metadata set --path-columns [name] } else {}
     | if (term size).columns >= 100 { table -e } else { table }
 }
 


### PR DESCRIPTION
## Summary
- replace deprecatedmetadata set --datasource-l withmetadata set --path-columns [name in the result module display hook
- preserve path-aware rendering forl output while matching the current Nushell metadata API

## Why
Nushell now warns that--datasource-l is deprecated and recommends--path-columns [name instead.