### PR TITLE
fix: support git add completion for file name that contains whitespace

### DIFF
--- a/custom-completions/git/git-completions.nu
+++ b/custom-completions/git/git-completions.nu
@@ -238,11 +238,11 @@ def "nu-complete git files" [path?: string] {
   | first 300             # limit the number of data for performance
   | each { |$it|
     if $it starts-with "1 " {
-      $it | parse --regex "1 (?P<short_status>\\S+) (?:\\S+\\s?){6} (?P<value>\\S+)"
+      $it | parse --regex "1 (?P<short_status>\\S+) (?:\\S+\\s?){6} (?P<value>.+)"
     } else if $it starts-with "2 " {
-      $it | parse --regex "2 (?P<short_status>\\S+) (?:\\S+\\s?){6} (?P<value>\\S+)"
+      $it | parse --regex "2 (?P<short_status>\\S+) (?:\\S+\\s?){6} (?P<value>.+)"
     } else if $it starts-with "u " {
-      $it | parse --regex "u (?P<short_status>\\S+) (?:\\S+\\s?){8} (?P<value>\\S+)"
+      $it | parse --regex "u (?P<short_status>\\S+) (?:\\S+\\s?){8} (?P<value>.+)"
     } else if $it starts-with "? " {
       $it | parse --regex "(?P<short_status>.{1}) (?P<value>.+)"
     } else {
@@ -251,6 +251,7 @@ def "nu-complete git files" [path?: string] {
   }
   | flatten
   | where $it.short_status in $relevant_statuses
+  | update value { |row| if ($row.value | str contains " ") { $"`($row.value)`" } else { $row.value } }
   | insert "description" { |e| $short_status_descriptions | get $e.short_status}
 }
 


### PR DESCRIPTION
Hi, I recently found that the git add custom completion can not deal with file name that contains whitespace. Therefore I slightly modified "nu-complete git file" to let it support recognizing file name that contains whitespace.

Originally, the regex for `<value>` only parses non-whitespace characters by using `\S+`. I changed it to `.+` so that it parses any character until the end of the string.

I also added a post process to add surrounding backtick to the path that contains whitespace.

I am new to Nushell, so if my implementation has any problem, feel free to point it out. I appreciate any feedback. :)

Here are the demoatration videos:

Before:


https://github.com/user-attachments/assets/251e0945-9a00-4aca-994d-ef0c71b30b70


After:


https://github.com/user-attachments/assets/629e933f-97eb-4a7e-864c-a34432716385

