### PR TITLE
fix(maths): scale-minmax-table fails on current Nu (undefined column2, deprecated merge)

### DIFF
--- a/modules/maths/math_functions.nu
+++ b/modules/maths/math_functions.nu
@@ -1,3 +1,9 @@
+# Get the nth column of a table as a list of values, by position rather
+# than name. Used internally by `scale-minmax-table`.
+def column2 [n] {
+	transpose | get $n | transpose | get column1 | skip 1
+}
+
 #Root with a custom denominator
 export def root [ denominator, num ] {
 	$num ** ( 1 / $denominator ) | math round  -p 10
@@ -155,7 +161,7 @@ export def scale-minmax-table [a, b,input?] {
 	0..($n_cols - 1)
 	| each {|i|
 		($x | column2 $i) | scale-minmax $a $b | wrap ($name_cols | get $i)
-	} | reduce {|it, acc| $acc | merge {$it}}
+	} | reduce {|it, acc| $acc | merge $it}
 }
 
 


### PR DESCRIPTION
## What's broken

`scale-minmax-table` in `modules/maths/math_functions.nu` fails on current Nu (tested on 0.113.1) for two independent reasons:

1. **`column2` is undefined in this module.** It's only defined in `sourced/misc/nu_defs.nu` (an unrelated personal-dotfiles file elsewhere in this repo). `scale-minmax-table` calls it without importing or defining it locally, so it only ever worked in a shell session where `nu_defs.nu` happened to already be sourced separately. As a standalone module command, it's always been broken.
2. **`merge {$it}` is no longer valid.** `merge` used to accept a closure form; current Nu's `merge` takes a `record`/`table` value directly (see `help merge`). This fails to parse on recent Nu regardless of the `column2` issue.

## Fix

- Add a local `column2` helper (same implementation as the one in `sourced/misc/nu_defs.nu`) so this module doesn't depend on an unrelated file being sourced first.
- `merge {$it}` -> `merge $it`.

## How I found this

I was evaluating this module as a candidate seed package for an unrelated project's package registry and ran it against a real Nu 0.113.1 instead of trusting the source — it failed to parse. Diagnosed both root causes from there.

## Verification

On Nu 0.113.1:
- The whole module now parses cleanly (it did not before).
- `[[a b]; [1 10] [2 20] [3 30]] | scale-minmax-table 0 1` produces correct per-column min-max scaling:
  ```
  ╭───┬──────┬──────╮
  │ # │  a   │  b   │
  ├───┼──────┼──────┤
  │ 0 │ 0.00 │ 0.00 │
  │ 1 │ 0.50 │ 0.50 │
  │ 2 │ 1.00 │ 1.00 │
  ╰───┴──────┴──────╯
  ```
- Spot-checked `root`, `croot`, and `delta` in the same file still produce correct output, unaffected by this change.