### PR TITLE
fix(auto-venv): handle overlay list returning table instead of list

### DIFF
--- a/modules/virtual_environments/auto-venv/venv_helpers.nu
+++ b/modules/virtual_environments/auto-venv/venv_helpers.nu
@@ -20,7 +20,7 @@ def get-env [
 }
 
 export def venv-is-active [] {
-    '__auto_venv' in (overlay list)
+    '__auto_venv' in (overlay list | get name)
 }
 
 # Creates a virtual environment under the current directory


### PR DESCRIPTION
`overlay list` now returns `table<name: string, active: bool>` instead of `list<string>`. The `in` operator does not support membership checks against tables, causing venv-is-active to fail.

Pipe through `get name` to extract the string column before checking overlay membership.
