### PR TITLE
Refactor output handling of `task log` in `task.nu`

### DIFF
--- a/modules/background_task/task.nu
+++ b/modules/background_task/task.nu
@@ -326,9 +326,9 @@ export def log [
     )
 
     if $detailed {
-      $full
+      $full | move --last status
     } else {
-      $full | select id label group Done? status? start? end?
+      $full | select id label group status
     }
   }
 


### PR DESCRIPTION
Removed `Done`, `start` and `end` from the short `task log` since they are always empty because they are inside the `status` field. Also moved the `status` field to the end of the detailed output so you will be able to see it at a glance at the end when the output grows more than the terminal size.