### PR TITLE
TWiN formatting using Deepseek V4 Flash

### DIFF
--- a/make_release/twin-tweaks.nu
+++ b/make_release/twin-tweaks.nu
@@ -12,12 +12,20 @@ def "twin format" [filename?] {
   )
 
   {
-    Authorization: $'Bearer (kv get -u OPENROUTER_API_KEY)'
+    Authorization: $'Bearer ($env.OPENROUTER_API_KEY)'
   }
   | kv set headers
 
   $"
-    Rewrite the following auto-generated changelog so it's more natural. For example, change things like 'rgwood created [Bump dependencies...' to 'rgwood [bumped dependencies...'. Keep the inline links. Make sure to keep ALL original URLs! When returning the text, do not include any explaination of the change or the surrounding backticks around the result:
+    Rewrite the following auto-generated changelog so it's more natural. For example,
+    change things like 'rgwood created [Bump dependencies...' to 'rgwood [bumped dependencies...'.
+    Keep the inline links. Make sure to keep ALL original URLs! Keep the list structure with
+    the top level list item being the contributor, and the sublist with one PR as each list item.
+
+    Move the 'nushell' repo so that it is the first section (## second level heading).
+        
+    Always move dependabot contributor to the last position in each section. When returning the text,
+    do not include any explaination of the change or the surrounding backticks around the result:
 
     ```
     ($twin_content)
@@ -33,7 +41,8 @@ def "twin format" [filename?] {
   | kv set message
 
   {
-    model: 'deepseek/deepseek-chat-v3-0324'
+    # model: 'deepseek/deepseek-chat-v3-0324'
+    model: 'deepseek/deepseek-v4-flash'
     messages: [ (kv drop message) ]
   }
   | kv set body


### PR DESCRIPTION
* The `twin-tweaks` script now uses the new Deepseek V4 Flash by default.
* Prompt adjusted to:
  * Be more explicit about formatting (should work with more models now)
  * Keep the Nushell repo at the top of the list, no matter which repo received the first commits in the week.
  * Move dependabot to the bottom of each list. Previously, I was doing this manually each week.