### PR TITLE
Posix command wrappers

### DIFF
--- a/aliases/posix/blkid-aliases.nu
+++ b/aliases/posix/blkid-aliases.nu
@@ -1,0 +1,3 @@
+export def --wrapped blkid [...rest] {
+    ^blkid ...$rest|lines|each {split column ':'|update column2 {str replace -a '" ' "\"\n"|from toml}|flatten }|flatten|rename DEVICE|update BLOCK_SIZE {into int}
+}

--- a/aliases/posix/df-aliases.nu
+++ b/aliases/posix/df-aliases.nu
@@ -1,0 +1,7 @@
+export def --wrapped df [...rest] {
+    ^df ...$rest| from ssv -m 1 |
+    update Available {|| ($in | into int ) / 1024 * 1000000 | into filesize} |
+    update Used      {|| ($in | into int ) / 1024 * 1000000 | into filesize} |
+    update "1K-blocks" {|| ($in | into int ) / 1024 * 1000000 | into filesize} |
+    update Use% {|| str trim -rc '%'|into int}
+}

--- a/aliases/posix/flatpak-aliases.nu
+++ b/aliases/posix/flatpak-aliases.nu
@@ -1,0 +1,3 @@
+extern def --wrapped "flatpak list" [...rest] {
+    ^flatpak list ...$rest|from tsv -n --no-infer|rename name package version branch origin installation
+}

--- a/aliases/posix/ldd-aliases.nu
+++ b/aliases/posix/ldd-aliases.nu
@@ -1,0 +1,3 @@
+export def ldd [...rest] {
+    ^ldd ...$rest|parse --regex "\\s*(?P<lib>\\S+?) => (?P<path>\\S+?) \\((?P<addr>\\S+?)\\)"|update addr {|| into int }
+}

--- a/aliases/posix/lsmod-aliases.nu
+++ b/aliases/posix/lsmod-aliases.nu
@@ -1,0 +1,3 @@
+def --wrapped lsmod [...rest] {
+    ^lsmod ...$rest|from ssv -m 1|rename module size n used-by|default '' used-by|update size {|| into int}|update n {|| into int}|update used-by {|| split row ,}
+}

--- a/modules/fsattr/mod.nu
+++ b/modules/fsattr/mod.nu
@@ -1,0 +1,92 @@
+# This module wraps the `getfattr` and `setfattr` commands (Debian package is `attr`), to allow for convenient modification of file tags, rating, and comments.
+
+export def 'attr get' [path] {
+    let output = getfattr -dm '' -- $path;
+
+    if not ($output|is-empty) {
+        $output|from toml
+    } else {
+        {}
+    }
+}
+
+export def 'attr set' [path, name, value] {
+    setfattr -n $name -v $value -- $path
+}
+
+export def 'attr remove' [path, name] {
+    setfattr -x $name -- $path
+}
+
+# List all the tags in this directory
+export def 'tags here' [path = '.'] {
+    ls $path | reduce --fold [] {|it, acc| $acc | append (try {tags list $it.name}) }|uniq
+}
+
+# List all the tags on a file
+export def 'tags list' [path] {
+    let tags = attr get $path|get --optional user.xdg.tags;
+
+    if $tags != null {
+        $tags | split row ','
+    } else {
+        []
+    }
+}
+
+# Add a tag to a file
+export def 'tags add' [path, name] {
+    let existing = tags list $path;
+    attr set $path 'user.xdg.tags' ($existing | append $name | str join ',');
+}
+
+# Remove a tag from a file
+export def 'tags remove' [path, name] {
+    let existing = tags list $path;
+    let indices  = ($existing|enumerate|where item == $name|get index);
+    let result   = if not ($indices|is-empty) { $existing|drop nth ($indices|first) } else { $existing };
+    attr set $path 'user.xdg.tags' ($result | str join ',');
+}
+
+# Get the rating for a file
+export def rating [path]: nothing -> int {
+    let score = attr get $path|get --optional user.baloo.rating;
+    return ($score|if ($in|is-not-empty) {into int});
+}
+
+# Set the rating for a file
+export def 'rating set' [
+    path,
+    score: int  # Must be between 1 and 10.
+] {
+    attr set $path 'user.baloo.rating' ($score|into string)
+}
+
+alias rate = rating set;    # FIXME: Name may clash with something
+
+# Remove the rating from a file
+export def 'rating remove' [path] {
+    attr remove $path 'user.baloo.rating'
+}
+
+# Sets a file's comment if a message is provided, else gets it.
+export def comment [path, message?] {
+    if ($message|is-empty) {
+        return (attr get $path|get --optional user.xdg.comment)
+    } else {
+        attr set $path 'user.xdg.comment' $message;
+    }
+}
+
+# TODO: Consider adding glob support, https://www.nushell.sh/book/moving_around.html#glob-patterns-wildcards
+
+# export def --wrapped 'ls attr' [...rest] {
+
+# Extension that adds fs attributes to `ls` command
+@example "Pipe the output of `ls` through this command" { ls | with attr }
+export def 'with attr' [] {
+    $in
+    | insert rating  {|row| rating $row.name}
+    | insert tags    {|row| tags list $row.name}
+    | insert comment {|row| comment $row.name}
+}


### PR DESCRIPTION
I've written some wrapper functions for common linux commands like `df` and `flatpak list` that parse their output. They're not aliases per-se, but that seemed to be the closest directory for them so I've put them into `aliases/posix/`.

I've also added a module containing my functions for modifying filesystem tags, comments, and ratings in `modules/fsattr/`.