### PR TITLE
fix(scoop): handle non-UTF-8 encoding in scoop list output

### DIFF
--- a/custom-completions/scoop/scoop-completions.nu
+++ b/custom-completions/scoop/scoop-completions.nu
@@ -166,21 +166,17 @@ export extern "scoop" [
 ################################################################
 # scoop list
 ################################################################
-
-# Lists all installed apps, or the apps matching the supplied query.
 export def "scoop list" [
-  query?: string@scoopInstalledApps # string that will be matched
+  query?: string@scoopInstalledApps
 ] {
-  ^scoop list ($query | default "")
-  | complete
-  | if $in.exit_code == 0 {
-    $in.stdout
+  let result = (^scoop list ($query | default "") | complete)
+  if $result.exit_code == 0 {
+    ($result.stdout | decode utf-8)
     | lines
     | skip 4
     | parse -r '(?P<name>\S+)\s+(?P<version>\S+)\s+(?P<source>\S+)\s+(?P<updated>\S+\s+\S+)\s+(?P<info>\S+)?'
   }
 }
-
 ################################################################
 # scoop uninstall
 ################################################################


### PR DESCRIPTION
## Description

Fix tab completion failure for 'scoop list' on Windows when scoop output contains non-UTF-8 characters.

## Problem

On Windows with non-UTF-8 locales (e.g., Chinese Windows using GBK encoding), the `scoop list` command may output text in the system's local encoding, causing the completion to fail silently.

## Solution

Use `decode utf-8` to properly handle the output encoding, ensuring the completion works correctly regardless of locale settings.

## Testing

Tested on Windows with Chinese locale where scoop outputs GBK-encoded text.