### PR TITLE
replace str downcase for str lowercase

### DIFF
--- a/benchmarks/gradient_benchmark.nu
+++ b/benchmarks/gradient_benchmark.nu
@@ -6,7 +6,7 @@ def iter_inc [incr mult iter] {
 
 let is_release = (input "Did you compile in a release mode? y/n ")
 
-if ($is_release | str downcase | str trim) == "y" {
+if ($is_release | str lowercase | str trim) == "y" {
     print $"running test 0 at (date now |  format date '%Y-%m-%d %H:%M:%S.%3f')"
     # 0. this has wrong output
     let 0 = (seq 1 10 | each { timeit {

--- a/benchmarks/gradient_benchmark_no_check.nu
+++ b/benchmarks/gradient_benchmark_no_check.nu
@@ -7,7 +7,7 @@ def iter_inc [incr mult iter] {
 #let is_release = input "Did you compile in a release mode? y/n "
 let is_release = "y"
 
-if ($is_release | str downcase | str trim) == "y" {
+if ($is_release | str lowercase | str trim) == "y" {
 
     print $"running test 0 at (date now |  format date '%Y-%m-%d %H:%M:%S.%3f')"
     # 0. this has wrong output

--- a/games/humlespring/script.nu
+++ b/games/humlespring/script.nu
@@ -92,9 +92,9 @@ loop {
 
     # Parse input (simple verb-noun)
     let parts = ($user_input | split row " ")
-    let verb = ($parts | get 0 | str downcase)
+    let verb = ($parts | get 0 | str lowercase)
     # Use `get` and `default` for robust noun handling (handles commands with no noun)
-    let noun = if ($parts | length) > 1 { $parts | get 1 | default "" | str downcase } else {""}
+    let noun = if ($parts | length) > 1 { $parts | get 1 | default "" | str lowercase } else {""}
 
     # grab the current location once
     let loc_data = ($map | get $player_state.location)

--- a/make_release/notes/util.nu
+++ b/make_release/notes/util.nu
@@ -8,7 +8,7 @@ export def clean-title []: string -> string {
 
 # Check if the release notes section was left empty
 export def is-empty-keyword []: string -> bool {
-    str downcase | $in in ["", "n/a", "nothing", "none", "nan"]
+    str lowercase | $in in ["", "n/a", "nothing", "none", "nan"]
 }
 
 # Format a PR nicely, including a link

--- a/modules/fnm/fnm.nu
+++ b/modules/fnm/fnm.nu
@@ -102,7 +102,7 @@ export-env {
                 } else {
                     print $"(ansi yellow_bold)fnm:(ansi reset) ($err_msg)"
                     let answer = (input "Install it? [y/N] ")
-                    if ($answer | str downcase) == "y" {
+                    if ($answer | str lowercase) == "y" {
                         let install_res = (do { ^fnm install ...$fnm_config.install_flags } | complete)
                         if $install_res.exit_code != 0 {
                             print $"(ansi red_bold)fnm:(ansi reset) Install failed."

--- a/modules/formats/from-dmidecode.nu
+++ b/modules/formats/from-dmidecode.nu
@@ -21,7 +21,7 @@ export def "from dmidecode" [] {
                         | skip 2
                         | split column ':'
                         | str trim
-                        | str downcase column1
+                        | str lowercase column1
                         | str replace -a ' ' '_' column1
                         | transpose -r -d
                     }

--- a/modules/fun/wordle.nu
+++ b/modules/fun/wordle.nu
@@ -19,7 +19,7 @@ export def main [
     $guess_count += 1
     if ($guess_count <= $max_count or $unlimited) {
       print $"(ansi xterm_aquamarine1a)Enter your guess (ansi reset)\((ansi green)($guess_count)(ansi reset)/(ansi yellow)(if ($unlimited) {inf} else {$max_count})(ansi reset)\)"
-      let guess = (input | str downcase)
+      let guess = (input | str lowercase)
       if ($guess | str length) == 5 and ($words | any {|w| $w == $guess}) {
         mut out = ""
         mut checked = $word

--- a/modules/kubernetes/env.nu
+++ b/modules/kubernetes/env.nu
@@ -7,7 +7,7 @@ export-env {
     }
     let id = {
         name: [metadata name]
-        kind: [kind {|x|$x| str downcase}]
+        kind: [kind {|x|$x| str lowercase}]
         apiVersion: [apiVersion]
         labels: [metadata labels]
         created: [metadata creationTimestamp {|x|$x | into datetime}]

--- a/modules/kubernetes/utils.nu
+++ b/modules/kubernetes/utils.nu
@@ -17,7 +17,7 @@ export def normalize-column-names [ ] {
     let cols = $i | columns
     mut t = $i
     for c in $cols {
-        $t = ($t | rename -c {$c: ($c | str downcase | str replace ' ' '_')})
+        $t = ($t | rename -c {$c: ($c | str lowercase | str replace ' ' '_')})
     }
     $t
 }

--- a/modules/network/sockets/sockets.nu
+++ b/modules/network/sockets/sockets.nu
@@ -2,7 +2,7 @@ export def main [--abbreviate-java-class-paths (-j)] {
   let input = (^lsof +c 0xFFFF -i -n -P)
   let header = ($input | lines
                        | take 1
-                       | each { str downcase | str replace ' name$' ' name state' })
+                       | each { str lowercase | str replace ' name$' ' name state' })
   let body = ($input | lines
                      | skip 1
                      | each { str replace '([^)])$' '$1 (NONE)' | str replace ' \((.+)\)$' ' $1' })

--- a/modules/nix/nix.nu
+++ b/modules/nix/nix.nu
@@ -6,7 +6,7 @@ export def ns [
     let info = (
         sysctl -n kernel.arch kernel.ostype
         | lines
-        | {arch: ($in.0|str downcase), ostype: ($in.1|str downcase)}
+        | {arch: ($in.0|str lowercase), ostype: ($in.1|str lowercase)}
     )
 
     nix search --json nixpkgs $term

--- a/modules/prompt/git_status_prompt.nu
+++ b/modules/prompt/git_status_prompt.nu
@@ -90,7 +90,7 @@ def git-branch-icon [] {
                     "red"
                 }
             )
-            $"|(ansi $branch_colour)($branch)(ansi reset):($modified | get status | uniq | str downcase | each {|it| git-prompt-icons $it })" | str join
+            $"|(ansi $branch_colour)($branch)(ansi reset):($modified | get status | uniq | str lowercase | each {|it| git-prompt-icons $it })" | str join
         }
     }
   }

--- a/modules/prompt/left_and_right_prompt.nu
+++ b/modules/prompt/left_and_right_prompt.nu
@@ -55,8 +55,8 @@ export def construct_prompt [] {
 def home_abbrev [] {
     let is_home_in_path = (pwd | into string | str starts-with $nu.home-dir)
     if $is_home_in_path {
-        let lin_home = ($nu.home-dir | into string | str replace -a '\\' '/' | str downcase)
-        let lin_pwd = (pwd | into string | str replace -a '\\' '/' | str downcase)
+        let lin_home = ($nu.home-dir | into string | str replace -a '\\' '/' | str lowercase)
+        let lin_pwd = (pwd | into string | str replace -a '\\' '/' | str lowercase)
         $lin_pwd | str replace $lin_home '~'
     } else {
         pwd

--- a/modules/virtual_environments/conda.nu
+++ b/modules/virtual_environments/conda.nu
@@ -147,7 +147,7 @@ def conda-create-path-unix [env_dir: path] {
 }
 
 def windows? [] {
-    ($nu.os-info.name | str downcase) == "windows"
+    ($nu.os-info.name | str lowercase) == "windows"
 }
 
 def system-path [] {

--- a/modules/virtual_environments/nu_msvs/nu_msvs.nu
+++ b/modules/virtual_environments/nu_msvs/nu_msvs.nu
@@ -84,8 +84,8 @@ export def --env activate [
     return
   }
 
-  let fh = ($host | str downcase)
-  let ft = ($target | str downcase)
+  let fh = ($host | str lowercase)
+  let ft = ($target | str lowercase)
   let fs = (
       if ($sdk != latest) {
         $sdk

--- a/nu-hooks/nu-hooks/command_not_found/did_you_mean.nu
+++ b/nu-hooks/nu-hooks/command_not_found/did_you_mean.nu
@@ -21,8 +21,8 @@
         if ($nu.os-info.name == windows) {
             $env.Path | each {|directory|
                 if ($directory | path exists) {
-                    let cmd_exts = $env.PATHEXT | str downcase | split row ';' | str trim --char .
-                    ls $directory | get name | path parse | where {|it| $cmd_exts | any {|ext| $ext == ($it.extension | str downcase)} } | get stem
+                    let cmd_exts = $env.PATHEXT | str lowercase | split row ';' | str trim --char .
+                    ls $directory | get name | path parse | where {|it| $cmd_exts | any {|ext| $ext == ($it.extension | str lowercase)} } | get stem
                 }
             }
         } else {

--- a/skills/nushell/references/bash-equivalents.md
+++ b/skills/nushell/references/bash-equivalents.md
@@ -44,7 +44,7 @@
 | `sort -u` | `sort \| uniq` |
 | `uniq` | `uniq` |
 | `cut -d: -f1` | `split column ':' \| get column0` |
-| `tr '[:upper:]' '[:lower:]'` | `str downcase` |
+| `tr '[:upper:]' '[:lower:]'` | `str lowercase` |
 
 ## Variables and Environment
 

--- a/skills/nushell/references/commands.md
+++ b/skills/nushell/references/commands.md
@@ -89,7 +89,7 @@ $table | where {|row| $row.size > 1kb and $row.name =~ ".csv"}
 |---------|---------|---------|
 | `str trim` | Trim whitespace | `" hi " \| str trim` |
 | `str upcase` | Uppercase | `"hi" \| str upcase` |
-| `str downcase` | Lowercase | `"HI" \| str downcase` |
+| `str lowercase` | Lowercase | `"HI" \| str lowercase` |
 | `str replace` | Replace text | `"hi" \| str replace "hi" "hello"` |
 | `str contains` | Check substring | `"hello" \| str contains "ell"` |
 | `str starts-with` | Check prefix | `"hello" \| str starts-with "he"` |

--- a/sourced/fehbg.nu
+++ b/sourced/fehbg.nu
@@ -45,7 +45,7 @@ def select-random [] {
 def list-images [dir: path] {
     ls $"($dir)/**/*" |
     where type == file |
-    str downcase name |
+    str lowercase name |
     where name =~ jpg or name =~ jpeg or name =~ tif or name =~ tiff or name =~ png
 }
 

--- a/sourced/misc/password_generator/nupass.nu
+++ b/sourced/misc/password_generator/nupass.nu
@@ -104,7 +104,7 @@ def random-format-word [] {
         } else if $rint == 3 {
             ($it | split chars | each {|c| if (random float) < 0.2 { $c | str upcase } else { $c }} | str join "")
         } else {
-            ($it | str downcase)
+            ($it | str lowercase)
         }
     }
 }

--- a/sourced/nu_rust_ast/rust_ast.nu
+++ b/sourced/nu_rust_ast/rust_ast.nu
@@ -2796,7 +2796,7 @@ def _scan-ext-refs-on-fns [rows:list<record>] {
                           })
               if ($dep0 == null) { null } else {
                 let sym = ($segs | skip 1 | str join '::')  # what’s used *within* the dep
-                { dep: ($dep0 | str downcase), sym: $sym }
+                { dep: ($dep0 | str lowercase), sym: $sym }
               }
             }
           }
@@ -3087,8 +3087,8 @@ export def rust-print-dep-usage [
     let maybes   = ($row.maybe | default [])
 
     for d in $uses_det {
-      let key = ($d.dep | str downcase)
-      if ($ext_set | any {|e| ($e | str downcase) == $key }) {
+      let key = ($d.dep | str lowercase)
+      if ($ext_set | any {|e| ($e | str lowercase) == $key }) {
         let cur = ($dep_index | get -i $key | default { real: {}, maybe: {} })
         let cur_syms = ($cur.real | get -i $fq | default [])
         let next_syms = ($cur_syms | append $d.syms | flatten | uniq | sort)
@@ -3099,8 +3099,8 @@ export def rust-print-dep-usage [
 
     if $include_maybe {
       for m in $maybes {
-        let key = ($m | str downcase)
-        if ($ext_set | any {|e| ($e | str downcase) == $key }) {
+        let key = ($m | str lowercase)
+        if ($ext_set | any {|e| ($e | str lowercase) == $key }) {
           let cur = ($dep_index | get -i $key | default { real: {}, maybe: {} })
           let cur_syms = ($cur.maybe | get -i $fq | default [])
           let nxt = ($cur | upsert maybe ($cur.maybe | upsert $fq $cur_syms))
@@ -3111,7 +3111,7 @@ export def rust-print-dep-usage [
   }
 
   let wanted = if ($dep | default '' | str length) > 0 {
-    let key = ($dep | str downcase)
+    let key = ($dep | str lowercase)
     if ($dep_index | columns | any {|k| $k == $key }) { [ $key ] } else { [] }
   } else {
     ($dep_index | columns | sort)
@@ -3344,7 +3344,7 @@ export def --env _ensure-caches [] {
 
 # Treat these as "true": 1, true, yes, on (case-insensitive)
 def _debug_enabled [] {
-  let raw = (_env_str 'RUST_AST_DEBUG' | str downcase | str trim)
+  let raw = (_env_str 'RUST_AST_DEBUG' | str lowercase | str trim)
   match $raw {
     "1" | "true" | "yes" | "on" => true
     _ => false


### PR DESCRIPTION
nu 114 raises:

```
Warning: nu::parser::deprecated

  ⚠ Command deprecated.
     ╭─[/home/aucac/other-repos/nu/nu_scripts/modules/fnm/fnm.nu:105:35]
 104 │                     let answer = (input "Install it? [y/N] ")
 105 │                     if ($answer | str downcase) == "y" {
     ·                                   ──────┬─────
     ·                                         ╰── str downcase was deprecated in 0.114.0 and will be removed in a future release.
 106 │                         let install_res = (do { ^fnm install ...$fnm_config.install_flags } | complete)
     ╰────
  help: Use `str lowercase` instead.
```

So this PR replaces all `str downcase` for `str lowercase`